### PR TITLE
Improved the on-hover notification for the 'Auto-create on startup' checkbox.

### DIFF
--- a/src/GUI/LiveView.cpp
+++ b/src/GUI/LiveView.cpp
@@ -1409,7 +1409,7 @@ namespace RC::GUI
                 if (ImGui::IsItemHovered())
                 {
                     ImGui::BeginTooltip();
-                    ImGui::Text("Auto-create on startup");
+                    ImGui::Text("Auto-create on startup.\nRight-click for options.");
                     ImGui::EndTooltip();
                 }
             }


### PR DESCRIPTION
Made it more clear that there's a right-click menu for the 'auto-create on startup' opton for watches in LiveView.
This was impossible to know if the user didn't randomly right-click the checkbox.