### PR TITLE
Changed default UHT dumper settings for forcing flags

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,6 @@
 # Re-Host of Unreal Engine 4/5 Scripting System
 
-## The original creator no longer wishes to be involved with or connected to this project, or to receive messages related to it. Please respect their wishes, and avoid using their past username(s) in connection with this project. It is being reuploaded as open source with their permission.  Support for/updates to this project will now be very limited.
-
+### The original creator no longer wishes to be involved with or connected to this project, or to receive messages related to it. Please respect their wishes, and avoid using their past username(s) in connection with this project. It is being reuploaded as open source with their permission.  Support for/updates to this project will now be very limited.
 
 ## Targeting UE Versions: From 4.12 To 5.0
 
@@ -90,3 +89,4 @@ Note that you should also commit & push the submodules that you've updated if th
 - Motoson
 - hooter
 - Synopis
+- Buckminsterfullerene

--- a/Staging/Readme.md
+++ b/Staging/Readme.md
@@ -1,6 +1,6 @@
 # Unreal Engine 4/5 Scripting System
 
-## The original creator no longer wishes to be involved in or connected to this project.  Please respect their wishes, and avoid using their past usernames in connection with this project.
+### The original creator no longer wishes to be involved in or connected to this project.  Please respect their wishes, and avoid using their past usernames in connection with this project.
 
 ### This tool has entered "Maintenance" mode. No more features will be added for the foreseeable future, but it will hopefully still be updated whenever new UE versions are released.
 
@@ -35,6 +35,9 @@ You may need to update AOBs on your own, and there's a guide for that below.
 - **boop** / **usize**
   - New UFunction hook method
 - **Deadmoroz**
+  - Certain features and Lua updates/maintenance
+- **DmgVol**
+  - Inspiration for map dumper
 
 ## Thanks to everyone who helped with testing
 
@@ -44,3 +47,4 @@ You may need to update AOBs on your own, and there's a guide for that below.
 - Motoson
 - hooter
 - Synopis
+- Buckinsterfullerene

--- a/Staging/UE4SS-settings.ini
+++ b/Staging/UE4SS-settings.ini
@@ -64,25 +64,24 @@ IgnoreEngineAndCoreUObject = 1
 
 ; Whether to force all UFUNCTION macros to have "BlueprintCallable"
 ; Note: This will cause some errors in the generated headers that you will need to manually fix
-; Default: 0
-MakeAllFunctionsBlueprintCallable = 0
+; Default: 1
+MakeAllFunctionsBlueprintCallable = 1
 
 ; Whether to force all UPROPERTY macros to have 'BlueprintReadWrite'
 ; Also forces all UPROPERTY macros to have 'meta=(AllowPrivateAccess=true)'
-; Default: 0
-MakeAllPropertyBlueprintsReadWrite = 0
+; Default: 1
+MakeAllPropertyBlueprintsReadWrite = 1
 
 ; Whether to force UENUM macros on enums to have 'BlueprintType' if the underlying type was implicit or uint8
 ; Note: This also forces the underlying type to be uint8 where the type would otherwise be implicit
-; Default: 0
-MakeEnumClassesBlueprintType = 0
+; Default: 1
+MakeEnumClassesBlueprintType = 1
 
 [Debug]
 ; Whether to enable the external UE4SS debug console.
 ConsoleEnabled = 1
 GuiConsoleEnabled = 1
 GuiConsoleVisible = 1
-
 
 [Threads]
 ; The number of threads that the sig scanner will use (not real cpu threads, can be over your physical & hyperthreading max)


### PR DESCRIPTION
There is no real reason to not have these 1 by default and by having them 0 by default, people not accustomed with the tool are creating crappy templates.  

Also added my name to readme credits, because I helped Muppet with testing a lot during the early days of UE4SS, but never asked for credit.