### PR TITLE
USMapGenerator: Dumping the entire FName for enum elements.

### DIFF
--- a/src/USMapGenerator/Generator.cpp
+++ b/src/USMapGenerator/Generator.cpp
@@ -293,7 +293,7 @@ namespace RC::OutTheShade
 
 				Enum->ForEachName([&](FName Key, ...)
 				{
-					NameMap.insert_or_assign(FName(Key.GetComparisonIndex(), 0), 0);
+					NameMap.insert_or_assign(Key, 0);
                     return LoopAction::Continue;
 				});
 			}


### PR DESCRIPTION
This should probably be back-ported to https://github.com/OutTheShade/UnrealMappingsDumper.