### PR TITLE
Added 'Keybinds' mod, fixed a couple of bugs, added 'IsKeyBindRegistered'.

### DIFF
--- a/Staging/Mods/CXXHeaderGeneratorMod/Scripts/main.lua
+++ b/Staging/Mods/CXXHeaderGeneratorMod/Scripts/main.lua
@@ -1,4 +1,0 @@
-RegisterKeyBind(Key.D, {ModifierKey.CONTROL}, function()
-    GenerateSDK()
-end)
-

--- a/Staging/Mods/Keybinds/Scripts/main.lua
+++ b/Staging/Mods/Keybinds/Scripts/main.lua
@@ -1,0 +1,202 @@
+--[[
+    This file contains bindings for all built-in tools.
+    If you have a legacy bindings mod (listed below) then the binding in that mod takes precedence.
+
+    List of legacy bindings mods:
+    ObjectDumperMod
+    CXXHeaderGeneratorMod
+    UHTCompatibleHeaderGeneratorMod
+
+    You can modify the configuration below if you're not happy with the default key bindings.
+    Valid keys and modifier keys can be found at the bottom of this file.
+--]]
+Keybinds = {
+    ["ObjectDumper"]                 = {["Key"] = Key.J,             ["ModifierKeys"] = {}},
+    ["CXXHeaderGenerator"]           = {["Key"] = Key.D,             ["ModifierKeys"] = {ModifierKey.CONTROL}},
+    ["UHTCompatibleHeaderGenerator"] = {["Key"] = Key.NUM_NINE,      ["ModifierKeys"] = {ModifierKey.CONTROL}},
+}
+
+-- Logic, DO NOT CHANGE!
+local function RegisterKey(KeyBindName, Callable)
+    if (Keybinds[KeyBindName] and not IsKeyBindRegistered(Keybinds[KeyBindName].Key)) then
+        RegisterKeyBind(Keybinds[KeyBindName].Key, Keybinds[KeyBindName].ModifierKeys, Callable)
+    end
+end
+
+RegisterKey("ObjectDumper", function() DumpAllObjects() end)
+RegisterKey("CXXHeaderGenerator", function() GenerateSDK() end)
+RegisterKey("UHTCompatibleHeaderGenerator", function() GenerateUHTCompatibleHeaders() end)
+
+--[[
+    Valid keys:
+    LEFT_MOUSE_BUTTON
+    RIGHT_MOUSE_BUTTON
+    CANCEL
+    MIDDLE_MOUSE_BUTTON
+    XBUTTON_ONE
+    XBUTTON_TWO
+    BACKSPACE
+    TAB
+    CLEAR
+    RETURN
+    PAUSE
+    CAPS_LOCK
+    IME_KANA
+    IME_HANGUEL
+    IME_HANGUL
+    IME_ON
+    IME_JUNJA
+    IME_FINAL
+    IME_HANJA
+    IME_KANJI
+    IME_OFF
+    ESCAPE
+    IME_CONVERT
+    IME_NONCONVERT
+    IME_ACCEPT
+    IME_MODECHANGE
+    SPACE
+    PAGE_UP
+    PAGE_DOWN
+    END
+    HOME
+    LEFT_ARROW
+    UP_ARROW
+    RIGHT_ARROW
+    DOWN_ARROW
+    SELECT
+    PRINT
+    EXECUTE
+    PRINT_SCREEN
+    INS
+    DEL
+    HELP
+    ZERO
+    ONE
+    TWO
+    THREE
+    FOUR
+    FIVE
+    SIX
+    SEVEN
+    EIGHT
+    NINE
+    A
+    B
+    C
+    D
+    E
+    F
+    G
+    H
+    I
+    J
+    K
+    L
+    M
+    N
+    O
+    P
+    Q
+    R
+    S
+    T
+    U
+    V
+    W
+    X
+    Y
+    Z
+    LEFT_WIN
+    RIGHT_WIN
+    APPS
+    SLEEP
+    NUM_ZERO
+    NUM_ONE
+    NUM_TWO
+    NUM_THREE
+    NUM_FOUR
+    NUM_FIVE
+    NUM_SIX
+    NUM_SEVEN
+    NUM_EIGHT
+    NUM_NINE
+    MULTIPLY
+    ADD
+    SEPARATOR
+    SUBTRACT
+    DECIMAL
+    DIVIDE
+    F1
+    F2
+    F3
+    F4
+    F5
+    F6
+    F7
+    F8
+    F9
+    F10
+    F11
+    F12
+    F13
+    F14
+    F15
+    F16
+    F17
+    F18
+    F19
+    F20
+    F21
+    F22
+    F23
+    F24
+    NUM_LOCK
+    SCROLL_LOCK
+    BROWSER_BACK
+    BROWSER_FORWARD
+    BROWSER_REFRESH
+    BROWSER_STOP
+    BROWSER_SEARCH
+    BROWSER_FAVORITES
+    BROWSER_HOME
+    VOLUME_MUTE
+    VOLUME_DOWN
+    VOLUME_UP
+    MEDIA_NEXT_TRACK
+    MEDIA_PREV_TRACK
+    MEDIA_STOP
+    MEDIA_PLAY_PAUSE
+    LAUNCH_MAIL
+    LAUNCH_MEDIA_SELECT
+    LAUNCH_APP1
+    LAUNCH_APP2
+    OEM_ONE
+    OEM_PLUS
+    OEM_COMMA
+    OEM_MINUS
+    OEM_PERIOD
+    OEM_TWO
+    OEM_THREE
+    OEM_FOUR
+    OEM_FIVE
+    OEM_SIX
+    OEM_SEVEN
+    OEM_EIGHT
+    OEM_102
+    IME_PROCESS
+    PACKET
+    ATTN
+    CRSEL
+    EXSEL
+    EREOF
+    PLAY
+    ZOOM
+    PA1
+    OEM_CLEAR
+
+    Valid modifier keys:
+    SHIFT
+    CONTROL
+    ALT
+--]]

--- a/Staging/Mods/ObjectDumperMod/Scripts/main.lua
+++ b/Staging/Mods/ObjectDumperMod/Scripts/main.lua
@@ -1,4 +1,0 @@
-function KeyInput_DumpAllObjects()
-	DumpAllObjects()
-end
-RegisterKeyBind(Key.J, {ModifierKey.CONTROL}, KeyInput_DumpAllObjects) -- Key: 'J'

--- a/Staging/Mods/UHTCompatibleHeaderGeneratorMod/Scripts/main.lua
+++ b/Staging/Mods/UHTCompatibleHeaderGeneratorMod/Scripts/main.lua
@@ -1,3 +1,0 @@
-RegisterKeyBind(Key.NUM_NINE, {ModifierKey.CONTROL}, function()
-    GenerateUHTCompatibleHeaders()
-end)

--- a/Staging/Mods/mods.txt
+++ b/Staging/Mods/mods.txt
@@ -1,7 +1,11 @@
-ObjectDumperMod : 1
-CXXHeaderGeneratorMod : 1
-UHTCompatibleHeaderGeneratorMod : 1
 CheatManagerEnablerMod : 1
 ActorDumperMod : 0
 ConsoleCommandsMod : 1
 ConsoleEnablerMod : 1
+
+
+
+
+
+; Built-in keybinds, do not move up!
+Keybinds : 1

--- a/include/UE4SSProgram.hpp
+++ b/include/UE4SSProgram.hpp
@@ -198,6 +198,8 @@ namespace RC
         // API pass-through for use outside the private scope of UE4SSProgram
         auto register_keydown_event(Input::Key, const Input::EventCallbackCallable&, uint8_t custom_data = 0) -> void;
         auto register_keydown_event(Input::Key, const Input::Handler::ModifierKeyArray&, const Input::EventCallbackCallable&, uint8_t custom_data = 0) -> void;
+        auto is_keydown_event_registered(Input::Key) -> bool;
+        auto is_keydown_event_registered(Input::Key, const Input::Handler::ModifierKeyArray&) -> bool;
 
     private:
         static auto install_mods() -> void;

--- a/src/UE4SSProgram.cpp
+++ b/src/UE4SSProgram.cpp
@@ -1127,15 +1127,26 @@ namespace RC
         uninstall_mods();
 
         // Remove key binds that were set from Lua scripts
-        for (auto& input_event : m_input_handler.get_events())
-        {
+        auto& key_events = m_input_handler.get_events();
+        std::erase_if(key_events, [](Input::KeySet& input_event) -> bool {
+            bool were_all_events_registered_from_lua = true;
             for (auto&[key, vector_of_key_data] : input_event.key_data)
             {
-                std::erase_if(vector_of_key_data, [](Input::KeyData& key_data) -> bool {
-                    return key_data.custom_data == 1;
+                std::erase_if(vector_of_key_data, [&](Input::KeyData& key_data) -> bool {
+                    if (key_data.custom_data == 1)
+                    {
+                        return true;
+                    }
+                    else
+                    {
+                        were_all_events_registered_from_lua = false;
+                        return false;
+                    }
                 });
             }
-        }
+
+            return were_all_events_registered_from_lua;
+        });
 
         // Remove all custom properties
         // Uncomment when custom properties are working
@@ -1237,6 +1248,16 @@ namespace RC
     auto UE4SSProgram::register_keydown_event(Input::Key key, const Input::Handler::ModifierKeyArray& modifier_keys, const Input::EventCallbackCallable& callback, uint8_t custom_data) -> void
     {
         m_input_handler.register_keydown_event(key, modifier_keys, callback, custom_data);
+    }
+    
+    auto UE4SSProgram::is_keydown_event_registered(Input::Key key) -> bool
+    {
+        return m_input_handler.is_keydown_event_registered(key);
+    }
+
+    auto UE4SSProgram::is_keydown_event_registered(Input::Key key, const Input::Handler::ModifierKeyArray& modifier_keys) -> bool
+    {
+        return m_input_handler.is_keydown_event_registered(key, modifier_keys);
     }
 
     auto UE4SSProgram::find_mod_by_name(std::wstring_view mod_name, IsInstalled is_installed, IsStarted is_started) -> Mod*


### PR DESCRIPTION
See the commit for more information about the keybinds mod.

In addition to the keybinds mod:
Added a new global Lua function called "IsKeyBindRegistered". The result is dependent on the mod load order.
Fixed key bindings not getting unbound when hot-reloading mods.
Fixed bug where if you called 'RegisterKeyBind' and passed an empty table for the second parameter, the function passed for the third parameter would get executed regardless if the user is holding any modifier keys.