### PR TITLE
(#36) UHT: Fix module dependencies not getting generated

### DIFF
--- a/include/SDKGenerator/UEHeaderGenerator.hpp
+++ b/include/SDKGenerator/UEHeaderGenerator.hpp
@@ -120,7 +120,6 @@ namespace RC::UEGenerator
         auto serialize_file_content_to_disk() -> bool;
         
         virtual auto has_content_to_save() const -> bool;
-    protected:
         virtual auto generate_file_contents() -> std::wstring;
     };
 
@@ -162,10 +161,10 @@ namespace RC::UEGenerator
         }
 
         auto static create_source_file(const FFilePath& root_dir, const std::wstring& module_name, const std::wstring& base_name, bool is_implementation_file, UObject* object) -> GeneratedSourceFile;
+        virtual auto generate_file_contents() -> std::wstring override;
+
     protected:
         auto has_dependency(UObject* object, DependencyLevel dependency_level) -> bool;
-
-        virtual auto generate_file_contents() -> std::wstring override;
 
         auto generate_pre_declarations_string() const -> std::wstring;
         auto generate_includes_string() const -> std::wstring;

--- a/src/SDKGenerator/UEHeaderGenerator.cpp
+++ b/src/SDKGenerator/UEHeaderGenerator.cpp
@@ -3190,6 +3190,11 @@ namespace RC::UEGenerator
         }
         implementation_file.serialize_file_content_to_disk();
 
+        // This is necessary because header_file.serialize_file_content_to_disk() is not called anymore
+        // so we need to call all the necessary internal code to generate the dependency list
+        // otherwise the below code for copy_dependency_module_names will not work.
+        header_file.generate_file_contents();
+
         //Record module names used in the headers
         std::shared_ptr<std::set<std::wstring>> out_dependency_module_names = iterator->second;
         header_file.copy_dependency_module_names(*out_dependency_module_names);


### PR DESCRIPTION
This bug originated from 5ba7758542dc592b57c98064c4729003908164d0 at line 3120

My commits had their own issues but after they were fixed, they revealed this one. I did not see this bug as I was developing on a commit before 5ba7758542dc592b57c98064c4729003908164d0.

Fixes #36