### PR TITLE
Added a few Lua functions, fixed ObjectProperty unable to be set to nil.

### DIFF
--- a/Staging/API.txt
+++ b/Staging/API.txt
@@ -76,6 +76,19 @@ Table Definitions
         RF_HasExternalPackage            | 0x08000000
         RF_AllFlags                      | 0x0FFFFFFF
 
+    EInternalObjectFlags
+        - A table of internal object flags that can be or'd together by using |.
+        ReachableInCluster               | 0x00800000
+        ClusterRoot                      | 0x01000000
+        Native                           | 0x02000000
+        Async                            | 0x04000000
+        AsyncLoading                     | 0x08000000
+        Unreachable                      | 0x10000000
+        PendingKill                      | 0x20000000
+        RootSet                          | 0x40000000
+        GarbageCollectionKeepFlags       | 0x0E000000
+        AllFlags                         | 0x7F800000
+
 
 
 Global Functions
@@ -214,6 +227,15 @@ Classes
         Inheritance: RemoteObject
         - Class for interacting with the local mod object
         Methods
+            SetSharedVariable(string VariableName, any Value)
+                - Sets a variable that can be accessed by any mod.
+                - The second parameter (Value) can only be one of the following types: nil, string, number, bool, UObject(+derivatives), lightuserdata.
+                - These variables do not get reset when hot-reloading.
+
+            GetSharedVariable(string VariableName) -> any
+                - Gets a variable that could've been set from another mod.
+                - The return value can only be one of the following types: nil, string, number, bool, UObject(+derivatives), lightuserdata.
+        
             type() -> string
                 - Returns "ModRef"
 
@@ -274,6 +296,9 @@ Classes
 
             HasAnyFlags(EObjectFlags FlagsToCheck)
                 - Returns whether the object has any of the specified flags.
+            
+            HasAnyInternalFlags(EInternalObjectFlags InternalFlagsToCheck)
+                - Return whether the object has any of the specified internal flags.
 
             type() -> string
                 - Returns the type of this object as known by UE4SS

--- a/Staging/Mods/shared/UEHelpers/UEHelpers.lua
+++ b/Staging/Mods/shared/UEHelpers/UEHelpers.lua
@@ -1,0 +1,85 @@
+local UEHelpers = {}
+
+-- Functions local to this module, do not attempt to use!
+local CacheDefaultObject = nil
+
+-- Everything in this section can be used in any mod that requires this module.
+-- Exported functions -> START
+
+--- Returns the first valid PlayerController that is currently controlled by a player.
+---@return APlayerController
+function UEHelpers.GetPlayerController()
+    local PlayerControllers = FindAllOf("Controller")
+    local PlayerController = nil
+    for Index,Controller in pairs(PlayerControllers) do
+        if Controller.Pawn:IsValid() and Controller.Pawn:IsPlayerControlled() then
+            PlayerController = Controller
+        else
+            print("Not valid or not player controlled\n")
+        end
+    end
+    if PlayerController and PlayerController:IsValid() then
+        return PlayerController
+    else
+        error("No PlayerController found\n")
+    end
+end
+
+--- Returns the UWorld that the player is currenlty in.
+---@return UWorld
+function UEHelpers.GetWorld()
+    return UEHelpers.GetPlayerController():GetWorld()
+end
+
+--- Returns the UGameViewportClient for the player.
+---@return AActor
+function UEHelpers.GetGameViewportClient()
+    return UEHelpers.GetPlayerController().Player.ViewportClient
+end
+
+--- Returns an object that's useable with UFunctions that have a WorldContextObject param.
+--- Prefer to use an actor that you already have access to whenever possible over this function.
+---@return AActor
+function UEHelpers.GetWorldContextObject()
+    return UEHelpers.GetPlayerController()
+end
+
+function UEHelpers.GetGameplayStatics(ForceInvalidateCache)
+    return CacheDefaultObject("/Script/Engine.Default__GameplayStatics", "UEHelpers_GameplayStatics", ForceInvalidateCache)
+end
+
+function UEHelpers.GetKismetSystemLibrary(ForceInvalidateCache)
+    return CacheDefaultObject("/Script/Engine.Default__KismetSystemLibrary", "UEHelpers_KismetSystemLibrary", ForceInvalidateCache)
+end
+
+function UEHelpers.GetKismetMathLibrary(ForceInvalidateCache)
+    return CacheDefaultObject("/Script/Engine.Default__KismetMathLibrary", "UEHelpers_KismetMathLibrary", ForceInvalidateCache)
+end
+
+function UEHelpers.GetKismetMathLibrary(ForceInvalidateCache)
+    return CacheDefaultObject("/Script/Engine.Default__KismetMathLibrary", "UEHelpers_KismetMathLibrary", ForceInvalidateCache)
+end
+
+function UEHelpers.GetGameMapsSettings(ForceInvalidateCache)
+    return CacheDefaultObject("/Script/EngineSettings.Default__GameMapsSettings", "UEHelpers_GameMapsSettings", ForceInvalidateCache)
+end
+
+-- Exported functions -> END
+
+-- Functions local to this module, do not attempt to use!
+CacheDefaultObject = function(ObjectFullName, VariableName, ForceInvalidateCache)
+    local DefaultObject = nil
+
+    if not ForceInvalidateCache then
+        DefaultObject = ModRef:GetSharedVariable(VariableName)
+        if DefaultObject and DefaultObject:IsValid() then return DefaultObject end
+    end
+
+    DefaultObject = StaticFindObject(ObjectFullName)
+    ModRef:SetSharedVariable(VariableName, DefaultObject)
+    if not DefaultObject:IsValid() then error(string.format("%s not found", ObjectFullName)) end
+
+    return DefaultObject
+end
+
+return UEHelpers

--- a/include/LuaType/LuaUObject.hpp
+++ b/include/LuaType/LuaUObject.hpp
@@ -462,6 +462,37 @@ Overloads:
                 return 1;
             });
 
+            table.add_pair("HasAnyInternalFlags", [](const LuaMadeSimple::Lua& lua) -> int {
+                std::string error_overload_not_found{R"(
+No overload found for function 'UObject.HasAnyInternalFlags'.
+Overloads:
+#1: HasAnyInternalFlags(EInternalObjectFlags InternalObjectFlags))"};
+
+                const auto& lua_object = lua.get_userdata<SelfType>();
+
+                if (!lua.is_integer())
+                {
+                    lua.throw_error(error_overload_not_found);
+                }
+
+                Unreal::EInternalObjectFlags object_internal_flags = static_cast<Unreal::EInternalObjectFlags>(lua.get_integer());
+                lua.set_bool(lua_object.get_remote_cpp_object()->HasAnyInternalFlags(object_internal_flags));
+                return 1;
+            });
+
+            table.add_pair("IsValid", [](const LuaMadeSimple::Lua& lua) -> int {
+                const auto& lua_object = lua.get_userdata<SelfType>();
+                if (lua_object.get_remote_cpp_object() && !lua_object.get_remote_cpp_object()->IsUnreachable())
+                {
+                    lua.set_bool(true);
+                }
+                else
+                {
+                    lua.set_bool(false);
+                }
+                return 1;
+            });
+
             // Add things that are intended to be overridden later here
             // These will then be set only if this is the final object (nothing overrides it later)
             if constexpr (is_final == LuaMadeSimple::Type::IsFinal::Yes)

--- a/include/Mod.hpp
+++ b/include/Mod.hpp
@@ -20,6 +20,8 @@ namespace RC
         class UClass;
     }
 
+    auto get_mod_ref(const LuaMadeSimple::Lua& lua) -> class Mod*;
+
     class Mod
     {
     public:
@@ -66,6 +68,13 @@ namespace RC
         std::vector<AsyncAction> m_pending_actions{};
         std::vector<AsyncAction> m_delayed_actions{};
 
+        struct SharedLuaVariable
+        {
+            struct UserdataContainer { void* userdata; };
+            int lua_type{LUA_TNIL};
+            void* value{};
+            bool is_integer{}; // Is true if lua_isinteger returned true when this variable was shared.
+        };
         struct LuaCallbackData
         {
             const LuaMadeSimple::Lua& lua;
@@ -76,6 +85,8 @@ namespace RC
         static inline std::unordered_map<File::StringType, LuaCallbackData> m_global_command_lua_callbacks;
         static inline std::unordered_map<File::StringType, LuaCallbackData> m_custom_command_lua_pre_callbacks;
         static inline std::vector<SimpleLuaAction> m_game_thread_actions{};
+        // This is storage that persists through hot-reloads.
+        static inline std::unordered_map<std::string, SharedLuaVariable> m_shared_lua_variables{};
         static inline bool m_is_currently_executing_game_action{};
 
     protected:

--- a/src/LuaType/LuaMod.cpp
+++ b/src/LuaType/LuaMod.cpp
@@ -1,4 +1,7 @@
 #include <LuaType/LuaMod.hpp>
+#include <stdexcept>
+
+#include <Mod.hpp>
 
 namespace RC::LuaType
 {
@@ -34,6 +37,176 @@ namespace RC::LuaType
     template<LuaMadeSimple::Type::IsFinal is_final>
     auto Mod::setup_member_functions(const LuaMadeSimple::Lua::Table& table) -> void
     {
+        table.add_pair("SetSharedVariable", [](const LuaMadeSimple::Lua& lua) -> int {
+            std::string error_overload_not_found{R"(
+No overload found for function 'SetSharedVariable'.
+Overloads:
+#1: SetSharedVariable(string VariableName, any Value))"};
+            lua.discard_value(); // Discard the 'this' param.
+
+            if (!lua.is_string()) { throw std::runtime_error{error_overload_not_found}; }
+            auto variable_name = std::string{lua.get_string()};
+
+            RC::Mod::SharedLuaVariable* currently_stored_value{};
+            if (auto it = RC::Mod::m_shared_lua_variables.find(variable_name); it != RC::Mod::m_shared_lua_variables.end())
+            {
+                currently_stored_value = &it->second;
+            }
+
+            auto type = lua_type(lua.get_lua_state(), 1);
+            if (type == LUA_TNIL)
+            {
+                RC::Mod::m_shared_lua_variables[variable_name] = RC::Mod::SharedLuaVariable{type, nullptr, false};
+            }
+            else if (type == LUA_TBOOLEAN)
+            {
+                if (currently_stored_value && currently_stored_value->value)
+                {
+                    delete static_cast<bool*>(currently_stored_value->value);
+                    currently_stored_value->value = nullptr;
+                }
+                RC::Mod::m_shared_lua_variables[variable_name] = RC::Mod::SharedLuaVariable{type, new bool{lua.get_bool()}, false};
+            }
+            else if (type == LUA_TLIGHTUSERDATA)
+            {
+                if (currently_stored_value && currently_stored_value->value)
+                {
+                    delete static_cast<RC::Mod::SharedLuaVariable::UserdataContainer*>(currently_stored_value->value);
+                    currently_stored_value->value = nullptr;
+                }
+                RC::Mod::m_shared_lua_variables[variable_name] = RC::Mod::SharedLuaVariable{type, new RC::Mod::SharedLuaVariable::UserdataContainer{lua_touserdata(lua.get_lua_state(), 1)}, false};
+            }
+            else if (type == LUA_TNUMBER)
+            {
+                if (lua_isinteger(lua.get_lua_state(), 1))
+                {
+                    if (currently_stored_value && currently_stored_value->value)
+                    {
+                        delete static_cast<int64_t*>(currently_stored_value->value);
+                        currently_stored_value->value = nullptr;
+                    }
+                    RC::Mod::m_shared_lua_variables[variable_name] = RC::Mod::SharedLuaVariable{type, new int64_t{lua.get_integer()}, true};
+                }
+                else
+                {
+                    if (currently_stored_value && currently_stored_value->value)
+                    {
+                        delete static_cast<double*>(currently_stored_value->value);
+                        currently_stored_value->value = nullptr;
+                    }
+                    RC::Mod::m_shared_lua_variables[variable_name] = RC::Mod::SharedLuaVariable{type, new double{lua.get_number()}, false};
+                }
+            }
+            else if (type == LUA_TSTRING)
+            {
+                if (currently_stored_value && currently_stored_value->value)
+                {
+                    delete static_cast<std::string*>(currently_stored_value->value);
+                    currently_stored_value->value = nullptr;
+                }
+                RC::Mod::m_shared_lua_variables[variable_name] = RC::Mod::SharedLuaVariable{type, new std::string{lua.get_string()}, false};
+            }
+            else if (type == LUA_TTABLE)
+            {
+                lua.throw_error("Tried to set shared variable but the variable is unsupported type: 'table'.");
+            }
+            else if (type == LUA_TFUNCTION)
+            {
+                lua.throw_error("Tried to set shared variable but the variable is unsupported type: 'function'.");
+            }
+            else if (type == LUA_TUSERDATA)
+            {
+                if (currently_stored_value && currently_stored_value->value)
+                {
+                    delete static_cast<RC::Mod::SharedLuaVariable::UserdataContainer*>(currently_stored_value->value);
+                    currently_stored_value->value = nullptr;
+                }
+                auto& userdata = lua.get_userdata<LuaType::UE4SSBaseObject>();
+                std::string_view lua_object_name = userdata.get_object_name();
+                if (lua_object_name == "UObject" || lua_object_name == "World" || lua_object_name == "Actor" ||
+                    lua_object_name == "UClass" || lua_object_name == "UEnum" || lua_object_name == "UScriptStruct" ||
+                    lua_object_name == "UStruct")
+                {
+                    RC::Mod::m_shared_lua_variables[variable_name] = RC::Mod::SharedLuaVariable{type, new RC::Mod::SharedLuaVariable::UserdataContainer{userdata.get_remote_cpp_object()}, false};
+                }
+                else
+                {
+                    lua.throw_error("Tried to set shared variable but the variable is unsupported type: 'userdata' other than UObject derivative.");
+                }
+            }
+            else if (type == LUA_TTHREAD)
+            {
+                lua.throw_error("Tried to set shared variable but the variable is unsupported type: 'thread'.");
+            }
+
+            return 0;
+        });
+
+        table.add_pair("GetSharedVariable", [](const LuaMadeSimple::Lua& lua) -> int {
+            std::string error_overload_not_found{R"(
+No overload found for function 'GetSharedVariable'.
+Overloads:
+#1: GetSharedVariable(string VariableName))"};
+            lua.discard_value(); // Discard the 'this' param.
+
+            if (!lua.is_string()) { throw std::runtime_error{error_overload_not_found}; }
+            auto variable_name = std::string{lua.get_string()};
+
+            if (auto it = RC::Mod::m_shared_lua_variables.find(variable_name); it != RC::Mod::m_shared_lua_variables.end())
+            {
+                auto value = it->second.value;
+                if (it->second.lua_type == LUA_TNIL)
+                {
+                    lua.set_nil();
+                }
+                else if (it->second.lua_type == LUA_TBOOLEAN)
+                {
+                    lua.set_bool(*static_cast<bool*>(value));
+                }
+                else if (it->second.lua_type == LUA_TLIGHTUSERDATA)
+                {
+                    lua_pushlightuserdata(lua.get_lua_state(), static_cast<RC::Mod::SharedLuaVariable::UserdataContainer*>(value)->userdata);
+                }
+                else if (it->second.lua_type == LUA_TNUMBER)
+                {
+                    if (it->second.is_integer)
+                    {
+                        lua.set_integer(*static_cast<int64_t*>(value));
+                    }
+                    else
+                    {
+                        lua.set_number(*static_cast<double*>(value));
+                    }
+                }
+                else if (it->second.lua_type == LUA_TSTRING)
+                {
+                    lua.set_string(static_cast<std::string*>(value)->c_str());
+                }
+                else if (it->second.lua_type == LUA_TTABLE)
+                {
+                    lua.throw_error("Tried to get shared variable but the variable is unsupported type: 'table'.");
+                }
+                else if (it->second.lua_type == LUA_TFUNCTION)
+                {
+                    lua.throw_error("Tried to get shared variable but the variable is unsupported type: 'function'.");
+                }
+                else if (it->second.lua_type == LUA_TUSERDATA)
+                {
+                    auto_construct_object(lua, static_cast<Unreal::UObject*>(static_cast<RC::Mod::SharedLuaVariable::UserdataContainer*>(value)->userdata));
+                }
+                else if (it->second.lua_type == LUA_TTHREAD)
+                {
+                    lua.throw_error("Tried to get shared variable but the variable is unsupported type: 'thread'.");
+                }
+            }
+            else
+            {
+                lua.set_nil();
+            }
+
+            return 1;
+        });
+
         if constexpr (is_final == LuaMadeSimple::Type::IsFinal::Yes)
         {
             table.add_pair("type", [](const LuaMadeSimple::Lua& lua) -> int {

--- a/src/LuaType/LuaUObject.cpp
+++ b/src/LuaType/LuaUObject.cpp
@@ -342,7 +342,7 @@ namespace RC::LuaType
                 }
                 else if (params.lua.is_nil())
                 {
-                    params.lua.discard_value();
+                    *property_value = nullptr;
                 }
                 else
                 {

--- a/src/Mod.cpp
+++ b/src/Mod.cpp
@@ -65,7 +65,7 @@ namespace RC
     LuaMadeSimple::Lua* LuaStatics::console_executor{};
     bool LuaStatics::console_executor_enabled{};
 
-    static auto get_mod_ref(const LuaMadeSimple::Lua& lua) -> Mod*
+    auto get_mod_ref(const LuaMadeSimple::Lua& lua) -> Mod*
     {
         if (lua_getglobal(lua.get_lua_state(), "ModRef") == LUA_TNIL)
         {
@@ -474,6 +474,19 @@ namespace RC
         object_flags_table.add_pair("RF_HasExternalPackage", static_cast<std::underlying_type_t<Unreal::EObjectFlags>>(Unreal::EObjectFlags::RF_HasExternalPackage));
         object_flags_table.add_pair("RF_AllFlags", static_cast<std::underlying_type_t<Unreal::EObjectFlags>>(Unreal::EObjectFlags::RF_AllFlags));
         object_flags_table.make_global("EObjectFlags");
+
+        LuaMadeSimple::Lua::Table object_internal_flags_table = lua.prepare_new_table();
+        object_internal_flags_table.add_pair("ReachableInCluster", static_cast<std::underlying_type_t<Unreal::EInternalObjectFlags>>(Unreal::EInternalObjectFlags::ReachableInCluster));
+        object_internal_flags_table.add_pair("ClusterRoot", static_cast<std::underlying_type_t<Unreal::EInternalObjectFlags>>(Unreal::EInternalObjectFlags::ClusterRoot));
+        object_internal_flags_table.add_pair("Native", static_cast<std::underlying_type_t<Unreal::EInternalObjectFlags>>(Unreal::EInternalObjectFlags::Native));
+        object_internal_flags_table.add_pair("Async", static_cast<std::underlying_type_t<Unreal::EInternalObjectFlags>>(Unreal::EInternalObjectFlags::Async));
+        object_internal_flags_table.add_pair("AsyncLoading", static_cast<std::underlying_type_t<Unreal::EInternalObjectFlags>>(Unreal::EInternalObjectFlags::AsyncLoading));
+        object_internal_flags_table.add_pair("Unreachable", static_cast<std::underlying_type_t<Unreal::EInternalObjectFlags>>(Unreal::EInternalObjectFlags::Unreachable));
+        object_internal_flags_table.add_pair("PendingKill", static_cast<std::underlying_type_t<Unreal::EInternalObjectFlags>>(Unreal::EInternalObjectFlags::PendingKill));
+        object_internal_flags_table.add_pair("RootSet", static_cast<std::underlying_type_t<Unreal::EInternalObjectFlags>>(Unreal::EInternalObjectFlags::RootSet));
+        object_internal_flags_table.add_pair("GarbageCollectionKeepFlags", static_cast<std::underlying_type_t<Unreal::EInternalObjectFlags>>(Unreal::EInternalObjectFlags::GarbageCollectionKeepFlags));
+        object_internal_flags_table.add_pair("AllFlags", static_cast<std::underlying_type_t<Unreal::EInternalObjectFlags>>(Unreal::EInternalObjectFlags::AllFlags));
+        object_internal_flags_table.make_global("EInternalObjectFlags");
     }
 
     Mod::Mod(UE4SSProgram& program, std::wstring&& mod_name, std::wstring&& mod_path) : m_program(program), m_mod_name(mod_name), m_mod_path(mod_path), m_lua(LuaMadeSimple::new_state())


### PR DESCRIPTION
This pull request contains several things that were needed for the update SplitscreenMod.

Added `ModRef.SetSharedVariable` and `ModRef.GetSharedVariable`.
Added `UObject.HasAnyInternalFlags`.
Added global table: `EInternalObjectFlags`.

You can now set an ObjectProperty value to `nil`. Previously such an action would be ignored.

When calling `IsValid()` on UObjects, whether the UObject is reachable is now taken into account.

The splitscreen mod now operates independently of the Lua state which means that hot-reloading shouldn't cause it to break.