### PR TITLE
Added version tracking for the UEHelpers module.

### DIFF
--- a/Staging/Mods/shared/UEHelpers/UEHelpers.lua
+++ b/Staging/Mods/shared/UEHelpers/UEHelpers.lua
@@ -1,10 +1,17 @@
 local UEHelpers = {}
 
+-- Version 1 does not exist, we start at version 2 because the original version didn't have a version at all.
+local Version = 2
+
 -- Functions local to this module, do not attempt to use!
 local CacheDefaultObject = nil
 
 -- Everything in this section can be used in any mod that requires this module.
 -- Exported functions -> START
+
+function UEHelpers.GetUEHelpersVersion()
+    return Version
+end
 
 --- Returns the first valid PlayerController that is currently controlled by a player.
 ---@return APlayerController


### PR DESCRIPTION
The version number is intended to be increased whenever any changes are made to the module.
The intent is to allow scripts to verify that the currently installed module is of the correct version.
This could become important in the future if there eventually are breaking changes.