### PR TITLE
Halved the number of objects per chunk in the live view.

### DIFF
--- a/Staging/UE4SS-settings.ini
+++ b/Staging/UE4SS-settings.ini
@@ -93,6 +93,12 @@ GuiConsoleVisible = 0
 ; Default: opengl
 GraphicsAPI = opengl
 
+; How many objects to put in each group in the live view.
+; A lower number means more groups but less lag when a group is open.
+; A higher number means less groups but more lag when a group is open.
+; Default: 32768
+LiveViewObjectsPerGroup = 32768
+
 [Threads]
 ; The number of threads that the sig scanner will use (not real cpu threads, can be over your physical & hyperthreading max)
 ; If the game is modular then multi-threading will always be off regardless of the settings in this file

--- a/include/SettingsManager.hpp
+++ b/include/SettingsManager.hpp
@@ -58,9 +58,10 @@ namespace RC
         struct SectionDebug
         {
             bool SimpleConsoleEnabled{true};
-            bool DebugConsoleEnabled{ true };
-            bool DebugConsoleVisible{ true };
+            bool DebugConsoleEnabled{true};
+            bool DebugConsoleVisible{true};
             GUI::GfxBackend GraphicsAPI{GUI::GfxBackend::GLFW3_OpenGL3};
+            int64_t LiveViewObjectsPerGroup{64 * 1024 / 2};
         } Debug;
 
         struct SectionThreads

--- a/src/SettingsManager.cpp
+++ b/src/SettingsManager.cpp
@@ -78,6 +78,7 @@ namespace RC
         {
             Debug.GraphicsAPI = GUI::GfxBackend::GLFW3_OpenGL3;
         }
+        REGISTER_INT64_SETTING(Debug.LiveViewObjectsPerGroup, section_debug, LiveViewObjectsPerGroup);
 
         constexpr static File::CharType section_threads[] = STR("Threads");
         REGISTER_INT64_SETTING(Threads.SigScannerNumThreads, section_threads, SigScannerNumThreads)


### PR DESCRIPTION
I also renamed "chunks" to "groups" to distance this mechanic from the chunks system in UE. While the two systems are similar, they are not the same and the live view isn't tied to the UE chunks system.

Also added 'LiveViewObjectsPerGroup' to the settings file to allow the user to control this number in case they experience lag.