### PR TITLE
Iterate game directories with Lua

### DIFF
--- a/Staging/API.txt
+++ b/Staging/API.txt
@@ -188,6 +188,15 @@ Global Functions
 
     LoopAsync(integer DelayInMilliseconds, function Callback)
         - Starts a loop that sleeps for the supplied number of milliseconds and stops when the callback returns true.
+    
+    IterateGameDirectories() -> table
+        - Returns a table of all game directories.
+        - An example of an absolute path to Win64: Q:\SteamLibrary\steamapps\common\Deep Rock Galactic\FSD\Binaries\Win64
+        - To get to the same directory, do: IterateGameDirectories().Game.Binaries.Win64
+        - Note that the game name is replaced by 'Game' to keep things generic.
+        - You can use '.__name' and '.__absolute_path' to retrieve values.
+        - You can use '.__files' to retrieve a table containing all files in this directory.
+        - You also use '.__name' and '.__absolute_path' for files.
 
 Classes
     RemoteObject

--- a/include/UE4SSProgram.hpp
+++ b/include/UE4SSProgram.hpp
@@ -146,6 +146,7 @@ namespace RC
     public:
         auto reinstall_mods() -> void;
         auto get_object_dumper_output_directory() -> const File::StringType;
+        auto get_module_directory() -> File::StringViewType;
         auto get_working_directory() -> File::StringViewType;
         auto get_mods_directory() -> File::StringViewType;
         auto generate_uht_compatible_headers() -> void;

--- a/src/UE4SSProgram.cpp
+++ b/src/UE4SSProgram.cpp
@@ -957,6 +957,11 @@ namespace RC
         Output::send(STR("All mods re-installed\n"));
     }
 
+    auto UE4SSProgram::get_module_directory() -> File::StringViewType
+    {
+        return m_module_file_path.c_str();
+    }
+
     auto UE4SSProgram::get_working_directory() -> File::StringViewType
     {
         return m_working_directory.c_str();


### PR DESCRIPTION
Requires https://github.com/Re-UE4SS/UEPseudo/pull/12

It returns a table of all directories & files within the root game directory.
The game name (i.e. FSD) gets replaced with the string "Game" to make it easier to refer to game files.

Usage:
local Dirs = IterateGameDirectories()
local Win64Dir = Dirs.Game.Binaries.Win64
local DirName = Win64Dir.__name
local AbsolutePath = Win64Dir.__absolute_path