### PR TITLE
Added more hooks & functions to Lua, and fixed some bugs.

### DIFF
--- a/Problems_For_3.0.txt
+++ b/Problems_For_3.0.txt
@@ -1,0 +1,23 @@
+This file contains problems that are considered unsuitable for a feature release and must wait for a major release like 3.0.
+
+The following hooks exposed to Lua allow all parameters to be modified:
+InitGameState
+BeginPlay
+
+However, the following hooks exposed to Lua do NOT allow all parameters to be modified:
+CallFunctionByNameWithArguments
+	Modifiable = 'this' ptr, executor
+	Umodifiable = str, ar, bForceCallWithNonExec
+ProcessConsoleExec
+	Modifiable = 'this' ptr, executor
+	Unmodifiable = cmd, ar
+RegisterConsoleCommandGlobalHandler
+	Modifiable = None
+	Unmodifiable = 'this' ptr, cmd, ar, executor
+RegisterConsoleCommandHandler
+	Modifiable = None
+	Unmodifiable = 'this' ptr, cmd, ar, executor
+
+This inconsistency should be fixed in the next major release.
+It should be in the next major release because scripts that currently use these hooks will break if we change how the parameters are brought across from C++ to Lua.
+We also don't currently have a way to transport a non-UE value containerized from C++ to Lua which is the only way to make parameters modifiable.

--- a/Staging/API.txt
+++ b/Staging/API.txt
@@ -116,10 +116,14 @@ Global Functions
     IsKeyBindRegistered(integer Key, table ModifierKeys)
         - Checks if, at the time of the invocation, the supplied keys have been registered
     
-    RegisterHook(string UFunctionName, function Callback)
+    RegisterHook(string UFunctionName, function Callback) -> integer, integer
         - Registers a callback for a UFunction
         - Callbacks are triggered when a UFunction is executed
         - The callback params are: UObject self, UFunctionParams...
+        - Returns two ids, both of which must be passed to 'UnregisterHook' if you want to unregister the hook.
+
+    UnregisterHook(string UFunctionName, integer PreId, integer PostId)
+        - Unregisters a hook.
 		
     ExecuteInGameThread(function Callback)
         - Execute code inside the game thread using ProcessEvent.
@@ -155,6 +159,95 @@ Global Functions
         - Executes the provided Lua function whenever an instance of the provided class is constructed.
         - Inheritance is taken into account, so if you provide "/Script/Engine.Actor" as the class then it will execute your
         - Lua function when any object is constructed that's either an AActor or is derived from AActor.
+
+    RegisterCustomEvent(string EventName, function Callback)
+        - Registers a callback that will get called when a BP function/event is called with the name 'EventName'.
+
+    RegisterInitGameStatePreHook(function Callback)
+        - Registers a callback that will get called before AGameModeBase::InitGameState is called.
+        - The callback params are: AGameModeBase Context
+        - Params (except strings & bools & FOutputDevice) must be retrieved via 'Param:Get()' and set via 'Param:Set()'.
+
+    RegisterInitGameStatePostHook(function Callback)
+        - Registers a callback that will get called after AGameModeBase::InitGameState is called.
+        - The callback params are: AGameModeBase Context
+        - Params (except strings & bools & FOutputDevice) must be retrieved via 'Param:Get()' and set via 'Param:Set()'.
+
+    RegisterBeginPlayPreHook(function Callback)
+        - Registers a callback that will get called before AActor::BeginPlay is called.
+        - The callback params are: AActor Context
+        - Params (except strings & bools & FOutputDevice) must be retrieved via 'Param:Get()' and set via 'Param:Set()'.
+
+    RegisterBeginPlayPostHook(function Callback)
+        - Registers a callback that will get called after AActor::BeginPlay is called.
+        - The callback params are: AActor Context
+        - Params (except strings & bools & FOutputDevice) must be retrieved via 'Param:Get()' and set via 'Param:Set()'.
+
+    RegisterProcessConsoleExecPreHook(function Callback)
+        - Registers a callback that will get called before UObject::ProcessConsoleExec is called.
+        - The callback params are: UObject Context, string Cmd, table CommandParts, FOutputDevice Ar, UObject Executor
+        - Params (except strings & bools & FOutputDevice) must be retrieved via 'Param:Get()' and set via 'Param:Set()'.
+        - If the callback returns nothing (or nil), the original return value of ProcessConsoleExec will be used.
+        - If the callback returns true or false, the supplied value will override the original return value of ProcessConsoleExec.
+
+    RegisterProcessConsoleExecPostHook(function Callback)
+        - Registers a callback that will get called after UObject::ProcessConsoleExec is called.
+        - The callback params are: UObject Context, string Cmd, table CommandParts, FOutputDevice Ar, UObject Executor
+        - Params (except strings & bools & FOutputDevice) must be retrieved via 'Param:Get()' and set via 'Param:Set()'.
+        - If the callback returns nothing (or nil), the original return value of ProcessConsoleExec will be used.
+        - If the callback returns true or false, the supplied value will override the original return value of ProcessConsoleExec.
+
+    RegisterCallFunctionByNameWithArgumentsPreHook(function Callback)
+        - Registers a callback that will be called before UObject::CallFunctionByNameWithArguments is called.
+        - The callback params are: UObject Context, string Str, FOutputDevice Ar, UObject Executor, bool bForceCallWithNonExec
+        - Params (except strings & bools & FOutputDevice) must be retrieved via 'Param:Get()' and set via 'Param:Set()'.
+        - If the callback returns nothing (or nil), the original return value of CallFunctionByNameWithArguments will be used.
+        - If the callback returns true or false, the supplied value will override the original return value of CallFunctionByNameWithArguments.
+
+    RegisterCallFunctionByNameWithArgumentsPostHook(function Callback)
+        - Registers a callback that will be called after UObject::CallFunctionByNameWithArguments is called.
+        - The callback params are: UObject Context, string Str, FOutputDevice Ar, UObject Executor, bool bForceCallWithNonExec
+        - Params (except strings & bools & FOutputDevice) must be retrieved via 'Param:Get()' and set via 'Param:Set()'.
+        - If the callback returns nothing (or nil), the original return value of CallFunctionByNameWithArguments will be used.
+        - If the callback returns true or false, the supplied value will override the original return value of CallFunctionByNameWithArguments.
+
+    RegisterULocalPlayerExecPreHook(function Callback)
+        - Registers a callback that will be called before ULocalPlayer::Exec is called.
+        - The callback params are: ULocalPlayer Context, UWorld InWorld, string Cmd, FOutputDevice Ar
+        - Params (except strings & bools & FOutputDevice) must be retrieved via 'Param:Get()' and set via 'Param:Set()'.
+        - The callback can have two return values.
+        - If the first return value is nothing (or nil), the original return value of Exec will be used.
+        - If the first return value is true or false, the supplied value will override the original return value of Exec.
+        - The second return value controls whether the original Exec will execute.
+        - If the second return value is nil or true, the orginal Exec will execute.
+        - If the second return value is false, the original Exec will not execute.
+
+    RegisterULocalPlayerExecPostHook(function Callback)
+        - Registers a callback that will be called after ULocalPlayer::Exec is called.
+        - The callback params are: ULocalPlayer Context, UWorld InWorld, string Cmd, FOutputDevice Ar
+        - Params (except strings & bools & FOutputDevice) must be retrieved via 'Param:Get()' and set via 'Param:Set()'.
+        - The callback can have two return values.
+        - If the first return value is nothing (or nil), the original return value of Exec will be used.
+        - If the first return value is true or false, the supplied value will override the original return value of Exec.
+        - The second return value controls whether the original Exec will execute.
+        - If the second return value is nil or true, the orginal Exec will execute.
+        - If the second return value is false, the original Exec will not execute.
+
+    RegisterConsoleCommandHandler(string CommandName, function Callback)
+        - Registers a callback for a custom console commands.
+        - The callback only runs in the context of UGameViewportClient.
+        - The callback params are: string Cmd, table CommandParts, FOutputDevice Ar
+        - Params (except strings & bools & FOutputDevice) must be retrieved via 'Param:Get()' and set via 'Param:Set()'.
+        - The callback must return either true or false.
+        - If the callback returns true, no further handlers will be called for this command.
+
+    RegisterConsoleCommandGlobalHandler(string CommandName, function Callback)
+        - Registers a callback for a custom console command.
+        - Unlike 'RegisterConsoleCommandHandler', this global variant runs the callback for all contexts.
+        - The callback params are: string Cmd, table CommandParts, FOutputDevice Ar
+        - Params (except strings & bools & FOutputDevice) must be retrieved via 'Param:Get()' and set via 'Param:Set()'.
+        - The callback must return either true or false.
+        - If the callback returns true, no further handlers will be called for this command.
 
     ExecuteAsync(function Callback)
         - Asynchronously executes the specified function
@@ -309,6 +402,9 @@ Classes
             HasAnyInternalFlags(EInternalObjectFlags InternalFlagsToCheck)
                 - Return whether the object has any of the specified internal flags.
 
+            ProcessConsoleExec(string Cmd, nil Reserved, UObject Executor)
+                - Calls UObject::ProcessConsoleExec with the supplied params.
+
             type() -> string
                 - Returns the type of this object as known by UE4SS
                 - This does not return the type as known by Unreal
@@ -334,6 +430,9 @@ Classes
         Methods
             GetCDO() -> UClass
                 - Returns the ClassDefaultObject of a UClass.
+
+            IsChildOf(UClass Class) -> bool
+                - Returns whether or not the class is a child of another class.
 
     AActor
         Inheritance: UObject
@@ -440,6 +539,12 @@ Classes
         Methods
             __call(UFunctionParams...)
                 - Attempts to call the UFunction
+
+            GetFunctionFlags() -> integer
+                - Returns the flags for the UFunction.
+
+            SetFunctionFlags(integer Flags)
+                Sets the flags for the UFuction.
 
     FString
         Inheritance: RemoteObject

--- a/Staging/UE4SS-settings.ini
+++ b/Staging/UE4SS-settings.ini
@@ -118,3 +118,12 @@ SigScannerMultithreadingModuleSizeThreshold = 16777216
 ; The maximum memory usage (in percentage, see Task Manager %) allowed before asset loading (when LoadAllAssetsBefore* is 1) cannot happen.
 ; Once this percentage is reached, the asset loader will stop loading and whatever operation was in progress (object dump, or cxx generator) will continue.
 MaxMemoryUsageDuringAssetLoading = 80
+
+[Hooks]
+HookProcessInternal = 1
+HookProcessLocalScriptFunction = 1
+HookInitGameState = 1
+HookCallFunctionByNameWithArguments = 1
+HookBeginPlay  = 1
+HookLocalPlayerExec = 1
+FExecVTableOffsetInLocalPlayer = 0x28

--- a/include/GUI/LiveView.hpp
+++ b/include/GUI/LiveView.hpp
@@ -6,12 +6,13 @@
 #include <unordered_map>
 #include <functional>
 #include <variant>
+#include <memory>
 
 #include <DynamicOutput/DynamicOutput.hpp>
 
 namespace RC::Unreal
 {
-    class FUObjectItem;
+    struct FUObjectItem;
     class UObject;
     class UStruct;
     class UClass;
@@ -144,7 +145,7 @@ namespace RC::GUI
         auto render_struct_sub_tree_hierarchy(UStruct* ustruct) -> void;
         auto render_class(UClass*) -> void;
         auto render_super_struct(UStruct*) -> void;
-        
+
         enum class ContainerType { Object, NonObject, };
         auto render_property_value(FProperty* property, ContainerType container_type, void* container, FProperty** last_property_in, bool* tried_to_open_nullptr_object, bool is_watchable = true, int32_t first_offset = -1, bool container_is_array = false) -> std::variant<std::monostate, UObject*, FProperty*>;
 
@@ -156,7 +157,6 @@ namespace RC::GUI
         auto get_selected_object_or_property() -> const ObjectOrProperty&;
         auto get_selected_object(size_t index = 0, UseIndex = UseIndex::No) -> std::pair<const FUObjectItem*, UObject*>;
         auto get_selected_property(size_t index = 0, UseIndex = UseIndex::No) -> FProperty*;
-
 
     private:
         auto guobjectarray_iterator(int32_t int_data_1, int32_t int_data_2, const std::function<void(UObject*)>& callable) -> void;
@@ -194,4 +194,3 @@ namespace std
 }
 
 #endif //UE4SS_GUI_LIVE_VIEW_HPP
-

--- a/include/Mod.hpp
+++ b/include/Mod.hpp
@@ -86,6 +86,7 @@ namespace RC
         // This is storage that persists through hot-reloads.
         static inline std::unordered_map<std::string, SharedLuaVariable> m_shared_lua_variables{};
         static inline bool m_is_currently_executing_game_action{};
+        static inline std::mutex m_thread_actions_mutex{};
 
     protected:
         std::jthread m_async_thread;

--- a/include/Mod.hpp
+++ b/include/Mod.hpp
@@ -80,11 +80,22 @@ namespace RC
             std::vector<int32_t> registry_indexes;
         };
         static inline std::vector<LuaCallbackData> m_static_construct_object_lua_callbacks;
+        static inline std::vector<LuaCallbackData> m_process_console_exec_pre_callbacks;
+        static inline std::vector<LuaCallbackData> m_process_console_exec_post_callbacks;
+        static inline std::vector<LuaCallbackData> m_call_function_by_name_with_arguments_pre_callbacks;
+        static inline std::vector<LuaCallbackData> m_call_function_by_name_with_arguments_post_callbacks;
+        static inline std::vector<LuaCallbackData> m_local_player_exec_pre_callbacks;
+        static inline std::vector<LuaCallbackData> m_local_player_exec_post_callbacks;
         static inline std::unordered_map<File::StringType, LuaCallbackData> m_global_command_lua_callbacks;
         static inline std::unordered_map<File::StringType, LuaCallbackData> m_custom_command_lua_pre_callbacks;
         static inline std::vector<SimpleLuaAction> m_game_thread_actions{};
         // This is storage that persists through hot-reloads.
         static inline std::unordered_map<std::string, SharedLuaVariable> m_shared_lua_variables{};
+        static inline std::unordered_map<StringType, LuaCallbackData> m_custom_event_callbacks{};
+        static inline std::vector<LuaCallbackData> m_init_game_state_pre_callbacks{};
+        static inline std::vector<LuaCallbackData> m_init_game_state_post_callbacks{};
+        static inline std::vector<LuaCallbackData> m_begin_play_pre_callbacks{};
+        static inline std::vector<LuaCallbackData> m_begin_play_post_callbacks{};
         static inline bool m_is_currently_executing_game_action{};
         static inline std::recursive_mutex m_thread_actions_mutex{};
 

--- a/include/Mod.hpp
+++ b/include/Mod.hpp
@@ -86,7 +86,7 @@ namespace RC
         // This is storage that persists through hot-reloads.
         static inline std::unordered_map<std::string, SharedLuaVariable> m_shared_lua_variables{};
         static inline bool m_is_currently_executing_game_action{};
-        static inline std::mutex m_thread_actions_mutex{};
+        static inline std::recursive_mutex m_thread_actions_mutex{};
 
     protected:
         std::jthread m_async_thread;

--- a/include/SettingsManager.hpp
+++ b/include/SettingsManager.hpp
@@ -75,6 +75,17 @@ namespace RC
             int64_t MaxMemoryUsageDuringAssetLoading{85};
         } Memory;
 
+        struct SectionHooks
+        {
+            bool HookProcessInternal{true};
+            bool HookProcessLocalScriptFunction{true};
+            bool HookInitGameState{true};
+            bool HookCallFunctionByNameWithArguments{true};
+            bool HookBeginPlay{true};
+            bool HookLocalPlayerExec{true};
+            int64_t FExecVTableOffsetInLocalPlayer{0x28};
+        } Hooks;
+
     public:
         SettingsManager() = default;
 

--- a/src/GUI/GLFW3_OpenGL3.cpp
+++ b/src/GUI/GLFW3_OpenGL3.cpp
@@ -11,7 +11,7 @@ namespace RC::GUI
 {
     static void glfw_error_callback(int error, const char* description)
     {
-        throw std::runtime_error{std::format("Glfw Error {}: {}\n", error, description)};
+        Output::send<LogLevel::Error>(STR("Glfw Error {}: {}\n"), error, to_wstring(description));
     }
 
     auto Backend_GLFW3_OpenGL3::init() -> void

--- a/src/GUI/LiveView.cpp
+++ b/src/GUI/LiveView.cpp
@@ -114,7 +114,6 @@ namespace RC::GUI
             LiveView::s_name_search_results.emplace_back(object);
             LiveView::s_name_search_results_set.emplace(object);
         }
-        
     }
 
     static auto remove_search_result(UObject* object) -> void
@@ -1018,7 +1017,6 @@ namespace RC::GUI
                 ImGui::Text("Uses the same format as the 'set' UE4 console command.");
                 ImGui::Text("The game could crash if the new value is invalid.");
                 ImGui::Text("The game can override the new value immediately.");
-                
                 ImGui::PushItemWidth(-1.0f);
                 ImGui::InputText("##CurrentPropertyValue", &m_current_property_value_buffer);
                 if (ImGui::Button("Apply"))
@@ -1052,7 +1050,7 @@ namespace RC::GUI
                 m_modal_edit_property_value_opened_this_frame = false;
             }
         }
-        
+
         return next_item_to_render;
     }
 
@@ -1841,4 +1839,3 @@ namespace RC::GUI
         ImGui::EndChild();
     }
 }
-

--- a/src/LuaType/LuaUClass.cpp
+++ b/src/LuaType/LuaUClass.cpp
@@ -68,6 +68,15 @@ namespace RC::LuaType
             return 1;
         });
 
+        table.add_pair("IsChildOf", [](const LuaMadeSimple::Lua& lua) -> int {
+            const auto& lua_object = lua.get_userdata<UClass>();
+            
+            const auto& param_1 = lua.get_userdata<UClass>();
+            lua.set_bool(lua_object.get_remote_cpp_object()->IsChildOf(param_1.get_remote_cpp_object()));
+
+            return 1;
+        });
+
         if constexpr (is_final == LuaMadeSimple::Type::IsFinal::Yes)
         {
             table.add_pair("type", [](const LuaMadeSimple::Lua& lua) -> int {

--- a/src/LuaType/LuaUFunction.cpp
+++ b/src/LuaType/LuaUFunction.cpp
@@ -2,6 +2,7 @@
 
 #include <LuaType/LuaUFunction.hpp>
 #include <Helpers/Integer.hpp>
+#include <stdexcept>
 #pragma warning(disable: 4005)
 #include <Unreal/UFunction.hpp>
 #include <Unreal/FProperty.hpp>
@@ -70,6 +71,23 @@ namespace RC::LuaType
     template<LuaMadeSimple::Type::IsFinal is_final>
     auto UFunction::setup_member_functions(const LuaMadeSimple::Lua::Table& table) -> void
     {
+        table.add_pair("GetFunctionFlags", [](const LuaMadeSimple::Lua& lua) -> int {
+            const auto& lua_object = lua.get_userdata<LuaType::UFunction>();
+            lua.set_integer(lua_object.get_remote_cpp_object()->GetFunctionFlags());
+            return 1;
+        });
+
+        table.add_pair("SetFunctionFlags", [](const LuaMadeSimple::Lua& lua) -> int {
+            const auto& lua_object = lua.get_userdata<LuaType::UFunction>();
+            if (!lua.is_integer())
+            {
+                throw std::runtime_error{"UFunction::SetFunctionFlags must have an integer as the first param."};
+            }
+            auto new_function_flags = static_cast<Unreal::EFunctionFlags>(lua.get_integer());
+            lua_object.get_remote_cpp_object()->GetFunctionFlags() = new_function_flags;
+            return 0;
+        });
+
         if constexpr (is_final == LuaMadeSimple::Type::IsFinal::Yes)
         {
             table.add_pair("type", [](const LuaMadeSimple::Lua& lua) -> int {

--- a/src/Mod.cpp
+++ b/src/Mod.cpp
@@ -2082,7 +2082,7 @@ Overloads:
 
     auto static process_event_hook([[maybe_unused]]Unreal::UObject* Context, [[maybe_unused]]Unreal::UFunction* Function, [[maybe_unused]]void* Parms) -> void
     {
-        std::lock_guard<std::mutex> guard{Mod::m_thread_actions_mutex};
+        std::lock_guard<std::recursive_mutex> guard{Mod::m_thread_actions_mutex};
         // NOTE: This will break horribly if UFunctions ever execute asynchronously.
         Mod::m_game_thread_actions.erase(std::remove_if(Mod::m_game_thread_actions.begin(), Mod::m_game_thread_actions.end(), [&](Mod::SimpleLuaAction& lua_data) -> bool {
             if (Mod::m_is_currently_executing_game_action)
@@ -2176,7 +2176,7 @@ Overloads:
             lua_xmove(lua.get_lua_state(), hook_lua->get_lua_state(), 1);
             
             {
-                std::lock_guard<std::mutex> guard{Mod::m_thread_actions_mutex};
+                std::lock_guard<std::recursive_mutex> guard{Mod::m_thread_actions_mutex};
                 mod->m_game_thread_actions.emplace_back(SimpleLuaAction{hook_lua, luaL_ref(hook_lua->get_lua_state(), LUA_REGISTRYINDEX)});
             }
             

--- a/src/Mod.cpp
+++ b/src/Mod.cpp
@@ -2082,6 +2082,7 @@ Overloads:
 
     auto static process_event_hook([[maybe_unused]]Unreal::UObject* Context, [[maybe_unused]]Unreal::UFunction* Function, [[maybe_unused]]void* Parms) -> void
     {
+        std::lock_guard<std::mutex> guard{Mod::m_thread_actions_mutex};
         // NOTE: This will break horribly if UFunctions ever execute asynchronously.
         Mod::m_game_thread_actions.erase(std::remove_if(Mod::m_game_thread_actions.begin(), Mod::m_game_thread_actions.end(), [&](Mod::SimpleLuaAction& lua_data) -> bool {
             if (Mod::m_is_currently_executing_game_action)
@@ -2173,8 +2174,12 @@ Overloads:
             lua_pushvalue(lua.get_lua_state(), 1);
 
             lua_xmove(lua.get_lua_state(), hook_lua->get_lua_state(), 1);
-
-            mod->m_game_thread_actions.emplace_back(SimpleLuaAction{hook_lua, luaL_ref(hook_lua->get_lua_state(), LUA_REGISTRYINDEX)});
+            
+            {
+                std::lock_guard<std::mutex> guard{Mod::m_thread_actions_mutex};
+                mod->m_game_thread_actions.emplace_back(SimpleLuaAction{hook_lua, luaL_ref(hook_lua->get_lua_state(), LUA_REGISTRYINDEX)});
+            }
+            
             if (!mod->m_is_process_event_hooked)
             {
                 Unreal::Hook::RegisterProcessEventPreCallback(&process_event_hook);

--- a/src/Mod.cpp
+++ b/src/Mod.cpp
@@ -26,6 +26,7 @@
 #include <GUI/Dumpers.hpp>
 #include <USMapGenerator/Generator.hpp>
 #include <Unreal/UnrealVersion.hpp>
+#include <Unreal/UObjectGlobals.hpp>
 #include <Unreal/Hooks.hpp>
 #include <Unreal/UnrealVersion.hpp>
 #include <Unreal/UFunction.hpp>
@@ -37,6 +38,7 @@
 #include <Unreal/UGameViewportClient.hpp>
 #include <Unreal/PackageName.hpp>
 #include <Unreal/TypeChecker.hpp>
+#include <Unreal/FFrame.hpp>
 #include <Unreal/FOutputDevice.hpp>
 #include <Unreal/Property/NumericPropertyTypes.hpp>
 #include <Unreal/Property/FObjectProperty.hpp>
@@ -486,7 +488,7 @@ namespace RC
         object_internal_flags_table.add_pair("AllFlags", static_cast<std::underlying_type_t<Unreal::EInternalObjectFlags>>(Unreal::EInternalObjectFlags::AllFlags));
         object_internal_flags_table.make_global("EInternalObjectFlags");
     }
-    
+
     static auto regrister_efindname(const LuaMadeSimple::Lua& lua) -> void
     {
         LuaMadeSimple::Lua::Table efindname_table = lua.prepare_new_table();
@@ -949,7 +951,7 @@ Overloads:
                 
                 return 1;
             });
-            
+
             lua.register_function("RegisterKeyBind", [](const LuaMadeSimple::Lua& lua) -> int {
                 std::string error_overload_not_found{R"(
 No overload found for function 'RegisterKeyBind'.
@@ -1496,6 +1498,153 @@ Overloads:
             return 0;
         });
 
+        lua.register_function("RegisterCustomEvent", [](const LuaMadeSimple::Lua& lua) -> int {
+            std::string error_overload_not_found{R"(
+No overload found for function 'RegisterCustomEvent'.
+Overloads:
+#1: RegisterCustomEvent(string EventName, LuaFunction Callback))"};
+
+            if (!lua.is_string())
+            {
+                lua.throw_error(error_overload_not_found);
+            }
+
+            std::wstring event_name = to_wstring(lua.get_string());
+
+            if (!lua.is_function())
+            {
+                lua.throw_error(error_overload_not_found);
+            }
+
+            auto mod = get_mod_ref(lua);
+            auto hook_lua = make_hook_state(mod);
+
+            lua_xmove(lua.get_lua_state(), hook_lua->get_lua_state(), 1);
+
+            // Take a reference to the Lua function (it also pops it of the stack)
+            const int32_t lua_callback_registry_index = hook_lua->registry().make_ref();
+
+            Mod::m_custom_event_callbacks.emplace(event_name, Mod::LuaCallbackData{
+                .lua = lua,
+                .instance_of_class = nullptr,
+                .registry_indexes = {lua_callback_registry_index},
+            });
+
+            return 0;
+        });
+
+        lua.register_function("RegisterInitGameStatePreHook", [](const LuaMadeSimple::Lua& lua) -> int {
+            std::string error_overload_not_found{R"(
+No overload found for function 'RegisterInitGameStatePreHook'.
+Overloads:
+#1: RegisterInitGameStatePreHook(LuaFunction Callback))"};
+
+            if (!lua.is_function())
+            {
+                lua.throw_error(error_overload_not_found);
+            }
+
+            auto mod = get_mod_ref(lua);
+            auto hook_lua = make_hook_state(mod);
+
+            lua_xmove(lua.get_lua_state(), hook_lua->get_lua_state(), 1);
+
+            // Take a reference to the Lua function (it also pops it of the stack)
+            const int32_t lua_callback_registry_index = hook_lua->registry().make_ref();
+
+            Mod::m_init_game_state_pre_callbacks.emplace_back(Mod::LuaCallbackData{
+                .lua = lua,
+                .instance_of_class = nullptr,
+                .registry_indexes = {lua_callback_registry_index},
+            });
+
+            return 0;
+        });
+        
+        lua.register_function("RegisterInitGameStatePostHook", [](const LuaMadeSimple::Lua& lua) -> int {
+            std::string error_overload_not_found{R"(
+No overload found for function 'RegisterInitGameStatePostHook'.
+Overloads:
+#1: RegisterInitGameStatePostHook(LuaFunction Callback))"};
+
+            if (!lua.is_function())
+            {
+                lua.throw_error(error_overload_not_found);
+            }
+
+            auto mod = get_mod_ref(lua);
+            auto hook_lua = make_hook_state(mod);
+
+            lua_xmove(lua.get_lua_state(), hook_lua->get_lua_state(), 1);
+
+            // Take a reference to the Lua function (it also pops it of the stack)
+            const int32_t lua_callback_registry_index = hook_lua->registry().make_ref();
+
+            Mod::m_init_game_state_post_callbacks.emplace_back(Mod::LuaCallbackData{
+                .lua = lua,
+                .instance_of_class = nullptr,
+                .registry_indexes = {lua_callback_registry_index},
+            });
+
+            return 0;
+        });
+
+        lua.register_function("RegisterBeginPlayPreHook", [](const LuaMadeSimple::Lua& lua) -> int {
+            std::string error_overload_not_found{R"(
+No overload found for function 'RegisterBeginPlayPreHook'.
+Overloads:
+#1: RegisterBeginPlayPreHook(LuaFunction Callback))"};
+
+            if (!lua.is_function())
+            {
+                lua.throw_error(error_overload_not_found);
+            }
+
+            auto mod = get_mod_ref(lua);
+            auto hook_lua = make_hook_state(mod);
+
+            lua_xmove(lua.get_lua_state(), hook_lua->get_lua_state(), 1);
+
+            // Take a reference to the Lua function (it also pops it of the stack)
+            const int32_t lua_callback_registry_index = hook_lua->registry().make_ref();
+
+            Mod::m_begin_play_pre_callbacks.emplace_back(Mod::LuaCallbackData{
+                .lua = lua,
+                .instance_of_class = nullptr,
+                .registry_indexes = {lua_callback_registry_index},
+            });
+
+            return 0;
+        });
+        
+        lua.register_function("RegisterBeginPlayPostHook", [](const LuaMadeSimple::Lua& lua) -> int {
+            std::string error_overload_not_found{R"(
+No overload found for function 'RegisterBeginPlayPostHook'.
+Overloads:
+#1: RegisterBeginPlayPostHook(LuaFunction Callback))"};
+
+            if (!lua.is_function())
+            {
+                lua.throw_error(error_overload_not_found);
+            }
+
+            auto mod = get_mod_ref(lua);
+            auto hook_lua = make_hook_state(mod);
+
+            lua_xmove(lua.get_lua_state(), hook_lua->get_lua_state(), 1);
+
+            // Take a reference to the Lua function (it also pops it of the stack)
+            const int32_t lua_callback_registry_index = hook_lua->registry().make_ref();
+
+            Mod::m_begin_play_post_callbacks.emplace_back(Mod::LuaCallbackData{
+                .lua = lua,
+                .instance_of_class = nullptr,
+                .registry_indexes = {lua_callback_registry_index},
+            });
+
+            return 0;
+        });
+
         lua.register_function("IterateGameDirectories", [](const LuaMadeSimple::Lua& lua) -> int {
             std::string error_overload_not_found{R"(
 No overload found for function 'IterateGameDirectories'.
@@ -1503,14 +1652,15 @@ Overloads:
 #1: IterateGameDirectories()"};
 
             std::filesystem::path module_directory = UE4SSProgram::get_program().get_module_directory();
-            auto game_name = StringType{Unreal::UKismetSystemLibrary::GetGameName().GetCharArray()};
-            if (module_directory.parent_path().parent_path().parent_path().stem() != game_name)
+            auto game_content_dir = module_directory.parent_path().parent_path().parent_path() / "Content";
+            if (!std::filesystem::exists(game_content_dir))
             {
-                Output::send<LogLevel::Warning>(STR("IterateGameDirectories: Could not locate the root directory because the directory structure is unknown (not <RootGamePath>/Game/Binaries/Win64)"));
+                Output::send<LogLevel::Warning>(STR("IterateGameDirectories: Could not locate the root directory because the directory structure is unknown (not <RootGamePath>/Game/Binaries/Win64)\n"));
                 lua.set_nil();
                 return 1;
             }
             
+            auto game_name = module_directory.parent_path().parent_path().parent_path().stem();
             auto game_root_directory = module_directory.parent_path().parent_path().parent_path().parent_path();
             auto directories_table = lua.prepare_new_table();
 
@@ -1662,6 +1812,114 @@ Overloads:
             });
             mod->actions_unlock();
 
+            return 0;
+        });
+
+        lua.register_function("RegisterProcessConsoleExecPreHook", [](const LuaMadeSimple::Lua& lua) -> int {
+            std::string error_overload_not_found{R"(
+No overload found for function 'RegisterProcessConsoleExecPreHook'.
+Overloads:
+#1: RegisterProcessConsoleExecPreHook(LuaFunction Callback))"};
+
+            if (!lua.is_function()) { throw std::runtime_error{error_overload_not_found}; }
+
+            Mod::LuaCallbackData* callback = nullptr;
+            auto mod = get_mod_ref(lua);
+            auto hook_lua = make_hook_state(mod);
+            callback = &Mod::m_process_console_exec_pre_callbacks.emplace_back(Mod::LuaCallbackData{ *hook_lua, nullptr, {} });
+            lua_xmove(lua.get_lua_state(), callback->lua.get_lua_state(), 1);
+            const int32_t lua_function_ref = callback->lua.registry().make_ref();
+            callback->registry_indexes.emplace_back(lua_function_ref);
+            return 0;
+        });
+
+        lua.register_function("RegisterProcessConsoleExecPostHook", [](const LuaMadeSimple::Lua& lua) -> int {
+            std::string error_overload_not_found{R"(
+No overload found for function 'RegisterProcessConsoleExecPostHook'.
+Overloads:
+#1: RegisterProcessConsoleExecPostHook(LuaFunction Callback))"};
+
+            if (!lua.is_function()) { throw std::runtime_error{error_overload_not_found}; }
+
+            Mod::LuaCallbackData* callback = nullptr;
+            auto mod = get_mod_ref(lua);
+            auto hook_lua = make_hook_state(mod);
+            callback = &Mod::m_process_console_exec_post_callbacks.emplace_back(Mod::LuaCallbackData{ *hook_lua, nullptr, {} });
+            lua_xmove(lua.get_lua_state(), callback->lua.get_lua_state(), 1);
+            const int32_t lua_function_ref = callback->lua.registry().make_ref();
+            callback->registry_indexes.emplace_back(lua_function_ref);
+            return 0;
+        });
+
+        lua.register_function("RegisterCallFunctionByNameWithArgumentsPreHook", [](const LuaMadeSimple::Lua& lua) -> int {
+            std::string error_overload_not_found{R"(
+No overload found for function 'RegisterCallFunctionByNameWithArgumentsPreHook'.
+Overloads:
+#1: RegisterCallFunctionByNameWithArgumentsPreHook(LuaFunction Callback))"};
+
+            if (!lua.is_function()) { throw std::runtime_error{error_overload_not_found}; }
+
+            Mod::LuaCallbackData* callback = nullptr;
+            auto mod = get_mod_ref(lua);
+            auto hook_lua = make_hook_state(mod);
+            callback = &Mod::m_call_function_by_name_with_arguments_pre_callbacks.emplace_back(Mod::LuaCallbackData{ *hook_lua, nullptr, {} });
+            lua_xmove(lua.get_lua_state(), callback->lua.get_lua_state(), 1);
+            const int32_t lua_function_ref = callback->lua.registry().make_ref();
+            callback->registry_indexes.emplace_back(lua_function_ref);
+            return 0;
+        });
+
+        lua.register_function("RegisterCallFunctionByNameWithArgumentsPostHook", [](const LuaMadeSimple::Lua& lua) -> int {
+            std::string error_overload_not_found{R"(
+No overload found for function 'RegisterCallFunctionByNameWithArgumentsPostHook'.
+Overloads:
+#1: RegisterCallFunctionByNameWithArgumentsPostHook(LuaFunction Callback))"};
+
+            if (!lua.is_function()) { throw std::runtime_error{error_overload_not_found}; }
+
+            Mod::LuaCallbackData* callback = nullptr;
+            auto mod = get_mod_ref(lua);
+            auto hook_lua = make_hook_state(mod);
+            callback = &Mod::m_call_function_by_name_with_arguments_post_callbacks.emplace_back(Mod::LuaCallbackData{ *hook_lua, nullptr, {} });
+            lua_xmove(lua.get_lua_state(), callback->lua.get_lua_state(), 1);
+            const int32_t lua_function_ref = callback->lua.registry().make_ref();
+            callback->registry_indexes.emplace_back(lua_function_ref);
+            return 0;
+        });
+
+        lua.register_function("RegisterULocalPlayerExecPreHook", [](const LuaMadeSimple::Lua& lua) -> int {
+            std::string error_overload_not_found{R"(
+No overload found for function 'RegisterULocalPlayerExecPreHook'.
+Overloads:
+#1: RegisterULocalPlayerExecPreHook(LuaFunction Callback))"};
+
+            if (!lua.is_function()) { throw std::runtime_error{error_overload_not_found}; }
+
+            Mod::LuaCallbackData* callback = nullptr;
+            auto mod = get_mod_ref(lua);
+            auto hook_lua = make_hook_state(mod);
+            callback = &Mod::m_local_player_exec_pre_callbacks.emplace_back(Mod::LuaCallbackData{ *hook_lua, nullptr, {} });
+            lua_xmove(lua.get_lua_state(), callback->lua.get_lua_state(), 1);
+            const int32_t lua_function_ref = callback->lua.registry().make_ref();
+            callback->registry_indexes.emplace_back(lua_function_ref);
+            return 0;
+        });
+
+        lua.register_function("RegisterULocalPlayerExecPostHook", [](const LuaMadeSimple::Lua& lua) -> int {
+            std::string error_overload_not_found{R"(
+No overload found for function 'RegisterULocalPlayerExecPostHook'.
+Overloads:
+#1: RegisterULocalPlayerExecPostHook(LuaFunction Callback))"};
+
+            if (!lua.is_function()) { throw std::runtime_error{error_overload_not_found}; }
+
+            Mod::LuaCallbackData* callback = nullptr;
+            auto mod = get_mod_ref(lua);
+            auto hook_lua = make_hook_state(mod);
+            callback = &Mod::m_local_player_exec_post_callbacks.emplace_back(Mod::LuaCallbackData{ *hook_lua, nullptr, {} });
+            lua_xmove(lua.get_lua_state(), callback->lua.get_lua_state(), 1);
+            const int32_t lua_function_ref = callback->lua.registry().make_ref();
+            callback->registry_indexes.emplace_back(lua_function_ref);
             return 0;
         });
 
@@ -2158,7 +2416,7 @@ Overloads:
 
             return 2;
         });
-        
+
         m_lua.register_function("ExecuteInGameThread", [](const LuaMadeSimple::Lua& lua) -> int {
             std::string error_overload_not_found{ R"(
 No overload found for function 'ExecuteInGameThread'.
@@ -2174,7 +2432,7 @@ Overloads:
             lua_pushvalue(lua.get_lua_state(), 1);
 
             lua_xmove(lua.get_lua_state(), hook_lua->get_lua_state(), 1);
-            
+
             {
                 std::lock_guard<std::recursive_mutex> guard{Mod::m_thread_actions_mutex};
                 mod->m_game_thread_actions.emplace_back(SimpleLuaAction{hook_lua, luaL_ref(hook_lua->get_lua_state(), LUA_REGISTRYINDEX)});
@@ -2414,6 +2672,9 @@ Overloads:
         register_all_property_types(lua);
         register_object_flags(lua);
         regrister_efindname(lua);
+
+        lua.set_nil();
+        lua_setglobal(lua.get_lua_state(), "__OriginalReturnValue");
     }
 
     auto Mod::start_mod() -> void
@@ -2443,7 +2704,7 @@ Overloads:
             m_async_thread.request_stop();
             m_async_thread.join();
         }
-        
+
         if (m_hook_lua.size() > 0)
         {
             for (auto lua : m_hook_lua)
@@ -2519,8 +2780,187 @@ Overloads:
         LuaStatics::console_executor_enabled = false;
     }
 
+    static auto hook_for_custom_bp_events([[maybe_unused]]Unreal::UObject* Context, Unreal::FFrame& Stack, [[maybe_unused]]void* RESULT_DECL) -> void
+    {
+        TRY([&] {
+            if (Mod::m_custom_event_callbacks.empty()) { return; }
+            if (auto it = Mod::m_custom_event_callbacks.find(Stack.Node()->GetName()); it != Mod::m_custom_event_callbacks.end())
+            {
+                const auto& callback_data = it->second;
+                for (const auto registry_index : callback_data.registry_indexes)
+                {
+                    const auto& lua = callback_data.lua;
+
+                    set_is_in_game_thread(lua, true);
+
+                    lua.registry().get_function_ref(registry_index);
+
+                    static auto s_object_property_name = Unreal::FName(STR("ObjectProperty"));
+                    LuaType::RemoteUnrealParam::construct(lua, &Context, s_object_property_name);
+                    
+                    auto node = Stack.Node();
+                    auto return_value_offset = node->GetReturnValueOffset();
+                    auto has_return_value = return_value_offset != 0xFFFF;
+                    auto num_unreal_params = node->GetNumParms();
+                    if (has_return_value && num_unreal_params > 0) { --num_unreal_params; }
+
+                    if (has_return_value || num_unreal_params > 0)
+                    {
+                        node->ForEachProperty([&](Unreal::FProperty* param) {
+                            if (!param->HasAnyPropertyFlags(Unreal::EPropertyFlags::CPF_Parm)) { return LoopAction::Continue; }
+                            if (has_return_value && param->GetOffset_Internal() == return_value_offset) { return LoopAction::Continue; }
+
+                            auto param_type = param->GetClass().GetFName();
+                            auto param_type_comparison_index = param_type.GetComparisonIndex();
+                            if (auto it = LuaType::StaticState::m_property_value_pushers.find(param_type_comparison_index); it != LuaType::StaticState::m_property_value_pushers.end())
+                            {
+                                auto data = param->ContainerPtrToValuePtr<void>(Stack.Locals());
+                                const LuaType::PusherParams pusher_param{
+                                    .operation = LuaType::Operation::GetParam,
+                                    .lua = lua,
+                                    .base = nullptr,
+                                    .data = data,
+                                    .property = param,
+                                };
+                                auto& type_handler = it->second;
+                                type_handler(pusher_param);
+                            }
+                            else
+                            {
+                                lua.throw_error(std::format("[hook_for_custom_bp_events] Tried accessing unreal property without a registered handler. Property type '{}' not supported.", to_string(param_type.ToString())));
+                            }
+
+                            return LoopAction::Continue;
+                        });
+                    }
+                    
+                    lua.call_function(num_unreal_params + 1, 1);
+
+                    bool return_value_handled{};
+                    if (has_return_value && RESULT_DECL && lua.get_stack_size() > 0)
+                    {
+                        auto return_property = node->GetReturnProperty();
+                        if (return_property)
+                        {
+                            auto return_property_type = return_property->GetClass().GetFName();
+                            auto return_property_type_comparison_index = return_property_type.GetComparisonIndex();
+
+                            if (auto it = LuaType::StaticState::m_property_value_pushers.find(return_property_type_comparison_index); it != LuaType::StaticState::m_property_value_pushers.end())
+                            {
+                                const LuaType::PusherParams pusher_params{
+                                        .operation = LuaType::Operation::Set,
+                                        .lua = lua,
+                                        .base = static_cast<Unreal::UObject*>(RESULT_DECL),
+                                        .data = RESULT_DECL,
+                                        .property = return_property
+                                };
+                                auto& type_handler = it->second;
+                                type_handler(pusher_params);
+                                return_value_handled = true;
+                            }
+                            else
+                            {
+                                std::wstring return_property_type_name = return_property_type.ToString();
+                                std::wstring return_property_name = return_property->GetName();
+
+                                Output::send(STR("Tried altering return value of a custom BP function without a registered handler for return type Return property '{}' of type '{}' not supported."), return_property_name, return_property_type_name);
+                            }
+                        }
+                    }
+
+                    if (!return_value_handled)
+                    {
+                        lua.discard_value();
+                    }
+
+                    set_is_in_game_thread(lua, false);
+                }
+            }
+        });
+    }
+
     auto Mod::on_program_start() -> void
     {
+        Unreal::Hook::RegisterInitGameStatePreCallback([]([[maybe_unused]]Unreal::AGameModeBase* Context) {
+            TRY([&] {
+                for (const auto& callback_data : m_init_game_state_pre_callbacks)
+                {
+                    const auto& lua = callback_data.lua;
+                    //set_is_in_game_thread(lua, true);
+
+                    for (const auto registry_index : callback_data.registry_indexes)
+                    {
+                        lua.registry().get_function_ref(registry_index);
+                        static auto s_object_property_name = Unreal::FName(STR("ObjectProperty"));
+                        LuaType::RemoteUnrealParam::construct(lua, &Context, s_object_property_name);
+                        lua.call_function(1, 0);
+                    }
+
+                    //set_is_in_game_thread(lua, false);
+                }
+            });
+        });
+
+        Unreal::Hook::RegisterInitGameStatePostCallback([]([[maybe_unused]]Unreal::AGameModeBase* Context) {
+            TRY([&] {
+                for (const auto& callback_data : m_init_game_state_post_callbacks)
+                {
+                    const auto& lua = callback_data.lua;
+                    //set_is_in_game_thread(lua, true);
+
+                    for (const auto registry_index : callback_data.registry_indexes)
+                    {
+                        lua.registry().get_function_ref(registry_index);
+                        static auto s_object_property_name = Unreal::FName(STR("ObjectProperty"));
+                        LuaType::RemoteUnrealParam::construct(lua, &Context, s_object_property_name);
+                        lua.call_function(1, 0);
+                    }
+
+                    //set_is_in_game_thread(lua, false);
+                }
+            });
+        });
+
+        Unreal::Hook::RegisterBeginPlayPreCallback([]([[maybe_unused]]Unreal::AActor* Context) {
+            TRY([&] {
+                for (const auto& callback_data : m_begin_play_pre_callbacks)
+                {
+                    const auto& lua = callback_data.lua;
+                    //set_is_in_game_thread(lua, true);
+
+                    for (const auto registry_index : callback_data.registry_indexes)
+                    {
+                        lua.registry().get_function_ref(registry_index);
+                        static auto s_object_property_name = Unreal::FName(STR("ObjectProperty"));
+                        LuaType::RemoteUnrealParam::construct(lua, &Context, s_object_property_name);
+                        lua.call_function(1, 0);
+                    }
+
+                    //set_is_in_game_thread(lua, false);
+                }
+            });
+        });
+        
+        Unreal::Hook::RegisterBeginPlayPostCallback([]([[maybe_unused]]Unreal::AActor* Context) {
+            TRY([&] {
+                for (const auto& callback_data : m_begin_play_post_callbacks)
+                {
+                    const auto& lua = callback_data.lua;
+                    //set_is_in_game_thread(lua, true);
+
+                    for (const auto registry_index : callback_data.registry_indexes)
+                    {
+                        lua.registry().get_function_ref(registry_index);
+                        static auto s_object_property_name = Unreal::FName(STR("ObjectProperty"));
+                        LuaType::RemoteUnrealParam::construct(lua, &Context, s_object_property_name);
+                        lua.call_function(1, 0);
+                    }
+
+                    //set_is_in_game_thread(lua, false);
+                }
+            });
+        });
+
         Unreal::Hook::RegisterStaticConstructObjectPostCallback([](const Unreal::FStaticConstructObjectParameters&, Unreal::UObject* constructed_object) {
             Unreal::UStruct* object_class = constructed_object->GetClassPrivate();
             while (object_class)
@@ -2549,6 +2989,216 @@ Overloads:
             }
 
             return constructed_object;
+        });
+
+        Unreal::Hook::RegisterULocalPlayerExecPreCallback([](Unreal::ULocalPlayer* context, Unreal::UWorld* in_world, const TCHAR* cmd, Unreal::FOutputDevice& ar) -> Unreal::Hook::ULocalPlayerExecCallbackReturnValue {
+            return TRY([&] {
+                for (const auto& callback_data : m_local_player_exec_pre_callbacks)
+                {
+                    set_is_in_game_thread(callback_data.lua, true);
+
+                    Unreal::Hook::ULocalPlayerExecCallbackReturnValue return_value{};
+
+                    for (const auto& registry_index : callback_data.registry_indexes)
+                    {
+                        callback_data.lua.registry().get_function_ref(registry_index);
+
+                        static auto s_object_property_name = Unreal::FName(STR("ObjectProperty"));
+                        LuaType::RemoteUnrealParam::construct(callback_data.lua, &context, s_object_property_name);
+                        LuaType::RemoteUnrealParam::construct(callback_data.lua, &in_world, s_object_property_name);
+                        callback_data.lua.set_string(to_string(cmd));
+                        LuaType::FOutputDevice::construct(callback_data.lua, &ar);
+
+                        callback_data.lua.call_function(4, 2);
+
+                        if (callback_data.lua.is_nil())
+                        {
+                            return_value.UseOriginalReturnValue = true;
+                            callback_data.lua.discard_value();
+                        }
+                        else if (!callback_data.lua.is_bool())
+                        {
+                            throw std::runtime_error{"The first return value for 'RegisterULocalPlayerExecPreHook' must return bool or nil"};
+                        }
+                        else
+                        {
+                            return_value.UseOriginalReturnValue = false;
+                            return_value.NewReturnValue = callback_data.lua.get_bool();
+                        }
+
+                        if (callback_data.lua.is_nil())
+                        {
+                            return_value.ExecuteOriginalFunction = true;
+                            callback_data.lua.discard_value();
+                        }
+                        else if (!callback_data.lua.is_bool())
+                        {
+                            throw std::runtime_error{"The second return value for callback 'RegisterULocalPlayerExecPreHook' must return bool or nil"};
+                        }
+                        else
+                        {
+                            return_value.ExecuteOriginalFunction = callback_data.lua.get_bool();
+                        }
+                    }
+
+                    set_is_in_game_thread(callback_data.lua, false);
+
+                    return return_value;
+                }
+
+                return Unreal::Hook::ULocalPlayerExecCallbackReturnValue{};
+            });
+        });
+
+        Unreal::Hook::RegisterULocalPlayerExecPostCallback([](Unreal::ULocalPlayer* context, Unreal::UWorld* in_world, const TCHAR* cmd, Unreal::FOutputDevice& ar) -> Unreal::Hook::ULocalPlayerExecCallbackReturnValue {
+            return TRY([&] {
+                for (const auto& callback_data : m_local_player_exec_post_callbacks)
+                {
+                    set_is_in_game_thread(callback_data.lua, true);
+
+                    Unreal::Hook::ULocalPlayerExecCallbackReturnValue return_value{};
+
+                    for (const auto& registry_index : callback_data.registry_indexes)
+                    {
+                        callback_data.lua.registry().get_function_ref(registry_index);
+
+                        static auto s_object_property_name = Unreal::FName(STR("ObjectProperty"));
+                        LuaType::RemoteUnrealParam::construct(callback_data.lua, &context, s_object_property_name);
+                        LuaType::RemoteUnrealParam::construct(callback_data.lua, &in_world, s_object_property_name);
+                        callback_data.lua.set_string(to_string(cmd));
+                        LuaType::FOutputDevice::construct(callback_data.lua, &ar);
+
+                        callback_data.lua.call_function(4, 2);
+
+                        if (callback_data.lua.is_nil())
+                        {
+                            return_value.UseOriginalReturnValue = true;
+                            callback_data.lua.discard_value();
+                        }
+                        else if (!callback_data.lua.is_bool())
+                        {
+                            throw std::runtime_error{"A callback for 'RegisterULocalPlayerExecPreHook' must return bool or nil"};
+                        }
+                        else
+                        {
+                            return_value.UseOriginalReturnValue = false;
+                            return_value.NewReturnValue = callback_data.lua.get_bool();
+                        }
+
+                        if (callback_data.lua.is_nil())
+                        {
+                            return_value.ExecuteOriginalFunction = true;
+                            callback_data.lua.discard_value();
+                        }
+                        else if (!callback_data.lua.is_bool())
+                        {
+                            throw std::runtime_error{"The second return value for callback 'RegisterULocalPlayerExecPreHook' must return bool or nil"};
+                        }
+                        else
+                        {
+                            return_value.ExecuteOriginalFunction = callback_data.lua.get_bool();
+                        }
+                    }
+
+                    set_is_in_game_thread(callback_data.lua, false);
+
+                    return return_value;
+                }
+
+                return Unreal::Hook::ULocalPlayerExecCallbackReturnValue{};
+            });
+        });
+
+        Unreal::Hook::RegisterCallFunctionByNameWithArgumentsPreCallback([](Unreal::UObject* context, const TCHAR* str, Unreal::FOutputDevice& ar, Unreal::UObject* executor, bool b_force_call_with_non_exec) -> std::pair<bool, bool> {
+            return TRY([&] {
+                for (const auto& callback_data : m_call_function_by_name_with_arguments_pre_callbacks)
+                {
+                    set_is_in_game_thread(callback_data.lua, true);
+
+                    std::pair<bool, bool> return_value{};
+
+                    for (const auto& registry_index : callback_data.registry_indexes)
+                    {
+                        callback_data.lua.registry().get_function_ref(registry_index);
+
+                        static auto s_object_property_name = Unreal::FName(STR("ObjectProperty"));
+                        LuaType::RemoteUnrealParam::construct(callback_data.lua, &context, s_object_property_name);
+                        callback_data.lua.set_string(to_string(str));
+                        LuaType::FOutputDevice::construct(callback_data.lua, &ar);
+                        LuaType::RemoteUnrealParam::construct(callback_data.lua, &executor, s_object_property_name);
+                        callback_data.lua.set_bool(b_force_call_with_non_exec);
+
+                        callback_data.lua.call_function(5, 1);
+
+                        if (callback_data.lua.is_nil())
+                        {
+                            return_value.first = false;
+                            callback_data.lua.discard_value();
+                        }
+                        else if (!callback_data.lua.is_bool())
+                        {
+                            throw std::runtime_error{"A callback for 'RegisterCallFunctionByNameWithArgumentsPreHook' must return bool or nil"};
+                        }
+                        else
+                        {
+                            return_value.first = true;
+                            return_value.second = callback_data.lua.get_bool();
+                        }
+                    }
+
+                    set_is_in_game_thread(callback_data.lua, false);
+
+                    return return_value;
+                }
+
+                return std::pair{false, false};
+            });
+        });
+
+        Unreal::Hook::RegisterCallFunctionByNameWithArgumentsPostCallback([](Unreal::UObject* context, const TCHAR* str, Unreal::FOutputDevice& ar, Unreal::UObject* executor, bool b_force_call_with_non_exec) -> std::pair<bool, bool> {
+            return TRY([&] {
+                for (const auto& callback_data : m_call_function_by_name_with_arguments_post_callbacks)
+                {
+                    set_is_in_game_thread(callback_data.lua, true);
+
+                    std::pair<bool, bool> return_value{};
+
+                    for (const auto& registry_index : callback_data.registry_indexes)
+                    {
+                        callback_data.lua.registry().get_function_ref(registry_index);
+
+                        static auto s_object_property_name = Unreal::FName(STR("ObjectProperty"));
+                        LuaType::RemoteUnrealParam::construct(callback_data.lua, &context, s_object_property_name);
+                        callback_data.lua.set_string(to_string(str));
+                        LuaType::FOutputDevice::construct(callback_data.lua, &ar);
+                        LuaType::RemoteUnrealParam::construct(callback_data.lua, &executor, s_object_property_name);
+                        callback_data.lua.set_bool(b_force_call_with_non_exec);
+
+                        callback_data.lua.call_function(5, 1);
+
+                        if (callback_data.lua.is_nil())
+                        {
+                            return_value.first = false;
+                            callback_data.lua.discard_value();
+                        }
+                        else if (!callback_data.lua.is_bool())
+                        {
+                            throw std::runtime_error{"A callback for 'RegisterCallFunctionByNameWithArgumentsPreHook' must return bool or nil"};
+                        }
+                        else
+                        {
+                            return_value.first = true;
+                            return_value.second = callback_data.lua.get_bool();
+                        }
+                    }
+
+                    set_is_in_game_thread(callback_data.lua, false);
+
+                    return return_value;
+                }
+
+                return std::pair{false, false};
+            });
         });
 
         // Lua from the in-game console.
@@ -2628,6 +3278,117 @@ Overloads:
             }
         });
 
+        // RegisterProcessConsoleExecPreHook
+        Unreal::Hook::RegisterProcessConsoleExecGlobalPreCallback([](Unreal::UObject* context, const TCHAR* cmd, Unreal::FOutputDevice& ar, Unreal::UObject* executor) -> std::pair<bool, bool> {
+            return TRY([&] {
+                auto command = File::StringViewType{cmd};
+                auto command_parts = explode_by_occurrence(cmd, ' ');
+
+                for (const auto& callback_data : m_process_console_exec_pre_callbacks)
+                {
+                    set_is_in_game_thread(callback_data.lua, true);
+
+                    std::pair<bool, bool> return_value{};
+
+                    for (const auto& registry_index : callback_data.registry_indexes)
+                    {
+                        callback_data.lua.registry().get_function_ref(registry_index);
+
+                        static auto s_object_property_name = Unreal::FName(STR("ObjectProperty"));
+                        LuaType::RemoteUnrealParam::construct(callback_data.lua, &context, s_object_property_name);
+                        callback_data.lua.set_string(to_string(command));
+                        auto params_table = callback_data.lua.prepare_new_table();
+                        for (auto i = 1; i < command_parts.size(); ++i)
+                        {
+                            const auto& command_part = command_parts[i];
+                            params_table.add_pair(i, to_string(command_part).c_str());
+                        }
+                        LuaType::FOutputDevice::construct(callback_data.lua, &ar);
+                        LuaType::RemoteUnrealParam::construct(callback_data.lua, &executor, s_object_property_name);
+
+                        callback_data.lua.call_function(5, 1);
+
+                        if (callback_data.lua.is_nil())
+                        {
+                            return_value.first = false;
+                            callback_data.lua.discard_value();
+                        }
+                        else if (callback_data.lua.is_bool())
+                        {
+                            return_value.first = true;
+                            return_value.second = callback_data.lua.get_bool();
+                        }
+                        else
+                        {
+                            throw std::runtime_error{"A callback for 'RegisterProcessConsoleExecHook' must return bool or nil"};
+                        }
+                    }
+
+                    set_is_in_game_thread(callback_data.lua, false);
+
+                    return return_value;
+                }
+
+                return std::pair{false, false};
+            });
+        });
+
+        // RegisterProcessConsoleExecPostHook
+        Unreal::Hook::RegisterProcessConsoleExecGlobalPostCallback([](Unreal::UObject* context, const TCHAR* cmd, Unreal::FOutputDevice& ar, Unreal::UObject* executor) -> std::pair<bool, bool> {
+            return TRY([&] {
+                auto command = File::StringViewType{cmd};
+                auto command_parts = explode_by_occurrence(cmd, ' ');
+
+                for (const auto& callback_data : m_process_console_exec_post_callbacks)
+                {
+                    set_is_in_game_thread(callback_data.lua, true);
+
+                    std::pair<bool, bool> return_value{};
+
+                    for (const auto& registry_index : callback_data.registry_indexes)
+                    {
+                        callback_data.lua.registry().get_function_ref(registry_index);
+
+                        static auto s_object_property_name = Unreal::FName(STR("ObjectProperty"));
+                        LuaType::RemoteUnrealParam::construct(callback_data.lua, &context, s_object_property_name);
+                        callback_data.lua.set_string(to_string(command));
+                        auto params_table = callback_data.lua.prepare_new_table();
+                        for (auto i = 1; i < command_parts.size(); ++i)
+                        {
+                            const auto& command_part = command_parts[i];
+                            params_table.add_pair(i, to_string(command_part).c_str());
+                        }
+                        LuaType::FOutputDevice::construct(callback_data.lua, &ar);
+                        LuaType::RemoteUnrealParam::construct(callback_data.lua, &executor, s_object_property_name);
+
+                        callback_data.lua.call_function(4, 1);
+
+                        if (callback_data.lua.is_nil())
+                        {
+                            return_value.first = false;
+                            callback_data.lua.discard_value();
+                        }
+                        else if (callback_data.lua.is_bool())
+                        {
+                            return_value.first = true;
+                            return_value.second = callback_data.lua.get_bool();
+                        }
+                        else
+                        {
+                            throw std::runtime_error{"A callback for 'RegisterProcessConsoleExecHook' must return bool or nil"};
+                        }
+                    }
+
+                    set_is_in_game_thread(callback_data.lua, false);
+
+                    return return_value;
+                }
+
+                return std::pair{false, false};
+            });
+        });
+
+        // RegisterConsoleCommandHandler
         Unreal::Hook::RegisterProcessConsoleExecCallback([](Unreal::UObject* context, const TCHAR* cmd, Unreal::FOutputDevice& ar, Unreal::UObject* executor) -> bool {
             (void)executor;
 
@@ -2688,6 +3449,7 @@ Overloads:
             });
         });
 
+        // RegisterConsoleCommandGlobalHandler
         Unreal::Hook::RegisterProcessConsoleExecCallback([](Unreal::UObject* context, const TCHAR* cmd, Unreal::FOutputDevice& ar, Unreal::UObject* executor) -> bool {
             (void)context;
             (void)executor;
@@ -2747,6 +3509,17 @@ Overloads:
                 return false;
             });
         });
+
+        if (Unreal::UObject::ProcessLocalScriptFunctionInternal.is_ready() && Unreal::Version::IsAtLeast(4, 22))
+        {
+            Output::send(STR("Enabling custom events\n"));
+            Unreal::Hook::RegisterProcessLocalScriptFunctionPostCallback(hook_for_custom_bp_events);
+        }
+        else if (Unreal::UObject::ProcessInternalInternal.is_ready() && Unreal::Version::IsBelow(4, 22))
+        {
+            Output::send(STR("Enabling custom events\n"));
+            Unreal::Hook::RegisterProcessInternalPostCallback(hook_for_custom_bp_events);
+        }
     }
 
     auto Mod::update() -> void

--- a/src/SettingsManager.cpp
+++ b/src/SettingsManager.cpp
@@ -86,5 +86,14 @@ namespace RC
 
         constexpr static File::CharType section_memory[] = STR("Memory");
         REGISTER_INT64_SETTING(Memory.MaxMemoryUsageDuringAssetLoading, section_memory, MaxMemoryUsageDuringAssetLoading)
+
+        constexpr static File::CharType section_hooks[] = STR("Hooks");
+        REGISTER_BOOL_SETTING(Hooks.HookProcessInternal, section_hooks, HookProcessInternal)
+        REGISTER_BOOL_SETTING(Hooks.HookProcessLocalScriptFunction, section_hooks, HookProcessLocalScriptFunction)
+        REGISTER_BOOL_SETTING(Hooks.HookInitGameState, section_hooks, HookInitGameState)
+        REGISTER_BOOL_SETTING(Hooks.HookCallFunctionByNameWithArguments, section_hooks, HookCallFunctionByNameWithArguments)
+        REGISTER_BOOL_SETTING(Hooks.HookBeginPlay, section_hooks, HookBeginPlay)
+        REGISTER_BOOL_SETTING(Hooks.HookLocalPlayerExec, section_hooks, HookLocalPlayerExec)
+        REGISTER_INT64_SETTING(Hooks.FExecVTableOffsetInLocalPlayer, section_hooks, FExecVTableOffsetInLocalPlayer)
     }
 }


### PR DESCRIPTION
Added the `[Hooks]` section to the UE4SS-settings.ini file.
It has the following settings:
```
HookProcessInternal
HookProcessLocalScriptFunction
HookInitGameState
HookCallFunctionByNameWithArguments
HookBeginPlay
HookLocalPlayerExec
FExecVTableOffsetInLocalPlayer
```

IterateGameDirectories: No longer relies on `UKismetSystemLibrary::GetGameName()`.
This should make it work more consistently.

Added the following global Lua functions:
```
RegisterProcessConsoleExecPreHook
RegisterProcessConsoleExecPostHook
RegisterCallFunctionByNameWithArgumentsPreHook
RegisterCallFunctionByNameWithArgumentsPostHook
RegisterULocalPlayerExecPreHook
RegisterULocalPlayerExecPostHook
```

Added the Lua function `ProcessConsoleExec` to UObject.
Added the Lua functions `GetFunctionFlags` and `SetFunctionFlags` in UFunction.
Added the Lua function `IsChildOf` to UClass.

Fixed a bug when calling a UFunction from Lua.

Various Lua functions that return Unreal objects now automatically return a UFunction if it's appropriate.

No longer crashing when there's a GLFW error.

Fixed compiler warning about struct/class mismatch for `FUObjectItem` in LiveView.hpp.