### PR TITLE
Remove stdin read which blocks until user input on Linux

### DIFF
--- a/src/main_ue4ss_rewritten.cpp
+++ b/src/main_ue4ss_rewritten.cpp
@@ -55,8 +55,6 @@ auto dll_process_attached(HMODULE moduleHandle) -> void
     {
         CloseHandle(handle);
     }
-
-    std::cin.get();
 }
 
 auto WIN_API_FUNCTION_NAME(HMODULE hModule,


### PR DESCRIPTION
It's not clear to me what the purpose of this line is, but on Linux it will cause the game to appear to hang indefinitely without any user input in the console. 