### PR TITLE
Add Lua type definition generator and definitions for UE4SS built-ins

### DIFF
--- a/StagingDev/Mods/shared/Types.lua
+++ b/StagingDev/Mods/shared/Types.lua
@@ -1,0 +1,816 @@
+---@meta
+
+---@enum Key
+Key = {
+    LEFT_MOUSE_BUTTON = 0x1,
+    RIGHT_MOUSE_BUTTON = 0x2,
+    CANCEL = 0x3,
+    MIDDLE_MOUSE_BUTTON = 0x4,
+    XBUTTON_ONE = 0x5,
+    XBUTTON_TWO = 0x6,
+    BACKSPACE = 0x8,
+    TAB = 0x9,
+    CLEAR = 0x0C,
+    RETURN = 0x0D,
+    PAUSE = 0x13,
+    CAPS_LOCK = 0x14,
+    IME_KANA = 0x15,
+    IME_HANGUEL = 0x15,
+    IME_HANGUL = 0x15,
+    IME_ON = 0x16,
+    IME_JUNJA = 0x17,
+    IME_FINAL = 0x18,
+    IME_HANJA = 0x19,
+    IME_KANJI = 0x19,
+    IME_OFF = 0x1A,
+    ESCAPE = 0x1B,
+    IME_CONVERT = 0x1C,
+    IME_NONCONVERT = 0x1D,
+    IME_ACCEPT = 0x1E,
+    IME_MODECHANGE = 0x1F,
+    SPACE = 0x20,
+    PAGE_UP = 0x21,
+    PAGE_DOWN = 0x22,
+    END = 0x23,
+    HOME = 0x24,
+    LEFT_ARROW = 0x25,
+    UP_ARROW = 0x26,
+    RIGHT_ARROW = 0x27,
+    DOWN_ARROW = 0x28,
+    SELECT = 0x29,
+    PRINT = 0x2A,
+    EXECUTE = 0x2B,
+    PRINT_SCREEN = 0x2C,
+    INS = 0x2D,
+    DEL = 0x2E,
+    HELP = 0x2F,
+    ZERO = 0x30,
+    ONE = 0x31,
+    TWO = 0x32,
+    THREE = 0x33,
+    FOUR = 0x34,
+    FIVE = 0x35,
+    SIX = 0x36,
+    SEVEN = 0x37,
+    EIGHT = 0x38,
+    NINE = 0x39,
+    A = 0x41,
+    B = 0x42,
+    C = 0x43,
+    D = 0x44,
+    E = 0x45,
+    F = 0x46,
+    G = 0x47,
+    H = 0x48,
+    I = 0x49,
+    J = 0x4A,
+    K = 0x4B,
+    L = 0x4C,
+    M = 0x4D,
+    N = 0x4E,
+    O = 0x4F,
+    P = 0x50,
+    Q = 0x51,
+    R = 0x52,
+    S = 0x53,
+    T = 0x54,
+    U = 0x55,
+    V = 0x56,
+    W = 0x57,
+    X = 0x58,
+    Y = 0x59,
+    Z = 0x5A,
+    LEFT_WIN = 0x5B,
+    RIGHT_WIN = 0x5C,
+    APPS = 0x5D,
+    SLEEP = 0x5F,
+    NUM_ZERO = 0x69,
+    NUM_ONE = 0x61,
+    NUM_TWO = 0x62,
+    NUM_THREE = 0x63,
+    NUM_FOUR = 0x64,
+    NUM_FIVE = 0x65,
+    NUM_SIX = 0x66,
+    NUM_SEVEN = 0x67,
+    NUM_EIGHT = 0x68,
+    NUM_NINE = 0x69,
+    MULTIPLY = 0x6A,
+    ADD = 0x6B,
+    SEPARATOR = 0x6C,
+    SUBTRACT = 0x6D,
+    DECIMAL = 0x6E,
+    DIVIDE = 0x6F,
+    F1 = 0x70,
+    F2 = 0x71,
+    F3 = 0x72,
+    F4 = 0x73,
+    F5 = 0x74,
+    F6 = 0x75,
+    F7 = 0x76,
+    F8 = 0x77,
+    F9 = 0x78,
+    F10 = 0x79,
+    F11 = 0x7A,
+    F12 = 0x7B,
+    F13 = 0x7C,
+    F14 = 0x7D,
+    F15 = 0x7E,
+    F16 = 0x7F,
+    F17 = 0x80,
+    F18 = 0x81,
+    F19 = 0x82,
+    F20 = 0x83,
+    F21 = 0x84,
+    F22 = 0x85,
+    F23 = 0x86,
+    F24 = 0x87,
+    NUM_LOCK = 0x90,
+    SCROLL_LOCK = 0x91,
+    BROWSER_BACK = 0xA6,
+    BROWSER_FORWARD = 0xA7,
+    BROWSER_REFRESH = 0xA8,
+    BROWSER_STOP = 0xA9,
+    BROWSER_SEARCH = 0xAA,
+    BROWSER_FAVORITES = 0xAB,
+    BROWSER_HOME = 0xAC,
+    VOLUME_MUTE = 0xAD,
+    VOLUME_DOWN = 0xAE,
+    VOLUME_UP = 0xAF,
+    MEDIA_NEXT_TRACK = 0xB0,
+    MEDIA_PREV_TRACK = 0xB1,
+    MEDIA_STOP = 0xB2,
+    MEDIA_PLAY_PAUSE = 0xB3,
+    LAUNCH_MAIL = 0xB4,
+    LAUNCH_MEDIA_SELECT = 0xB5,
+    LAUNCH_APP1 = 0xB6,
+    LAUNCH_APP2 = 0xB7,
+    OEM_ONE = 0xBA,
+    OEM_PLUS = 0xBB,
+    OEM_COMMA = 0xBC,
+    OEM_MINUS = 0xBD,
+    OEM_PERIOD = 0xBE,
+    OEM_TWO = 0xBF,
+    OEM_THREE = 0xC0,
+    OEM_FOUR = 0xDB,
+    OEM_FIVE = 0xDC,
+    OEM_SIX = 0xDD,
+    OEM_SEVEN = 0xDE,
+    OEM_EIGHT = 0xDF,
+    OEM_102 = 0xE2,
+    IME_PROCESS = 0xE5,
+    PACKET = 0xE7,
+    ATTN = 0xF6,
+    CRSEL = 0xF7,
+    EXSEL = 0xF8,
+    EREOF = 0xF9,
+    PLAY = 0xFA,
+    ZOOM = 0xFB,
+    PA1 = 0xFD,
+    OEM_CLEAR = 0xFE,
+}
+
+---@alias PropertyTypes
+---| `PropertyTypes.ObjectProperty`
+---| `PropertyTypes.ObjectPtrProperty`
+---| `PropertyTypes.Int8Property`
+---| `PropertyTypes.Int16Property`
+---| `PropertyTypes.IntProperty`
+---| `PropertyTypes.Int64Property`
+---| `PropertyTypes.NameProperty`
+---| `PropertyTypes.FloatProperty`
+---| `PropertyTypes.StrProperty`
+---| `PropertyTypes.ByteProperty`
+---| `PropertyTypes.UInt16Property`
+---| `PropertyTypes.UIntProperty`
+---| `PropertyTypes.UInt64Property`
+---| `PropertyTypes.BoolProperty`
+---| `PropertyTypes.ArrayProperty`
+---| `PropertyTypes.MapProperty`
+---| `PropertyTypes.StructProperty`
+---| `PropertyTypes.ClassProperty`
+---| `PropertyTypes.WeakObjectProperty`
+---| `PropertyTypes.EnumProperty`
+---| `PropertyTypes.TextProperty`
+PropertyTypes = {}
+
+---@class CustomPropertyInfo
+---@field Name string Name to use with the __index metamethod
+---@field Type PropertyTypes[] PropertyTypes
+---@field BelongsToClass string Full class name without type that this property belongs to
+---@field OffsetInternal OffsetInternalInfo|integer OffsetInternalInfo or integer offset from base to this property
+---@field ArrayPropertyInfo ArrayPropertyInfo?
+
+---@class OffsetInternalInfo
+---@field Property string Name of the property to use as relative start instead of base
+---@field RelativeOffset integer Offset from relative start to this property
+
+---@class ArrayPropertyInfo
+---@field Type PropertyTypes[]
+
+----A table of object flags that can be or'd together by using |.
+---@enum EObjectFlags
+EObjectFlags = {
+    RF_NoFlags                       = 0x00000000,
+    RF_Public                        = 0x00000001,
+    RF_Standalone                    = 0x00000002,
+    RF_MarkAsNative                  = 0x00000004,
+    RF_Transactional                 = 0x00000008,
+    RF_ClassDefaultObject            = 0x00000010,
+    RF_ArchetypeObject               = 0x00000020,
+    RF_Transient                     = 0x00000040,
+    RF_MarkAsRootSet                 = 0x00000080,
+    RF_TagGarbageTemp                = 0x00000100,
+    RF_NeedInitialization            = 0x00000200,
+    RF_NeedLoad                      = 0x00000400,
+    RF_KeepForCooker                 = 0x00000800,
+    RF_NeedPostLoad                  = 0x00001000,
+    RF_NeedPostLoadSubobjects        = 0x00002000,
+    RF_NewerVersionExists            = 0x00004000,
+    RF_BeginDestroyed                = 0x00008000,
+    RF_FinishDestroyed               = 0x00010000,
+    RF_BeingRegenerated              = 0x00020000,
+    RF_DefaultSubObject              = 0x00040000,
+    RF_WasLoaded                     = 0x00080000,
+    RF_TextExportTransient           = 0x00100000,
+    RF_LoadCompleted                 = 0x00200000,
+    RF_InheritableComponentTemplate  = 0x00400000,
+    RF_DuplicateTransient            = 0x00800000,
+    RF_StrongRefOnFrame              = 0x01000000,
+    RF_NonPIEDuplicateTransient      = 0x01000000,
+    RF_Dynamic                       = 0x02000000,
+    RF_WillBeLoaded                  = 0x04000000,
+    RF_HasExternalPackage            = 0x08000000,
+    RF_AllFlags                      = 0x0FFFFFFF,
+}
+
+---@enum ModifierKey
+ModifierKey = {
+    SHIFT = 0x10,
+    CONTROL = 0x11,
+    ALT = 0x12,
+}
+
+
+---A table of internal object flags that can be or'd together by using |.
+---@enum EInternalObjectFlags
+EInternalObjectFlags = {
+    ReachableInCluster               = 0x00800000,
+    ClusterRoot                      = 0x01000000,
+    Native                           = 0x02000000,
+    Async                            = 0x04000000,
+    AsyncLoading                     = 0x08000000,
+    Unreachable                      = 0x10000000,
+    PendingKill                      = 0x20000000,
+    RootSet                          = 0x40000000,
+    GarbageCollectionKeepFlags       = 0x0E000000,
+    AllFlags                         = 0x7F800000,
+}
+
+---@alias int8 number
+---@alias int16 number
+---@alias int32 number
+---@alias int64 number
+---@alias uint8 number
+---@alias uint16 number
+---@alias uint32 number
+---@alias uint64 number
+---@alias float number
+---@alias double number
+
+
+-- # Global Functions
+
+---@param ObjectName string
+---@return UObject
+function StaticFindObject(ObjectName) end
+
+---Maps to https://docs.unrealengine.com/4.26/en-US/API/Runtime/CoreUObject/UObject/StaticFindObject/
+---@param Class UClass?
+---@param InOuter UObject?
+---@param ObjectName string
+---@param ExactClass boolean?
+---@return UObject
+function StaticFindObject(Class, InOuter, ObjectName, ExactClass) end
+
+---Find the first non-default instance of the supplied class name
+---@param ShortClassName string Should only contains the class name itself without path info
+---@return UObject?
+function FindFirstOf(ShortClassName) end
+
+---Find all non-default instances of the supplied class name
+---@param ShortClassName string Should only contains the class name itself without path info
+---@return UObject[]?
+function FindAllOf(ShortClassName) end
+
+--- Registers a callback for a key-bind
+--- Callbacks can only be triggered while the game or debug console is on focus
+---@param Key Key
+---@param Callback fun()
+function RegisterKeyBind(Key, Callback) end
+
+--- Registers a callback for a key-bind
+--- Callbacks can only be triggered while the game or debug console is on focus
+---@param Key Key
+---@param ModifierKeys ModifierKey[]
+---@param Callback fun()
+function RegisterKeyBind(Key, ModifierKeys, Callback) end
+
+---Checks if, at the time of the invocation, the supplied keys have been registered
+---@param Key integer
+function IsKeyBindRegistered(Key) end
+
+---Checks if, at the time of the invocation, the supplied keys have been registered
+---@param Key integer
+---@param ModifierKeys ModifierKey[]
+function IsKeyBindRegistered(Key, ModifierKeys) end
+
+--- Registers a callback for a UFunction
+--- Callbacks are triggered when a UFunction is executed
+--- The callback params are: UObject self, UFunctionParams...
+--- Returns two ids, both of which must be passed to `UnregisterHook` if you want to unregister the hook.
+---@param UFunctionName string
+---@param Callback fun(self: UObject, ...)
+---@return integer PreId
+---@return integer PostId
+function RegisterHook(UFunctionName, Callback) end
+
+---Unregisters a hook.
+---@param UFunctionName string
+---@param PreId integer
+---@param PostId integer
+function UnregisterHook(UFunctionName, PreId, PostId) end
+
+---Execute code inside the game thread using ProcessEvent.
+---Will execute as soon as the game has time to execute.
+---@param Callback fun()
+function ExecuteInGameThread(Callback) end
+
+---Returns the FName for this string/ComparisonIndex or the FName for "None" if the name doesn't exist
+---@param Name string
+---@return FName
+function FName(Name) end
+
+---Returns the FName for this string/ComparisonIndex or the FName for "None" if the name doesn't exist
+---@param ComparisonIndex integer
+---@return FName
+function FName(ComparisonIndex) end
+
+---Attempts to construct a UObject of the passed UClass
+---(>=4.26) Maps to https://docs.unrealengine.com/4.27/en-US/API/Runtime/CoreUObject/UObject/StaticConstructObject_Internal/1/
+---(<4.25) Maps to https://docs.unrealengine.com/4.27/en-US/API/Runtime/CoreUObject/UObject/StaticConstructObject_Internal/2/
+---@param Class UClass
+---@param Outer UObject
+---@param Name FName?
+---@param Flags EObjectFlags?
+---@param InternalSetFlags EInternalObjectFlags?
+---@param CopyTransientsFromClassDefaults boolean?
+---@param AssumeTemplateIsArchetype boolean?
+---@param Template UObject?
+---@param InstanceGraph FObjectInstancingGraph?
+---@param ExternalPackage UPackage?
+---@param SubobjectOverrides any?
+---@return UObject
+function StaticConstructObject(Class, Outer, Name, Flags, InternalSetFlags, CopyTransientsFromClassDefaults, AssumeTemplateIsArchetype, Template, InstanceGraph, ExternalPackage, SubobjectOverrides) end
+
+--- Registers a custom property to be used automatically with `UObject.__index`
+---@param info CustomPropertyInfo
+function RegisterCustomProperty(info) end
+
+---Execute the callback function for each UObject in GUObjectArray
+---The callback params are: UObject object, integer ChunkIndex, integer ObjectIndex
+---@param Callback fun(object: UObject, ChunkIndex: integer, ObjectIndex: integer)
+function ForEachUObject(Callback) end
+
+---Executes the provided Lua function whenever an instance of the provided class is constructed.
+---Inheritance is taken into account, so if you provide "/Script/Engine.Actor" as the class then it will execute your
+---Lua function when any object is constructed that's either an AActor or is derived from AActor.
+---@param UClassName string
+---@param Callback fun()
+function NotifyOnNewObject(UClassName, Callback) end
+
+---Registers a callback that will get called when a BP function/event is called with the name 'EventName'.
+---@param EventName string
+---@param Callback function
+function RegisterCustomEvent(EventName, Callback) end
+
+---Registers a callback that will get called before AGameModeBase::InitGameState is called.
+---The callback params are: AGameModeBase Context
+---Params (except strings & bools & FOutputDevice) must be retrieved via 'Param:Get()' and set via 'Param:Set()'.
+---@param Callback fun(Context: RemoteUnrealParam<AGameModeBase>)
+function RegisterInitGameStatePreHook(Callback) end
+
+---Registers a callback that will get called after AGameModeBase::InitGameState is called.
+---The callback params are: AGameModeBase Context
+---Params (except strings & bools & FOutputDevice) must be retrieved via 'Param:Get()' and set via 'Param:Set()'.
+---@param Callback fun(Context: RemoteUnrealParam<AGameModeBase>)
+function RegisterInitGameStatePostHook(Callback) end
+
+---Registers a callback that will get called before AActor::BeginPlay is called.
+---The callback params are: AActor Context
+---Params (except strings & bools & FOutputDevice) must be retrieved via 'Param:Get()' and set via 'Param:Set()'.
+---@param Callback fun(Context: RemoteUnrealParam<AActor>)
+function RegisterBeginPlayPreHook(Callback) end
+
+---Registers a callback that will get called after AActor::BeginPlay is called.
+---The callback params are: AActor Context
+---Params (except strings & bools & FOutputDevice) must be retrieved via 'Param:Get()' and set via 'Param:Set()'.
+---@param Callback fun(Context: RemoteUnrealParam<AActor>)
+function RegisterBeginPlayPostHook(Callback) end
+
+---Registers a callback that will get called before UObject::ProcessConsoleExec is called.
+---The callback params are: UObject Context, string Cmd, table CommandParts, FOutputDevice Ar, UObject Executor
+---Params (except strings & bools & FOutputDevice) must be retrieved via 'Param:Get()' and set via 'Param:Set()'.
+---If the callback returns nothing (or nil), the original return value of ProcessConsoleExec will be used.
+---If the callback returns true or false, the supplied value will override the original return value of ProcessConsoleExec.
+---@param Callback fun(Context: RemoteUnrealParam<UObject>, Cmd: string, CommandParts: table, Ar: FOutputDevice, Executor: RemoteUnrealParam<UObject>): boolean?
+function RegisterProcessConsoleExecPreHook(Callback) end
+
+---Registers a callback that will get called after UObject::ProcessConsoleExec is called.
+---The callback params are: UObject Context, string Cmd, table CommandParts, FOutputDevice Ar, UObject Executor
+---Params (except strings & bools & FOutputDevice) must be retrieved via 'Param:Get()' and set via 'Param:Set()'.
+---If the callback returns nothing (or nil), the original return value of ProcessConsoleExec will be used.
+---If the callback returns true or false, the supplied value will override the original return value of ProcessConsoleExec.
+---@param Callback fun(Context: RemoteUnrealParam<UObject>, Cmd: string, CommandParts: table, Ar: FOutputDevice, Executor: RemoteUnrealParam<UObject>): boolean?
+function RegisterProcessConsoleExecPostHook(Callback) end
+
+---Registers a callback that will be called before UObject::CallFunctionByNameWithArguments is called.
+---The callback params are: UObject Context, string Str, FOutputDevice Ar, UObject Executor, bool bForceCallWithNonExec
+---Params (except strings & bools & FOutputDevice) must be retrieved via 'Param:Get()' and set via 'Param:Set()'.
+---If the callback returns nothing (or nil), the original return value of CallFunctionByNameWithArguments will be used.
+---If the callback returns true or false, the supplied value will override the original return value of CallFunctionByNameWithArguments.
+---@param Callback fun(Context: RemoteUnrealParam<UObject>, Str: string, Ar: FOutputDevice, Executor: RemoteUnrealParam<UObject>, bForceCallWithNonExec: boolean): boolean?
+function RegisterCallFunctionByNameWithArgumentsPreHook(Callback) end
+
+---Registers a callback that will be called after UObject::CallFunctionByNameWithArguments is called.
+---The callback params are: UObject Context, string Str, FOutputDevice Ar, UObject Executor, bool bForceCallWithNonExec
+---Params (except strings & bools & FOutputDevice) must be retrieved via 'Param:Get()' and set via 'Param:Set()'.
+---If the callback returns nothing (or nil), the original return value of CallFunctionByNameWithArguments will be used.
+---If the callback returns true or false, the supplied value will override the original return value of CallFunctionByNameWithArguments.
+---@param Callback fun(Context: RemoteUnrealParam<UObject>, Str: string, Ar: FOutputDevice, Executor: RemoteUnrealParam<UObject>, bForceCallWithNonExec: boolean): boolean?
+function RegisterCallFunctionByNameWithArgumentsPostHook(Callback) end
+
+---Registers a callback that will be called before ULocalPlayer::Exec is called.
+---The callback params are: ULocalPlayer Context, UWorld InWorld, string Cmd, FOutputDevice Ar
+---Params (except strings & bools & FOutputDevice) must be retrieved via 'Param:Get()' and set via 'Param:Set()'.
+---The callback can have two return values.
+---If the first return value is nothing (or nil), the original return value of Exec will be used.
+---If the first return value is true or false, the supplied value will override the original return value of Exec.
+---The second return value controls whether the original Exec will execute.
+---If the second return value is nil or true, the orginal Exec will execute.
+---If the second return value is false, the original Exec will not execute.
+---@param Callback fun(Context: RemoteUnrealParam<UObject>, Str: string, Ar: FOutputDevice, Executor: UObject, bForceCallWithNonExec: boolean): boolean?, boolean?
+function RegisterULocalPlayerExecPreHook(Callback) end
+
+---Registers a callback that will be called after ULocalPlayer::Exec is called.
+---The callback params are: ULocalPlayer Context, UWorld InWorld, string Cmd, FOutputDevice Ar
+---Params (except strings & bools & FOutputDevice) must be retrieved via 'Param:Get()' and set via 'Param:Set()'.
+---The callback can have two return values.
+---If the first return value is nothing (or nil), the original return value of Exec will be used.
+---If the first return value is true or false, the supplied value will override the original return value of Exec.
+---The second return value controls whether the original Exec will execute.
+---If the second return value is nil or true, the orginal Exec will execute.
+---If the second return value is false, the original Exec will not execute.
+---@param Callback fun(Context: RemoteUnrealParam<UObject>, Str: string, Ar: FOutputDevice, Executor: UObject, bForceCallWithNonExec: boolean): boolean?, boolean?
+function RegisterULocalPlayerExecPostHook(Callback) end
+
+---Registers a callback for a custom console commands.
+---The callback only runs in the context of UGameViewportClient.
+---The callback params are: string Cmd, table CommandParts, FOutputDevice Ar
+---Params (except strings & bools & FOutputDevice) must be retrieved via 'Param:Get()' and set via 'Param:Set()'.
+---The callback must return either true or false.
+---If the callback returns true, no further handlers will be called for this command.
+---@param CommandName string
+---@param Callback fun(Cmd: string, CommandParts: table, Ar: FOutputDevice): boolean?
+function RegisterConsoleCommandHandler(CommandName, Callback) end
+
+---Registers a callback for a custom console command.
+---Unlike 'RegisterConsoleCommandHandler', this global variant runs the callback for all contexts.
+---The callback params are: string Cmd, table CommandParts, FOutputDevice Ar
+---Params (except strings & bools & FOutputDevice) must be retrieved via 'Param:Get()' and set via 'Param:Set()'.
+---The callback must return either true or false.
+---If the callback returns true, no further handlers will be called for this command.
+---@param CommandName string
+---@param Callback fun(Cmd: string, CommandParts: table, Ar: FOutputDevice): boolean?
+function RegisterConsoleCommandGlobalHandler(CommandName, Callback) end
+
+---Asynchronously executes the specified function
+---@param Callback fun()
+function ExecuteAsync(Callback) end
+
+---Asynchronously executes the specified function after the specified delay
+---@param DelayInMilliseconds integer
+---@param Callback fun()
+function ExecuteWithDelay(DelayInMilliseconds, Callback) end
+
+---Loads an asset by name.
+---Must only be called from within the game thread.
+---For example, from within a UFunction hook or RegisterConsoleCommandHandler callback.
+---@param AssetPathAndName string
+function LoadAsset(AssetPathAndName) end
+
+---Finds an object by either class name or short object name.
+---ClassName or ObjectShortName can be nil, but not both.
+---Returns a UObject of a derivative of UObject.
+---@param ClassName (string|FName)?
+---@param ObjectShortName (string|FName)?
+---@param RequiredFlags EObjectFlags
+---@param BannedFlags EObjectFlags
+---@return UObject
+function FindObject(ClassName, ObjectShortName, RequiredFlags, BannedFlags) end
+
+---Finds an object. Works the same way as the function by the same name in the UE source.
+---comment
+---@param InClass UClass
+---@param InOuter UObject
+---@param Name string
+---@param ExactClass boolean
+---@return UObject
+function FindObject(InClass, InOuter, Name, ExactClass) end
+
+---Finds the first specified number of objects by class name or short object name.
+---To find all objects that match your criteria, set NumObjectsToFind to 0 or nil.
+---Returns a table of UObject derivatives
+---@param NumObjectsToFind integer
+---@param ClassName (string|FName)?
+---@param ObjectShortName (string|FName)?
+---@param RequiredFlags EObjectFlags
+---@param BannedFlags EObjectFlags
+---@return UObject[]
+function FindObjects(NumObjectsToFind, ClassName, ObjectShortName, RequiredFlags, BannedFlags, bExactClass) end
+
+---Starts a loop that sleeps for the supplied number of milliseconds and stops when the callback returns true.
+---@param DelayInMilliseconds integer
+---@param Callback fun(): boolean
+function LoopAsync(DelayInMilliseconds, Callback) end
+
+---Returns a table of all game directories.
+---An example of an absolute path to Win64: Q:\SteamLibrary\steamapps\common\Deep Rock Galactic\FSD\Binaries\Win64
+---To get to the same directory, do: IterateGameDirectories().Game.Binaries.Win64
+---Note that the game name is replaced by 'Game' to keep things generic.
+---You can use `.__name` and `.__absolute_path` to retrieve values.
+---You can use `.__files` to retrieve a table containing all files in this directory.
+---You also use `.__name` and `.__absolute_path` for files.
+function IterateGameDirectories() end
+
+
+-- # Classes
+
+---@class UFunction : UObject
+UFunction = {}
+
+---Attempts to call the UFunction
+---@param ... UFunctionParams
+function UFunction:__call(...) end
+
+---Returns the flags for the UFunction.
+---@return integer
+function UFunction:GetFunctionFlags() end
+
+---Sets the flags for the UFuction.
+---@param Flags integer
+function UFunction:SetFunctionFlags(Flags) end
+
+
+---A TArray of characters
+---@class FString
+FString = {}
+
+---Returns a string that Lua can understand
+---@return string
+function FString:ToString() end
+
+---Clears the string by setting the number of elements in the TArray to 0
+function FString:Clear() end
+
+
+---@class FieldClass : LocalObject
+FieldClass = {}
+
+---Returns the FName of this class by copy.
+---@return FName
+function FieldClass:GetFName() end
+
+
+---@class FName
+
+
+---@class FText
+
+
+---@class RemoteObject
+RemoteObject = {}
+
+---Returns whether this object is valid or not
+---@return boolean
+function RemoteObject:IsValid() end
+
+
+---@class Property : RemoteObject
+Property = {}
+---Returns the full name & path for this property.
+---@return string
+function Property:GetFullName() end
+
+---Returns the FName of this property by copy.
+---All FNames returned by `__index` are returned by reference.
+---@return FName
+function Property:GetFName() end
+
+---Returns true if the property is of type PropertyType.
+---@param PropertyType PropertyTypes
+---@return boolean
+function Property:IsA(PropertyType) end
+
+---@return PropertyClass
+function Property:GetClass() end
+
+---Equivalent to FProperty::ContainerPtrToValuePtr<uint8> in UE.
+---@param Container UObjectDerivative
+---@param ArrayIndex integer
+---@return lightuserdata
+function Property:ContainerPtrToValuePtr(Container, ArrayIndex) end
+
+---Equivalent to FProperty::ImportText in UE, except without the 'ErrorText' param.
+---@param Buffer string
+---@param Data lightuserdata
+---@param PortFlags integer
+---@param OwnerObject UObject
+function Property:ImportText(Buffer, Data, PortFlags, OwnerObject) end
+
+
+---@class ObjectProperty : Property
+ObjectProperty = {}
+
+---Returns the class that this property holds.
+---@return UClass
+function GetPropertyClass() end
+
+
+---@class BoolProperty : Property
+
+---@return integer
+function GetByteMask() end
+
+---@return integer
+function GetByteOffset() end
+
+---@return integer
+function GetFieldMask() end
+
+---@return integer
+function GetFieldSize() end
+
+
+---@class StructProperty : Property
+---Returns the UScriptStruct that's mapped to this property.
+---@return UScriptStruct
+function GetStruct() end
+
+
+---@class ArrayProperty : Property
+---Returns the inner property of the array.
+---@return Property
+function GetInner() end
+
+
+---@class UObjectReflection
+UObjectReflection = {}
+
+---Returns a property meta-data object
+---@param PropertyName string
+---@return Property
+function UObjectReflection:GetProperty(PropertyName) end
+
+
+---@class UObject : RemoteObject
+UObject = {}
+
+---Attempts to return either a member variable or a callable UFunction
+---Can return any type, you can use the `type()` function on the returned value to figure out what Lua class it's using (if non-trivial type)
+---@param MemberVariableName string
+---@return any
+function UObject:__index(MemberVariableName) end
+
+---Attempts to set the value of a member variable
+---@param MemberVariableName string
+---@param NewValue any
+function UObject:__newindex(MemberVariableName, NewValue) end
+
+---Returns the full name & path info for a UObject & its derivatives
+---@return string
+function UObject:GetFullName() end
+
+---Returns the FName of this object by copy
+---All FNames returned by `__index` are returned by reference
+---@retur FName
+function UObject:GetFName() end
+
+---Returns the memory address of this object
+---@return integer
+function UObject:GetAddress() end
+
+---Returns the class of this object, this is equivalent to `UObject->ClassPrivate` in Unreal
+---@return UClass
+function UObject:GetClass() end
+
+---Returns the Outer of this object
+---@return UObject
+function UObject:GetOuter() end
+
+---Returns true if this UObject is a UClass or a derivative of UClass
+---@return boolean
+function UObject:IsAnyClass() end
+
+---Returns a reflection object
+---@return UObjectReflection
+function UObject:Reflection() end
+
+---Identical to __index
+---@param MemberVariableName string
+---@return any
+function UObject:GetPropertyValue(MemberVariableName) end
+
+---Identical to __newindex
+---@param MemberVariableName string
+---@param NewValue any
+function UObject:SetPropertyValue(MemberVariableName, NewValue) end
+
+---Returns whether this object is a UClass or UClass derivative
+---@return boolean
+function UObject:IsClass() end
+
+---Returns the UWorld that this UObject is contained within.
+---@return UWorld
+function UObject:GetWorld() end
+
+---Calls the supplied UFunction on this UObject.
+---@param func UFunction
+---@param ... any[]
+function UObject:CallFunction(func, ...) end
+
+---Returns whether this object is of the specified class.
+---@param Class UClass
+---@return boolean
+function UObject:IsA(Class) end
+
+---Returns whether this object is of the specified class.
+---@param FullClassName string
+---@return boolean
+function UObject:IsA(FullClassName) end
+
+---Returns whether the object has all of the specified flags.
+---@param FlagsToCheck EObjectFlags
+---@return boolean
+function UObject:HasAllFlags(FlagsToCheck) end
+
+---Returns whether the object has any of the specified flags.
+---@param FlagsToCheck EObjectFlags
+---@return boolean
+function UObject:HasAnyFlags(FlagsToCheck) end
+
+---Return whether the object has any of the specified internal flags.
+---@param InternalFlagsToCheck EInternalObjectFlags
+---@return boolean
+function UObject:HasAnyInternalFlags(InternalFlagsToCheck) end
+
+---Calls UObject::ProcessConsoleExec with the supplied params.
+---@param Cmd string
+---@param Reserved nil
+---@param Executor UObject
+function UObject:ProcessConsoleExec(Cmd, Reserved, Executor) end
+
+---Returns the type of this object as known by UE4SS
+---This does not return the type as known by Unreal
+---@return string
+function UObject:type() end
+
+---@class TArray<T> : { [integer]: T }
+TArray = {}
+
+
+---This is a dynamic wrapper for any and all types & classes
+---Whether the Remote or Local variant is used depends on the requirements of the data but the usage is identical with either param types
+---@generic T
+---@class RemoteUnrealParam<T> : RemoteObject<T>
+RemoteUnrealParam = {}
+
+---Returns the underlying value for this param
+---@generic T
+---@param self RemoteUnrealParam<T>
+---@return T
+function RemoteUnrealParam:get() end
+
+---Sets the underlying value for this param
+---@generic T
+---@param self RemoteUnrealParam<T>
+---@param NewValue T
+function RemoteUnrealParam:set(NewValue) end
+
+---Returns "RemoteUnrealParam"
+---@return 'RemoteUnrealParam'
+function RemoteUnrealParam:type() end
+
+
+---@class TSoftClassPtr<T> : string
+---@class TSoftObjectPtr<T> : string
+---@class TSubclassOf<T> : UClass

--- a/StagingDev/Mods/shared/Types.lua
+++ b/StagingDev/Mods/shared/Types.lua
@@ -787,6 +787,12 @@ function UObject:type() end
 ---@class TArray<T> : { [integer]: T }
 TArray = {}
 
+---@class TSet<K> : { [K]: nil }
+
+---@class TMap<K, V> : { [K]: V }
+
+---@class TScriptInterface<K>
+
 
 ---This is a dynamic wrapper for any and all types & classes
 ---Whether the Remote or Local variant is used depends on the requirements of the data but the usage is identical with either param types

--- a/include/SDKGenerator/Common.hpp
+++ b/include/SDKGenerator/Common.hpp
@@ -32,6 +32,7 @@ namespace RC
         auto is_integral_type(Unreal::FProperty* property) -> bool;
         auto get_native_enum_name(Unreal::UEnum* uenum, bool include_type = true) -> File::StringType;
         auto generate_property_cxx_name(Unreal::FProperty* property, bool is_top_level_declaration, Unreal::UObject* class_context, EnableForwardDeclarations = EnableForwardDeclarations::No) -> File::StringType;
+        auto generate_property_lua_name(Unreal::FProperty* property, bool is_top_level_declaration, Unreal::UObject* class_context) -> File::StringType;
         auto sanitize_property_name(const File::StringType& property_name) -> File::StringType;
         auto generate_delegate_name(Unreal::FProperty* property, const File::StringType& context_name) -> File::StringType;
         auto get_native_class_name(Unreal::UClass* uclass, bool interface_name = false) -> File::StringType;

--- a/include/SDKGenerator/Generator.hpp
+++ b/include/SDKGenerator/Generator.hpp
@@ -26,83 +26,8 @@ namespace RC::UEGenerator
         No,
     };
 
-    class CXXGenerator
-    {
-    private:
-        const std::filesystem::path m_directory_to_generate_in;
-
-    public:
-        struct ObjectInfo
-        {
-            Unreal::UObject* object{};
-            ObjectInfo* first_encountered_at{};
-        };
-
-        struct PropertyInfo
-        {
-            Unreal::FProperty* property{};
-            bool should_forward_declare{};
-        };
-
-        struct FunctionInfo
-        {
-            Unreal::UFunction* function{};
-            ObjectInfo& owner;
-            std::vector<PropertyInfo> params{};
-        };
-
-        struct GeneratedFile
-        {
-            std::filesystem::path primary_file_name;
-            std::filesystem::path secondary_file_name;
-            std::vector<File::StringType> ordered_primary_file_contents;
-            std::vector<File::StringType> ordered_secondary_file_contents;
-            File::StringType package_name;
-            File::Handle primary_file;
-            File::Handle secondary_file;
-            bool primary_file_has_no_contents;
-            bool secondary_file_has_no_contents;
-        };
-
-        struct FileName
-        {
-            uint32_t num_collisions{};
-        };
-
-        // Map of FName.ComparisonIndex -> File::Handle
-        std::unordered_map<Unreal::FName, GeneratedFile> m_files{};
-        std::unordered_map<File::StringType, FileName> m_file_names{};
-        std::unordered_map<Unreal::UObject*, ObjectInfo> m_classes_dumped{};
-
-    public:
-        CXXGenerator() = delete;
-        CXXGenerator(const std::filesystem::path directory_to_generate_in);
-
-    private:
-        auto create_all_files() -> void;
-        auto object_is_package(Unreal::UObject* object) -> bool;
-
-        auto generate_offset_comment(Unreal::FProperty*, File::StringType& file_contents) -> File::StringType;
-        auto generate_header_start(GeneratedFile& generated_file, File::StringViewType file_name) -> void;
-        auto generate_header_end(GeneratedFile& generated_file) -> void;
-        auto generate_tab(size_t num_tabs = 1) -> File::StringType;
-        auto make_function_info(ObjectInfo& owner, Unreal::UFunction* function, File::StringType& current_class_content) -> FunctionInfo;
-        auto generate_function_declaration(ObjectInfo&, const FunctionInfo&, GeneratedFile&, File::StringType& current_class_content, IsDelegateFunction = IsDelegateFunction::No) -> void;
-        auto generate_prefix(Unreal::UStruct* obj_class) -> File::StringType;
-        auto generate_class_dependency(ObjectInfo& owner, Unreal::UStruct* native_class, File::StringType& current_class_content) -> void;
-        auto generate_class_dependency_from_property(ObjectInfo& owner, Unreal::FProperty* property, File::StringType& current_class_content) -> bool;
-        auto generate_class(ObjectInfo object_info, GeneratedFile& generated_file, File::StringType& current_class_content) -> Unreal::FProperty*;
-        auto generate_enum(Unreal::UObject* native_object, GeneratedFile& generated_file) -> void;
-        auto generate_package(Unreal::UObject* package, File::StringType& out) -> void;
-        auto generate_package_if_non_existent(Unreal::UObject* object) -> GeneratedFile*;
-        auto cleanup_old_sdk() -> void;
-        auto sort_files(std::vector<File::StringType>& content) -> void;
-        auto sort_types(std::vector<File::StringType>& content) -> void;
-        auto get_class_name(const auto& x) -> std::wstring;
-
-    public:
-        auto generate() -> void;
-    };
+    auto generate_cxx_headers(const std::filesystem::path directory_to_generate_in) -> void;
+    auto generate_lua_types(const std::filesystem::path directory_to_generate_in) -> void;
 }
 
 

--- a/include/UE4SSProgram.hpp
+++ b/include/UE4SSProgram.hpp
@@ -153,6 +153,7 @@ namespace RC
         RC_UE4SS_API auto get_mods_directory() -> File::StringViewType;
         RC_UE4SS_API auto generate_uht_compatible_headers() -> void;
         RC_UE4SS_API auto generate_cxx_headers(const std::filesystem::path& output_dir) -> void;
+        RC_UE4SS_API auto generate_lua_types(const std::filesystem::path& output_dir) -> void;
         auto get_debugging_ui() -> GUI::DebuggingGUI&
         {
             return m_debugging_gui;

--- a/src/GUI/Dumpers.cpp
+++ b/src/GUI/Dumpers.cpp
@@ -335,19 +335,22 @@ namespace RC::GUI::Dumpers
             UEGenerator::TMapOverrideGenerator::generate_tmapoverride();
         }
 
-	    if (ImGui::Button("Generate UHT Compatible Headers\n"))
-	    {
-	        UE4SSProgram::get_program().generate_uht_compatible_headers();
-	    }
+        if (ImGui::Button("Generate UHT Compatible Headers\n"))
+        {
+            UE4SSProgram::get_program().generate_uht_compatible_headers();
+        }
 
-	    if (ImGui::Button("Dump CXX Headers\n"))
-	    {
-	        File::StringType working_dir{UE4SSProgram::get_program().get_working_directory()};
-	        UE4SSProgram::get_program().generate_cxx_headers(working_dir + STR("\\CXXHeaderDump"));
-	    }
+        if (ImGui::Button("Dump CXX Headers\n"))
+        {
+            File::StringType working_dir{UE4SSProgram::get_program().get_working_directory()};
+            UE4SSProgram::get_program().generate_cxx_headers(working_dir + STR("\\CXXHeaderDump"));
+        }
 
-	    
-	    
+        if (ImGui::Button("Generate Lua Types\n"))
+        {
+            File::StringType working_dir{UE4SSProgram::get_program().get_working_directory()};
+            UE4SSProgram::get_program().generate_lua_types(working_dir + STR("\\Mods\\shared\\types"));
+        }
     }
 }
 

--- a/src/SDKGenerator/Common.cpp
+++ b/src/SDKGenerator/Common.cpp
@@ -502,6 +502,314 @@ namespace RC::UEGenerator
         throw std::runtime_error(RC::fmt("Unsupported property class %S", field_class_name.c_str()));
     }
 
+    auto generate_property_lua_name(FProperty* property, bool is_top_level_declaration, UObject* class_context) -> File::StringType
+    {
+        const std::wstring field_class_name = property->GetClass().GetName();
+
+        //Byte Property
+        if (field_class_name == STR("ByteProperty"))
+        {
+            FByteProperty* byte_property = static_cast<FByteProperty*>(property);
+            UEnum* enum_value = byte_property->GetEnum();
+
+            if (enum_value != NULL)
+            {
+                //Non-EnumClass enumerations should be wrapped into TEnumAsByte according to UHT
+                const std::wstring enum_type_name = get_native_enum_name(enum_value);
+                return fmt::format(STR("{}"), enum_type_name);
+            }
+            return STR("uint8");
+        }
+
+        //Enum Property
+        if (field_class_name == STR("EnumProperty"))
+        {
+            FEnumProperty* enum_property = static_cast<FEnumProperty*>(property);
+            UEnum* uenum = enum_property->GetEnum();
+
+            if (uenum == NULL)
+            {
+                throw std::runtime_error(RC::fmt("EnumProperty %S does not have a valid Enum value", property->GetName().c_str()));
+            }
+
+            const std::wstring enum_type_name = get_native_enum_name(uenum);
+            return enum_type_name;
+        }
+
+        //Bool Property
+        if (field_class_name == STR("BoolProperty"))
+        {
+            return STR("boolean");
+        }
+
+        //Standard Numeric Properties
+        if (field_class_name == STR("Int8Property"))
+        {
+            return STR("int8");
+        }
+        else if (field_class_name == STR("Int16Property"))
+        {
+            return STR("int16");
+        }
+        else if (field_class_name == STR("IntProperty"))
+        {
+            return STR("int32");
+        }
+        else if (field_class_name == STR("Int64Property"))
+        {
+            return STR("int64");
+        }
+        else if (field_class_name == STR("UInt16Property"))
+        {
+            return STR("uint16");
+        }
+        else if (field_class_name == STR("UInt32Property"))
+        {
+            return STR("uint32");
+        }
+        else if (field_class_name == STR("UInt64Property"))
+        {
+            return STR("uint64");
+        }
+        else if (field_class_name == STR("FloatProperty"))
+        {
+            return STR("float");
+        }
+        else if (field_class_name == STR("DoubleProperty"))
+        {
+            return STR("double");
+        }
+
+        //Object Properties
+        // TODO: Verify that the syntax for 'AssetObjectProperty' is the same as for 'ObjectProperty'.
+        //       If it's not, then add another branch here after you figure out what the syntax should be.
+        if (field_class_name == STR("ObjectProperty") || field_class_name == STR("AssetObjectProperty"))
+        {
+            FObjectProperty* object_property = static_cast<FObjectProperty*>(property);
+            UClass* property_class = object_property->GetPropertyClass();
+
+            if (property_class == NULL)
+            {
+                return STR("UObject");
+            }
+
+            const std::wstring property_class_name = get_native_class_name(property_class, false);
+            return fmt::format(STR("{}"), property_class_name);
+        }
+
+        if (auto* object_property = CastField<FObjectPtrProperty>(property); object_property)
+        {
+            auto* property_class = object_property->GetPropertyClass();
+
+            if (!property_class)
+            {
+                return STR("TObjectPtr<UObject>");
+            }
+            else
+            {
+                const auto property_class_name = get_native_class_name(property_class, false);
+                return std::format(STR("TObjectPtr<{}>"), property_class_name);
+            }
+        }
+
+        if (field_class_name == STR("WeakObjectProperty"))
+        {
+            FWeakObjectProperty* weak_object_property = static_cast<FWeakObjectProperty*>(property);
+            UClass* property_class = weak_object_property->GetPropertyClass();
+
+            if (property_class == NULL)
+            {
+                return STR("TWeakObjectPtr<UObject>");
+            }
+
+            File::StringType property_class_name{};
+            property_class_name.append(get_native_class_name(property_class, false));
+            return fmt::format(STR("TWeakObjectPtr<{}>"), property_class_name);
+        }
+
+        if (field_class_name == STR("LazyObjectProperty"))
+        {
+            FLazyObjectProperty* lazy_object_property = static_cast<FLazyObjectProperty*>(property);
+            UClass* property_class = lazy_object_property->GetPropertyClass();
+
+            if (property_class == NULL)
+            {
+                return STR("TLazyObjectPtr<UObject>");
+            }
+
+            File::StringType property_class_name{};
+            property_class_name.append(get_native_class_name(property_class, false));
+            return fmt::format(STR("TLazyObjectPtr<{}>"), property_class_name);
+        }
+
+        if (field_class_name == STR("SoftObjectProperty"))
+        {
+            FSoftObjectProperty* soft_object_property = static_cast<FSoftObjectProperty*>(property);
+            UClass* property_class = soft_object_property->GetPropertyClass();
+
+            if (property_class == NULL)
+            {
+                return STR("TSoftObjectPtr<UObject>");
+            }
+
+            const std::wstring property_class_name = get_native_class_name(property_class, false);
+            return fmt::format(STR("TSoftObjectPtr<{}>"), property_class_name);
+        }
+
+        //Class Properties
+        if (field_class_name == STR("ClassProperty") || field_class_name == STR("AssetClassProperty"))
+        {
+            FClassProperty* class_property = static_cast<FClassProperty*>(property);
+            UClass* meta_class = class_property->GetMetaClass();
+
+            if (meta_class == NULL || meta_class == UObject::StaticClass())
+            {
+                return STR("UClass");
+            }
+
+            File::StringType meta_class_name{};
+            meta_class_name.append(get_native_class_name(meta_class, false));
+            return fmt::format(STR("TSubclassOf<{}>"), meta_class_name);
+        }
+
+        if (auto* class_property = CastField<FClassPtrProperty>(property); class_property)
+        {
+            // TODO: Confirm that this is accurate
+            return STR("TObjectPtr<UClass>");
+        }
+
+        if (field_class_name == STR("SoftClassProperty"))
+        {
+            FSoftClassProperty* soft_class_property = static_cast<FSoftClassProperty*>(property);
+            UClass* meta_class = soft_class_property->GetMetaClass();
+
+            if (meta_class == NULL || meta_class == UObject::StaticClass())
+            {
+                return STR("TSoftClassPtr<UObject>");
+            }
+
+            const std::wstring meta_class_name = get_native_class_name(meta_class, false);
+            return fmt::format(STR("TSoftClassPtr<{}>"), meta_class_name);
+        }
+
+        //Interface Property
+        if (field_class_name == STR("InterfaceProperty"))
+        {
+            FInterfaceProperty* interface_property = static_cast<FInterfaceProperty*>(property);
+            UClass* interface_class = interface_property->GetInterfaceClass();
+
+            if (interface_class == NULL || interface_class == UInterface::StaticClass())
+            {
+                return STR("FScriptInterface");
+            }
+
+            File::StringType interface_class_name{};
+            interface_class_name.append(get_native_class_name(interface_class, true));
+            return fmt::format(STR("TScriptInterface<{}>"), interface_class_name);
+        }
+
+        //Struct Property
+        if (field_class_name == STR("StructProperty"))
+        {
+            FStructProperty* struct_property = static_cast<FStructProperty*>(property);
+            UScriptStruct* script_struct = struct_property->GetStruct();
+
+            if (script_struct == NULL)
+            {
+                throw std::runtime_error(RC::fmt("Struct is NULL for StructProperty %S", property->GetName().c_str()));
+            }
+
+            const std::wstring native_struct_name = get_native_struct_name(script_struct);
+            return native_struct_name;
+        }
+
+        //Delegate Properties
+        if (field_class_name == STR("DelegateProperty"))
+        {
+            FDelegateProperty* delegate_property = static_cast<FDelegateProperty*>(property);
+
+            const std::wstring delegate_type_name = generate_delegate_name(delegate_property, class_context->GetName());
+            return delegate_type_name;
+        }
+
+        // In 4.23, they replaced 'MulticastDelegateProperty' with 'Inline' & 'Sparse' variants
+        // It looks like the delegate macro might be the same as the 'Inline' variant in later versions, so we'll use the same branch here
+        if (field_class_name == STR("MulticastInlineDelegateProperty") || field_class_name == STR("MulticastDelegateProperty"))
+        {
+            FMulticastInlineDelegateProperty* delegate_property = static_cast<FMulticastInlineDelegateProperty*>(property);
+
+            const std::wstring delegate_type_name = generate_delegate_name(delegate_property, class_context->GetName());
+            return delegate_type_name;
+        }
+
+        if (field_class_name == STR("MulticastSparseDelegateProperty"))
+        {
+            FMulticastSparseDelegateProperty* delegate_property = static_cast<FMulticastSparseDelegateProperty*>(property);
+
+            const std::wstring delegate_type_name = generate_delegate_name(delegate_property, class_context->GetName());
+            return delegate_type_name;
+        }
+
+        //Field path property
+        if (field_class_name == STR("FieldPathProperty"))
+        {
+            FFieldPathProperty* field_path_property = static_cast<FFieldPathProperty*>(property);
+            const std::wstring property_class_name = field_path_property->GetPropertyClass()->GetName();
+            return fmt::format(STR("TFieldPath<F{}>"), property_class_name);
+        }
+
+        //Collection and Map Properties
+        // TODO: This is missing support for freeze image array properties because XArrayProperty is incomplete. (low priority)
+        if (field_class_name == STR("ArrayProperty"))
+        {
+            FArrayProperty* array_property = static_cast<FArrayProperty*>(property);
+            FProperty* inner_property = array_property->GetInner();
+
+            File::StringType inner_property_type{};
+            inner_property_type.append(generate_property_lua_name(inner_property, is_top_level_declaration, class_context));
+            return fmt::format(STR("TArray<{}>"), inner_property_type);
+        }
+
+        if (field_class_name == STR("SetProperty"))
+        {
+            FSetProperty* set_property = static_cast<FSetProperty*>(property);
+            FProperty* element_prop = set_property->GetElementProp();
+
+            const std::wstring element_property_type = generate_property_cxx_name(element_prop, is_top_level_declaration, class_context);
+            return fmt::format(STR("TSet<{}>"), element_property_type);
+        }
+
+        // TODO: This is missing support for freeze image map properties because XMapProperty is incomplete. (low priority)
+        if (field_class_name == STR("MapProperty"))
+        {
+            FMapProperty* map_property = static_cast<FMapProperty*>(property);
+            FProperty* key_property = map_property->GetKeyProp();
+            FProperty* value_property = map_property->GetValueProp();
+
+            File::StringType key_type{};
+            File::StringType value_type{};
+            key_type.append(generate_property_cxx_name(key_property, is_top_level_declaration, class_context));
+            value_type.append(generate_property_cxx_name(value_property, is_top_level_declaration, class_context));
+
+            return fmt::format(STR("TMap<{}, {}>"), key_type, value_type);
+        }
+
+        //Standard properties that do not have any special attributes
+        if (field_class_name == STR("NameProperty"))
+        {
+            return STR("FName");
+        }
+        else if (field_class_name == STR("StrProperty"))
+        {
+            return STR("FString");
+        }
+        else if (field_class_name == STR("TextProperty"))
+        {
+            return STR("FText");
+        }
+        throw std::runtime_error(RC::fmt("Unsupported property class %S", field_class_name.c_str()));
+    }
+
     auto get_native_delegate_type_name(Unreal::UFunction* signature_function, Unreal::UClass* current_class, bool strip_outer_name) -> File::StringType {
         if (!is_delegate_signature_function(signature_function)) {
            throw std::runtime_error(RC::fmt("Function %S is not a delegate signature function", signature_function->GetName().c_str()));

--- a/src/SDKGenerator/Common.cpp
+++ b/src/SDKGenerator/Common.cpp
@@ -775,7 +775,7 @@ namespace RC::UEGenerator
             FSetProperty* set_property = static_cast<FSetProperty*>(property);
             FProperty* element_prop = set_property->GetElementProp();
 
-            const std::wstring element_property_type = generate_property_cxx_name(element_prop, is_top_level_declaration, class_context);
+            const std::wstring element_property_type = generate_property_lua_name(element_prop, is_top_level_declaration, class_context);
             return fmt::format(STR("TSet<{}>"), element_property_type);
         }
 
@@ -788,8 +788,8 @@ namespace RC::UEGenerator
 
             File::StringType key_type{};
             File::StringType value_type{};
-            key_type.append(generate_property_cxx_name(key_property, is_top_level_declaration, class_context));
-            value_type.append(generate_property_cxx_name(value_property, is_top_level_declaration, class_context));
+            key_type.append(generate_property_lua_name(key_property, is_top_level_declaration, class_context));
+            value_type.append(generate_property_lua_name(value_property, is_top_level_declaration, class_context));
 
             return fmt::format(STR("TMap<{}, {}>"), key_type, value_type);
         }

--- a/src/SDKGenerator/Generator.cpp
+++ b/src/SDKGenerator/Generator.cpp
@@ -46,309 +46,49 @@ namespace RC::UEGenerator
     using FMulticastInlineDelegateProperty = RC::Unreal::FMulticastInlineDelegateProperty;
     using FMulticastSparseDelegateProperty = RC::Unreal::FMulticastSparseDelegateProperty;
 
-    CXXGenerator::CXXGenerator(const std::filesystem::path directory_to_generate_in) : m_directory_to_generate_in(directory_to_generate_in)
+    struct ObjectInfo
     {
-        m_files.reserve(512);
-    }
+        Unreal::UObject* object{};
+        ObjectInfo* first_encountered_at{};
+    };
 
-    auto CXXGenerator::create_all_files() -> void
+    struct PropertyInfo
     {
-        Output::send(STR("Creating all files...\n"));
-        for (auto&[comparison_index, generated_file] : m_files)
-        {
-            if (!generated_file.ordered_primary_file_contents.empty())
-            {
-                generated_file.primary_file = File::open(generated_file.primary_file_name, File::OpenFor::Appending, File::OverwriteExistingFile::Yes, File::CreateIfNonExistent::Yes);
-                generate_header_start(generated_file, generated_file.package_name);
+        Unreal::FProperty* property{};
+        bool should_forward_declare{};
+    };
 
-                sort_files(generated_file.ordered_primary_file_contents);
-
-                File::StringType combined_file_contents;
-                for (auto& line : generated_file.ordered_primary_file_contents)
-                {
-                    combined_file_contents.append(line);
-                }
-
-                if (combined_file_contents.empty())
-                {
-                    Output::send(STR("Empty primary file contents in '{}'\n"), generated_file.package_name);
-                }
-                else
-                {
-                    generated_file.primary_file.write_string_to_file(combined_file_contents);
-                }
-
-                generate_header_end(generated_file);
-                generated_file.primary_file.close();
-            }
-
-            if (!generated_file.ordered_secondary_file_contents.empty())
-            {
-                generated_file.secondary_file = File::open(generated_file.secondary_file_name, File::OpenFor::Appending, File::OverwriteExistingFile::Yes, File::CreateIfNonExistent::Yes);
-
-                sort_files(generated_file.ordered_secondary_file_contents);
-
-                File::StringType combined_file_contents;
-                for (auto& line : generated_file.ordered_secondary_file_contents)
-                {
-                    combined_file_contents.append(line);
-                }
-
-                if (combined_file_contents.empty())
-                {
-                    Output::send(STR("Empty secondary file contents in '{}'\n"), generated_file.package_name);
-                }
-                else
-                {
-                    generated_file.secondary_file.write_string_to_file(combined_file_contents);
-                }
-
-                generated_file.secondary_file.close();
-            }
-        }
-    }
-
-    auto CXXGenerator::sort_files(std::vector<File::StringType>& content) -> void
+    struct FunctionInfo
     {
-        std::vector<File::StringType> struct_content;
-        std::vector<File::StringType> class_content;
-        std::vector<File::StringType> other_content;
-        for (auto& line : content)
-        {
-            if (line.starts_with(STR("struct")))
-            {
-                struct_content.push_back(line);
-            }
-            else if (line.starts_with(STR("class")))
-            {
-                class_content.push_back(line);
-            }
-            else
-            {
-                other_content.push_back(line);
-            }
-        }
-        
-        sort_types(struct_content);
-        sort_types(class_content);
-        sort_types(other_content);
+        Unreal::UFunction* function{};
+        ObjectInfo& owner;
+        std::vector<PropertyInfo> params{};
+    };
 
-        content.clear();
-        content.reserve(struct_content.size() + class_content.size() + other_content.size());
-        content.insert(content.end(), struct_content.begin(), struct_content.end());
-        content.insert(content.end(), class_content.begin(), class_content.end());
-        content.insert(content.end(), other_content.begin(), other_content.end());
-    }
-
-    auto CXXGenerator::sort_types(std::vector<File::StringType>& content) -> void
+    struct GeneratedFile
     {
-        std::sort(content.begin(), content.end(), [&](const auto& a, const auto& b) {
-            auto a_class_name = get_class_name(a);
-            auto b_class_name = get_class_name(b);
-            return a_class_name < b_class_name;
-        });
-    }
+        std::filesystem::path primary_file_name;
+        std::filesystem::path secondary_file_name;
+        std::vector<File::StringType> ordered_primary_file_contents;
+        std::vector<File::StringType> ordered_secondary_file_contents;
+        File::StringType package_name;
+        File::Handle primary_file;
+        File::Handle secondary_file;
+        bool primary_file_has_no_contents;
+        bool secondary_file_has_no_contents;
+    };
 
-    auto CXXGenerator::get_class_name(const auto& x) -> std::wstring
-    {
-        // Using this method instead of regex because it is extremely slow
-        auto class_name = x.substr(x.find(STR(' ')) + 1);
-        class_name = class_name.substr(0, class_name.find(STR(' ')));
-        if (class_name == STR("class"))
-        {
-            // Case for enum class
-            class_name = x.substr(x.find(STR(' ')) + 7);
-            class_name = class_name.substr(0, class_name.find(STR(' ')));
-        }
-        return class_name;
-    }
-
-    auto CXXGenerator::object_is_package(UObject* object) -> bool
-    {
-        return object->GetClassPrivate()->GetNamePrivate().Equals(Unreal::GPackageName);
-    }
-
-    auto CXXGenerator::generate_offset_comment(XProperty* property, File::StringType& line) -> File::StringType
-    {
-        if (UE4SSProgram::settings_manager.CXXHeaderGenerator.DumpOffsetsAndSizes)
-        {
-            return std::format(STR("{:85} // 0x{:04X} (size: 0x{:X})"), line, property->GetOffset_Internal(), property->GetSize());
-        }
-        else
-        {
-            return line;
-        }
-    }
-
-    auto CXXGenerator::generate_header_start(GeneratedFile& generated_file, File::StringViewType file_name) -> void
-    {
-        generated_file.primary_file.write_string_to_file(std::format(STR("#ifndef UE4SS_SDK_{}_HPP\n#define UE4SS_SDK_{}_HPP\n\n"), file_name, file_name));
-
-        if (!generated_file.secondary_file_has_no_contents)
-        {
-            generated_file.primary_file.write_string_to_file(std::format(STR("#include \"{}\"\n\n"), generated_file.secondary_file_name.filename().c_str()));
-        }
-    }
-
-    auto CXXGenerator::generate_header_end(GeneratedFile& generated_file) -> void
-    {
-        generated_file.primary_file.write_string_to_file(std::format(STR("#endif\n")));
-    }
-
-    auto CXXGenerator::generate_tab(size_t num_tabs) -> File::StringType
+    auto generate_tab(size_t num_tabs = 1) -> File::StringType
     {
         File::StringType tab_storage{};
         for (size_t i = 0; i < num_tabs; ++i)
         {
-            for (int space = 0; space < 4; ++space)
-            {
-                tab_storage += STR(" ");
-            }
+            tab_storage += STR("    ");
         }
 
         return tab_storage;
     }
-
-    auto CXXGenerator::generate_function_declaration(ObjectInfo& owner, const FunctionInfo& function_info, GeneratedFile& generated_file, File::StringType& out_current_class_content, IsDelegateFunction is_delegate_function) -> void
-    {
-        std::optional<PropertyInfo> return_property_info = [&]() -> std::optional<PropertyInfo> {
-            for (const auto& property_info : function_info.params)
-            {
-                if (property_info.property->HasAnyPropertyFlags(Unreal::CPF_ReturnParm))
-                {
-                    return property_info;
-                }
-            }
-
-            return {};
-        }();
-
-        XProperty* return_property = [&]() {
-            return return_property_info.has_value() ? return_property_info.value().property : nullptr;
-        }();
-
-        File::StringType function_name{function_info.function->GetName()};
-        if (is_delegate_function == IsDelegateFunction::Yes)
-        {
-            // Remove the last 19 characters, which is always '__DelegateSignature' for delegates
-            function_name.erase(function_name.size() - 19, 19);
-        }
-
-        File::StringType function_type_name{};
-        if (return_property)
-        {
-            try
-            {
-                function_type_name = generate_property_cxx_name(return_property, true, function_info.function, EnableForwardDeclarations::Yes);
-            }
-            catch (std::exception& e)
-            {
-                Output::send<LogLevel::Warning>(STR("Could not generate function '{}' because: {}\n"), function_info.function->GetFullName(), to_wstring(e.what()));
-                return;
-            }
-
-            if (return_property_info.value().should_forward_declare)
-            {
-                bool ignore_forward_declare{};
-                if (return_property->IsA<FStructProperty>())
-                {
-                    // Can StructProperty even be forward declared ? I don't know if it's ever a pointer to a struct
-                    auto* script_struct = static_cast<FStructProperty*>(return_property)->GetStruct();
-                    if (m_classes_dumped.contains(script_struct))
-                    {
-                        auto& property_class_info = m_classes_dumped[script_struct];
-                        if (property_class_info.first_encountered_at)
-                        {
-                            ignore_forward_declare = property_class_info.first_encountered_at->object == owner.object;
-                        }
-                    }
-                }
-                else if (return_property->IsA<FClassProperty>())
-                {
-                    // Can ClassProperty be forward declared ? Maybe ?
-                    auto* meta_class = static_cast<FClassProperty*>(return_property)->GetMetaClass();
-                    if (m_classes_dumped.contains(meta_class))
-                    {
-                        auto& property_class_info = m_classes_dumped[meta_class];
-                        if (property_class_info.first_encountered_at)
-                        {
-                            ignore_forward_declare = property_class_info.first_encountered_at->object == owner.object;
-                        }
-                    }
-                }
-                else if (return_property->IsA<FObjectProperty>())
-                {
-                    auto* property_class = static_cast<FObjectProperty*>(return_property)->GetPropertyClass();
-                    if (m_classes_dumped.contains(property_class))
-                    {
-                        auto& property_class_info = m_classes_dumped[property_class];
-                        if (property_class_info.first_encountered_at)
-                        {
-                            ignore_forward_declare = property_class_info.first_encountered_at->object == owner.object;
-                        }
-                    }
-                }
-
-                if (!ignore_forward_declare)
-                {
-                    function_type_name.insert(0, STR("class "));
-                }
-            }
-        }
-        else
-        {
-            function_type_name = STR("void");
-        }
-
-        StringType current_class_content{};
-
-        current_class_content.append(std::format(STR("{}{} {}("), generate_tab(), function_type_name, function_name));
-
-        for (size_t i = 0; i < function_info.params.size(); ++i)
-        {
-            const auto& param_info = function_info.params[i];
-            if (!param_info.property->HasAnyPropertyFlags(Unreal::CPF_ReturnParm))
-            {
-                try
-                {
-                    current_class_content.append(std::format(STR("{}{}{}{} {}"),
-                                                                            param_info.property->HasAnyPropertyFlags(Unreal::CPF_ConstParm) ? STR("const ") : STR(""),
-                                                                            param_info.should_forward_declare ? STR("class ") : STR(""),
-                                                                            generate_property_cxx_name(param_info.property, true, function_info.function, EnableForwardDeclarations::Yes),
-                                                                            param_info.property->HasAnyPropertyFlags(Unreal::CPF_ReferenceParm | Unreal::CPF_OutParm) ? STR("&") : STR(""),
-                                                                            param_info.property->GetName()));
-                }
-                catch (std::exception& e)
-                {
-                    Output::send<LogLevel::Warning>(STR("Could not generate function '{}' because: {}\n"), function_info.function->GetFullName(), to_wstring(e.what()));
-                    return;
-                }
-
-                if (i + 1 < function_info.params.size())
-                {
-                    auto* next_param = function_info.params[i + 1].property;
-                    if (next_param && (!next_param->HasAnyPropertyFlags(Unreal::CPF_ReturnParm) || i + 2 < function_info.params.size()))
-                    {
-                        current_class_content.append(STR(", "));
-                    }
-                }
-            }
-        }
-
-        current_class_content.append(STR(");"));
-        // Commenting out this code because all network replicated functions are events
-        // Therefore this is not an accurate way to check if a function is an event
-        /*
-        if ((function->get_function_flags() & Unreal::EFunctionFlags::FUNC_Event) != 0)
-        {
-            current_class_content.append(STR(" // EVENT"));
-        }
-        //*/
-        current_class_content.append(STR("\n"));
-        out_current_class_content.append(current_class_content);
-    }
-
-    auto CXXGenerator::generate_prefix(UStruct* obj) -> File::StringType
+    auto generate_prefix(UStruct* obj) -> File::StringType
     {
         UClass* obj_class = obj->GetClassPrivate();
         if (obj_class->IsChildOf<UScriptStruct>())
@@ -360,478 +100,1079 @@ namespace RC::UEGenerator
             return STR("class");
         }
     }
-
-    auto CXXGenerator::generate_class_dependency(ObjectInfo& owner, UStruct* inherited_class, File::StringType& current_class_content) -> void
-    {
-        if (!inherited_class) { return; }
-
-        if (!m_classes_dumped.contains(inherited_class))
+    auto generate_class_name(UStruct* class_to_generate) -> File::StringType {
+        if (class_to_generate->GetClassPrivate()->IsChildOf<UScriptStruct>())
         {
-            GeneratedFile* package_file_for_inherited_class = generate_package_if_non_existent(inherited_class);
-            if (package_file_for_inherited_class)
-            {
-                auto& inherited_object_info = m_classes_dumped.emplace(inherited_class, ObjectInfo{inherited_class, &owner}).first->second;
-                File::StringType new_class_content{};
-                generate_class(inherited_object_info, *package_file_for_inherited_class, new_class_content);
-                if (!package_file_for_inherited_class->primary_file_has_no_contents)
-                {
-                    package_file_for_inherited_class->ordered_primary_file_contents.push_back(new_class_content);
-                }
-            }
-
-            return;
+            return get_native_struct_name(std::bit_cast<UScriptStruct*>(class_to_generate));
+        }
+        else if (class_to_generate->IsChildOf<UInterface>())
+        {
+            return get_native_class_name(static_cast<UClass*>(class_to_generate), true);
+        }
+        else
+        {
+            // Assume that it's a UClass
+            return get_native_class_name(static_cast<UClass*>(class_to_generate));
         }
     }
 
-    auto CXXGenerator::generate_class_dependency_from_property(ObjectInfo& owner, XProperty* property, File::StringType& current_class_content) -> bool
+
+    template<typename T>
+    class TypeGenerator
     {
-        if (property->IsA<FStructProperty>())
-        {
-            generate_class_dependency(owner, static_cast<FStructProperty*>(property)->GetStruct(), current_class_content);
-            return false;
-        }
-        else if (property->IsA<FClassProperty>())
-        {
-            //return generate_class_dependency(owner, static_cast<XClassProperty*>(property)->get_meta_class());
-            return false;
-        }
-        else if (property->IsA<FObjectProperty>())
-        {
-            //return generate_class_dependency(owner, static_cast<XObjectProperty*>(property)->get_property_class());
-            return true;
-        }
-        else if (property->IsA<FArrayProperty>())
-        {
-            //return generate_class_dependency_from_property(owner, static_cast<XArrayProperty*>(property)->get_inner());
-            //if (static_cast<XArrayProperty*>(property)->get_inner()->is_child_of<XObjectProperty>())
-            //{
-            //    return true;
-            //}
-            XProperty* inner = static_cast<FArrayProperty*>(property)->GetInner();
-            if (inner->IsA<FStructProperty>())
-            {
-                generate_class_dependency(owner, static_cast<FStructProperty*>(inner)->GetStruct(), current_class_content);
-                return false;
-            }
-        }
-        else if (property->IsA<FMapProperty>())
-        {
-            XProperty* key_property = static_cast<FMapProperty*>(property)->GetKeyProp();
-            XProperty* value_property = static_cast<FMapProperty*>(property)->GetValueProp();
+    private:
+        T specification{};
+        const std::filesystem::path m_directory_to_generate_in;
 
-            if (key_property->IsA<FStructProperty>())
-            {
-                generate_class_dependency(owner, static_cast<FStructProperty*>(key_property)->GetStruct(), current_class_content);
-            }
+    public:
 
-            if (value_property->IsA<FStructProperty>())
-            {
-                generate_class_dependency(owner, static_cast<FStructProperty*>(value_property)->GetStruct(), current_class_content);
-            }
-
-            return false;
-        }
-
-        return false;
-    }
-
-    auto CXXGenerator::make_function_info(ObjectInfo& owner, UFunction* function, File::StringType& current_class_content) -> FunctionInfo
-    {
-        FunctionInfo function_info{
-            .function = function,
-            .owner = owner,
+        struct FileName
+        {
+            uint32_t num_collisions{};
         };
 
-        function->ForEachProperty([&](XProperty* param) {
-            if (!param->HasAnyPropertyFlags(Unreal::CPF_Parm | Unreal::CPF_ReturnParm)) { return LoopAction::Continue; }
+        // Map of FName.ComparisonIndex -> File::Handle
+        std::unordered_map<Unreal::FName, GeneratedFile> m_files{};
+        std::unordered_map<File::StringType, FileName> m_file_names{};
+        std::unordered_map<Unreal::UObject*, ObjectInfo> m_classes_dumped{};
 
-            function_info.params.emplace_back(PropertyInfo{param, generate_class_dependency_from_property(owner, param, current_class_content)});
-            return LoopAction::Continue;
-        });
+    public:
+        TypeGenerator() = delete;
+        TypeGenerator(const std::filesystem::path directory_to_generate_in) : m_directory_to_generate_in(directory_to_generate_in)
+        {
+            m_files.reserve(512);
+        }
 
-        return function_info;
-    }
+        auto create_all_files() -> void
+        {
+            Output::send(STR("Creating all files...\n"));
+            for (auto&[comparison_index, generated_file] : m_files)
+            {
+                if (!generated_file.ordered_primary_file_contents.empty())
+                {
+                    generated_file.primary_file = File::open(generated_file.primary_file_name, File::OpenFor::Appending, File::OverwriteExistingFile::Yes, File::CreateIfNonExistent::Yes);
 
-    auto CXXGenerator::generate_class(ObjectInfo object_info, GeneratedFile& generated_file, File::StringType& current_class_content) -> XProperty*
-    {
-        UStruct* native_class = static_cast<UStruct*>(object_info.object);
-        generated_file.primary_file_has_no_contents = false;
-        File::StringType content_buffer{};
+                    specification.generate_file_header(generated_file);
 
-        UStruct* inherits_from_class = native_class->GetSuperStruct();
+                    sort_files(generated_file.ordered_primary_file_contents);
 
-        // Make sure that the base class is defined
-        generate_class_dependency(object_info, inherits_from_class, current_class_content);
+                    File::StringType combined_file_contents;
+                    for (auto& line : generated_file.ordered_primary_file_contents)
+                    {
+                        combined_file_contents.append(line);
+                    }
 
-        // If any properties have dependencies, make sure that they are defined
-        // This makes sure that we don't have member variables with undefined types (if the types are local, otherwise we need to include the file that the struct exists in)
-        std::vector<PropertyInfo> properties_to_generate{};
-        native_class->ForEachProperty([&](XProperty* property) {
-            properties_to_generate.emplace_back(PropertyInfo{property, generate_class_dependency_from_property(object_info, property, current_class_content)});
-            return LoopAction::Continue;
-        });
+                    if (combined_file_contents.empty())
+                    {
+                        Output::send(STR("Empty primary file contents in '{}'\n"), generated_file.package_name);
+                    }
+                    else
+                    {
+                        generated_file.primary_file.write_string_to_file(combined_file_contents);
+                    }
 
-        std::vector<FunctionInfo> functions_to_generate{};
-        native_class->ForEachFunction([&](UFunction* function) {
-            auto& function_info = functions_to_generate.emplace_back(FunctionInfo{function, object_info});
+                    specification.generate_file_footer(generated_file);
+
+                    generated_file.primary_file.close();
+                }
+
+                if (!generated_file.ordered_secondary_file_contents.empty())
+                {
+                    generated_file.secondary_file = File::open(generated_file.secondary_file_name, File::OpenFor::Appending, File::OverwriteExistingFile::Yes, File::CreateIfNonExistent::Yes);
+
+                    sort_files(generated_file.ordered_secondary_file_contents);
+
+                    File::StringType combined_file_contents;
+                    for (auto& line : generated_file.ordered_secondary_file_contents)
+                    {
+                        combined_file_contents.append(line);
+                    }
+
+                    if (combined_file_contents.empty())
+                    {
+                        Output::send(STR("Empty secondary file contents in '{}'\n"), generated_file.package_name);
+                    }
+                    else
+                    {
+                        generated_file.secondary_file.write_string_to_file(combined_file_contents);
+                    }
+
+                    generated_file.secondary_file.close();
+                }
+            }
+        }
+
+        auto sort_files(std::vector<File::StringType>& content) -> void
+        {
+            std::vector<File::StringType> struct_content;
+            std::vector<File::StringType> class_content;
+            std::vector<File::StringType> other_content;
+            for (auto& line : content)
+            {
+                if (line.starts_with(STR("struct")))
+                {
+                    struct_content.push_back(line);
+                }
+                else if (line.starts_with(STR("class")))
+                {
+                    class_content.push_back(line);
+                }
+                else
+                {
+                    other_content.push_back(line);
+                }
+            }
+            
+            sort_types(struct_content);
+            sort_types(class_content);
+            sort_types(other_content);
+
+            content.clear();
+            content.reserve(struct_content.size() + class_content.size() + other_content.size());
+            content.insert(content.end(), struct_content.begin(), struct_content.end());
+            content.insert(content.end(), class_content.begin(), class_content.end());
+            content.insert(content.end(), other_content.begin(), other_content.end());
+        }
+
+        auto sort_types(std::vector<File::StringType>& content) -> void
+        {
+            std::sort(content.begin(), content.end(), [&](const auto& a, const auto& b) {
+                auto a_class_name = get_class_name(a);
+                auto b_class_name = get_class_name(b);
+                return a_class_name < b_class_name;
+            });
+        }
+
+        auto get_class_name(const auto& x) -> std::wstring
+        {
+            // Using this method instead of regex because it is extremely slow
+            auto class_name = x.substr(x.find(STR(' ')) + 1);
+            class_name = class_name.substr(0, class_name.find(STR(' ')));
+            if (class_name == STR("class"))
+            {
+                // Case for enum class
+                class_name = x.substr(x.find(STR(' ')) + 7);
+                class_name = class_name.substr(0, class_name.find(STR(' ')));
+            }
+            return class_name;
+        }
+
+        auto object_is_package(UObject* object) -> bool
+        {
+            return object->GetClassPrivate()->GetNamePrivate().Equals(Unreal::GPackageName);
+        }
+
+        auto generate_offset_comment(XProperty* property, File::StringType& line) -> File::StringType
+        {
+            if (UE4SSProgram::settings_manager.CXXHeaderGenerator.DumpOffsetsAndSizes)
+            {
+                return std::format(STR("{:85} // 0x{:04X} (size: 0x{:X})"), line, property->GetOffset_Internal(), property->GetSize());
+            }
+            else
+            {
+                return line;
+            }
+        }
+
+        auto check_ignore_forward_declaration(const ObjectInfo& owner, XProperty* return_property) -> bool
+        {
+            if (return_property->IsA<FStructProperty>())
+            {
+                // Can StructProperty even be forward declared ? I don't know if it's ever a pointer to a struct
+                auto* script_struct = static_cast<FStructProperty*>(return_property)->GetStruct();
+                if (m_classes_dumped.contains(script_struct))
+                {
+                    auto& property_class_info = m_classes_dumped[script_struct];
+                    if (property_class_info.first_encountered_at)
+                    {
+                        return property_class_info.first_encountered_at->object == owner.object;
+                    }
+                }
+            }
+            else if (return_property->IsA<FClassProperty>())
+            {
+                // Can ClassProperty be forward declared ? Maybe ?
+                auto* meta_class = static_cast<FClassProperty*>(return_property)->GetMetaClass();
+                if (m_classes_dumped.contains(meta_class))
+                {
+                    auto& property_class_info = m_classes_dumped[meta_class];
+                    if (property_class_info.first_encountered_at)
+                    {
+                        return property_class_info.first_encountered_at->object == owner.object;
+                    }
+                }
+            }
+            else if (return_property->IsA<FObjectProperty>())
+            {
+                auto* property_class = static_cast<FObjectProperty*>(return_property)->GetPropertyClass();
+                if (m_classes_dumped.contains(property_class))
+                {
+                    auto& property_class_info = m_classes_dumped[property_class];
+                    if (property_class_info.first_encountered_at)
+                    {
+                        return property_class_info.first_encountered_at->object == owner.object;
+                    }
+                }
+            }
+            return false;
+        }
+
+        auto generate_function_declaration(ObjectInfo& owner, const FunctionInfo& function_info, GeneratedFile& generated_file, File::StringType& out_current_class_content, IsDelegateFunction is_delegate_function = IsDelegateFunction::No) -> void
+        {
+            std::optional<PropertyInfo> return_property_info = [&]() -> std::optional<PropertyInfo> {
+                for (const auto& property_info : function_info.params)
+                {
+                    if (property_info.property->HasAnyPropertyFlags(Unreal::CPF_ReturnParm))
+                    {
+                        return property_info;
+                    }
+                }
+
+                return {};
+            }();
+
+            XProperty* return_property = [&]() {
+                return return_property_info.has_value() ? return_property_info.value().property : nullptr;
+            }();
+
+            File::StringType function_name{function_info.function->GetName()};
+            if (is_delegate_function == IsDelegateFunction::Yes)
+            {
+                // Remove the last 19 characters, which is always '__DelegateSignature' for delegates
+                function_name.erase(function_name.size() - 19, 19);
+            }
+
+            StringType current_class_content{};
+            specification.generate_function_declaration(this, current_class_content, owner, function_info, function_name, return_property, return_property_info);
+
+            // Commenting out this code because all network replicated functions are events
+            // Therefore this is not an accurate way to check if a function is an event
+            /*
+            if ((function->get_function_flags() & Unreal::EFunctionFlags::FUNC_Event) != 0)
+            {
+                current_class_content.append(STR(" // EVENT"));
+            }
+            //*/
+            current_class_content.append(STR("\n"));
+            out_current_class_content.append(current_class_content);
+        }
+
+        auto generate_class_dependency(ObjectInfo& owner, UStruct* inherited_class, File::StringType& current_class_content) -> void
+        {
+            if (!inherited_class) { return; }
+
+            if (!m_classes_dumped.contains(inherited_class))
+            {
+                GeneratedFile* package_file_for_inherited_class = generate_package_if_non_existent(inherited_class);
+                if (package_file_for_inherited_class)
+                {
+                    auto& inherited_object_info = m_classes_dumped.emplace(inherited_class, ObjectInfo{inherited_class, &owner}).first->second;
+                    File::StringType new_class_content{};
+                    generate_class(inherited_object_info, *package_file_for_inherited_class, new_class_content);
+                    if (!package_file_for_inherited_class->primary_file_has_no_contents)
+                    {
+                        package_file_for_inherited_class->ordered_primary_file_contents.push_back(new_class_content);
+                    }
+                }
+
+                return;
+            }
+        }
+
+        auto generate_class_dependency_from_property(ObjectInfo& owner, XProperty* property, File::StringType& current_class_content) -> bool
+        {
+            if (property->IsA<FStructProperty>())
+            {
+                generate_class_dependency(owner, static_cast<FStructProperty*>(property)->GetStruct(), current_class_content);
+                return false;
+            }
+            else if (property->IsA<FClassProperty>())
+            {
+                //return generate_class_dependency(owner, static_cast<XClassProperty*>(property)->get_meta_class());
+                return false;
+            }
+            else if (property->IsA<FObjectProperty>())
+            {
+                //return generate_class_dependency(owner, static_cast<XObjectProperty*>(property)->get_property_class());
+                return true;
+            }
+            else if (property->IsA<FArrayProperty>())
+            {
+                //return generate_class_dependency_from_property(owner, static_cast<XArrayProperty*>(property)->get_inner());
+                //if (static_cast<XArrayProperty*>(property)->get_inner()->is_child_of<XObjectProperty>())
+                //{
+                //    return true;
+                //}
+                XProperty* inner = static_cast<FArrayProperty*>(property)->GetInner();
+                if (inner->IsA<FStructProperty>())
+                {
+                    generate_class_dependency(owner, static_cast<FStructProperty*>(inner)->GetStruct(), current_class_content);
+                    return false;
+                }
+            }
+            else if (property->IsA<FMapProperty>())
+            {
+                XProperty* key_property = static_cast<FMapProperty*>(property)->GetKeyProp();
+                XProperty* value_property = static_cast<FMapProperty*>(property)->GetValueProp();
+
+                if (key_property->IsA<FStructProperty>())
+                {
+                    generate_class_dependency(owner, static_cast<FStructProperty*>(key_property)->GetStruct(), current_class_content);
+                }
+
+                if (value_property->IsA<FStructProperty>())
+                {
+                    generate_class_dependency(owner, static_cast<FStructProperty*>(value_property)->GetStruct(), current_class_content);
+                }
+
+                return false;
+            }
+
+            return false;
+        }
+
+        auto make_function_info(ObjectInfo& owner, UFunction* function, File::StringType& current_class_content) -> FunctionInfo
+        {
+            FunctionInfo function_info{
+                .function = function,
+                .owner = owner,
+            };
 
             function->ForEachProperty([&](XProperty* param) {
                 if (!param->HasAnyPropertyFlags(Unreal::CPF_Parm | Unreal::CPF_ReturnParm)) { return LoopAction::Continue; }
 
-                function_info.params.emplace_back(PropertyInfo{param, generate_class_dependency_from_property(object_info, param, current_class_content)});
+                function_info.params.emplace_back(PropertyInfo{param, generate_class_dependency_from_property(owner, param, current_class_content)});
                 return LoopAction::Continue;
             });
-            return LoopAction::Continue;
-        });
 
-        auto generate_class_name = [](UStruct* class_to_generate) {
-            if (class_to_generate->GetClassPrivate()->IsChildOf<UScriptStruct>())
+            return function_info;
+        }
+
+        auto generate_class(ObjectInfo object_info, GeneratedFile& generated_file, File::StringType& current_class_content) -> XProperty*
+        {
+            UStruct* native_class = static_cast<UStruct*>(object_info.object);
+            if (specification.should_generate_class(native_class))
             {
-                return get_native_struct_name(std::bit_cast<UScriptStruct*>(class_to_generate));
+                generated_file.primary_file_has_no_contents = false;
+                specification.generate_class(this, object_info, generated_file, current_class_content);
             }
-            else if (class_to_generate->IsChildOf<UInterface>())
+
+            return native_class->GetFirstProperty();
+        }
+
+        auto generate_enum(UObject* native_object, GeneratedFile& generated_file) -> void
+        {
+            generated_file.secondary_file_has_no_contents = false;
+
+            File::StringType content_buffer;
+            UEnum* uenum = static_cast<UEnum*>(native_object);
+            auto& enum_names = uenum->GetEnumNames();
+
+            specification.generate_enum_declaration(content_buffer, uenum);
+            const auto cpp_form = uenum->GetCppForm();
+
+            enum_names.ForEach([&](Unreal::FEnumNamePair* elem, size_t index) {
+                auto enum_value_full_name = elem->Key.ToString();
+                size_t colon_pos = enum_value_full_name.rfind(STR(":"));
+                auto enum_value_name = colon_pos == enum_value_full_name.npos ? enum_value_full_name : enum_value_full_name.substr(colon_pos + 1);
+
+                specification.generate_enum_member(content_buffer, uenum, enum_value_name, elem);
+
+                return LoopAction::Continue;
+            });
+
+            specification.generate_enum_end(content_buffer, uenum);
+
+            content_buffer.append(STR("\n\n"));
+
+            generated_file.ordered_secondary_file_contents.push_back(content_buffer);
+        }
+
+        auto generate_package(UObject* package, File::StringType& out) -> void
+        {
+            UObjectGlobals::ForEachUObject([&](void* object, [[maybe_unused]]int32_t chunk_index, [[maybe_unused]]int32_t object_index) {
+                return LoopAction::Continue;
+            });
+        }
+
+        auto generate_package_if_non_existent(UObject* object) -> GeneratedFile*
+        {
+            UObject* package{};
+            UObject* outer = object;
+            if (!outer) { return nullptr; }
+
+            do
             {
-                return get_native_class_name(static_cast<UClass*>(class_to_generate), true);
+                if (object_is_package(outer))
+                {
+                    package = outer;
+                    break;
+                }
+
+                outer = outer->GetOuterPrivate();
+            } while (outer);
+
+            if (!package)
+            {
+                throw std::runtime_error{"[generate_package_if_non_existent] Was unable to find UPackage for this object"};
+            }
+
+            FName package_fname = package->GetNamePrivate();
+            if (m_files.contains(package_fname))
+            {
+                return &m_files.at(package_fname);
             }
             else
             {
-                // Assume that it's a UClass
-                return get_native_class_name(static_cast<UClass*>(class_to_generate));
+                // Get rid of everything before the last slash + the last slash, leaving only the actual name
+                File::StringType package_name = package->GetNamePrivate().ToString();
+                package_name = package_name.substr(package_name.rfind(STR("/")) + 1);
+                File::StringType package_name_all_lower = package_name;
+                std::transform(package_name_all_lower.begin(), package_name_all_lower.end(), package_name_all_lower.begin(), [](File::CharType c) {
+                    return std::towlower(c);
+                });
+
+                if (m_file_names.contains(package_name_all_lower))
+                {
+                    // File name collision
+                    auto& file_name = m_file_names[package_name_all_lower];
+                    package_name.append(std::format(STR("_DUPL_{}"), ++file_name.num_collisions));
+                    Output::send(STR("File name collision, renamed to '{}'\n"), package_name);
+                }
+                else
+                {
+                    m_file_names.emplace(package_name_all_lower, FileName{});
+                }
+
+                // The '\\?\' at the beginning of the string unlocks path size restriction from MAX_PATH to 32k
+                std::filesystem::path directory_to_generate_in = std::filesystem::path("\\\\?\\");
+                directory_to_generate_in += (m_directory_to_generate_in);
+
+                File::StringType ext = specification.get_file_extension();
+                std::filesystem::path primary_file_path_and_name = directory_to_generate_in;
+                primary_file_path_and_name.append(package_name);
+                primary_file_path_and_name.replace_extension(ext);
+
+                std::filesystem::path secondary_file_path_and_name = directory_to_generate_in;
+                secondary_file_path_and_name.append(package_name + STR("_enums"));
+                secondary_file_path_and_name.replace_extension(ext);
+
+                GeneratedFile generated_file{
+                    .primary_file_name = primary_file_path_and_name,
+                    .secondary_file_name = secondary_file_path_and_name,
+                    .ordered_primary_file_contents = {},
+                    .ordered_secondary_file_contents = {},
+                    .package_name = package_name,
+                    .primary_file = {},
+                    .secondary_file = {},
+                    .primary_file_has_no_contents = true,
+                    .secondary_file_has_no_contents = true,
+                };
+
+                auto& file_in_map = m_files.emplace(std::move(package_fname), std::move(generated_file)).first->second;
+                return &file_in_map;
             }
-        };
-
-        auto class_name = generate_class_name(native_class);
-
-        if (inherits_from_class)
-        {
-            content_buffer.append(std::format(STR("{} {} : public {}\n{{\n"), generate_prefix(native_class), class_name, generate_class_name(inherits_from_class)));
         }
-        else
+
+        auto cleanup_old_sdk() -> void
         {
-            content_buffer.append(std::format(STR("{} {}\n{{\n"), generate_prefix(native_class), class_name));
+            if (!std::filesystem::exists(m_directory_to_generate_in)) { return; }
+
+            for (const auto& item : std::filesystem::directory_iterator(m_directory_to_generate_in))
+            {
+                if (item.is_directory()) { continue; }
+                if (item.path().extension() != specification.get_file_extension()) { continue; }
+
+                File::delete_file(item.path());
+            }
         }
 
-        int32_t num_padding_elements{0};
-        XProperty* last_property_in_this_class{nullptr};
-
-        for (const auto& property_info : properties_to_generate)
+    public:
+        auto generate() -> void
         {
-            XProperty* property = property_info.property;
-            int32_t current_property_offset = property->GetOffset_Internal();
-            int32_t current_property_size = property->GetSize();
+            Output::send(STR("Cleaning up old SDK files...\n"));
+            cleanup_old_sdk();
+            Output::send(STR("Generating SDK...\n"));
 
-            StringType part_one{};
-            try
+            // 400k should be enough for most games, and it's highly unlikely to cause more than one reallocation even if the game is huge
+            m_classes_dumped.reserve(400000);
+
+            size_t num_objects_generated{};
+            UObjectGlobals::ForEachUObject([&](void* untyped_object, [[maybe_unused]]int32_t chunk_index, [[maybe_unused]]int32_t object_index) {
+                UObject* object = static_cast<UObject*>(untyped_object);
+                UClass* object_class = object->GetClassPrivate();
+
+                // Generate file for package if it doesn't already exist
+                GeneratedFile* package_file = generate_package_if_non_existent(object);
+
+                if (!package_file)
+                {
+                    // Object should not be dumped
+                    return LoopAction::Continue;
+                }
+                else if (object->IsA<UEnum>())
+                {
+                    generate_enum(object, *package_file);
+                    ++num_objects_generated;
+
+                    return LoopAction::Continue;
+                }
+                else if ((object_class->IsChildOf<UClass>() ||
+                          object_class->IsChildOf<UScriptStruct>()) &&
+                         !m_classes_dumped.contains(object))
+                {
+                    // Generate a class for this object
+                    auto& object_info = m_classes_dumped.emplace(object, ObjectInfo{object}).first->second;
+                    File::StringType class_content{};
+                    generate_class(object_info, *package_file, class_content);
+                    if (!package_file->primary_file_has_no_contents)
+                    {
+                        package_file->ordered_primary_file_contents.push_back(class_content);
+                    }
+                    ++num_objects_generated;
+
+                    return LoopAction::Continue;
+                }
+                else
+                {
+                    // Object should not be dumped
+                    return LoopAction::Continue;
+                }
+            });
+
+            create_all_files();
+        }
+    };
+
+    class CXXHeaderGenerator
+    {
+    public:
+        auto get_file_extension() -> File::StringType
+        {
+            return STR(".hpp");
+        }
+        auto generate_file_header(GeneratedFile& generated_file) -> void
+        {
+            generated_file.primary_file.write_string_to_file(std::format(STR("#ifndef UE4SS_SDK_{}_HPP\n#define UE4SS_SDK_{}_HPP\n\n"), generated_file.package_name, generated_file.package_name));
+
+            if (!generated_file.secondary_file_has_no_contents)
             {
-                part_one = std::format(STR("{}{}{} {};"),
-                                            generate_tab(),
-                                            property_info.should_forward_declare ? STR("class ") : STR(""),
-                                            generate_property_cxx_name(property, true, native_class, EnableForwardDeclarations::Yes),
-                                            property->GetName());
+                generated_file.primary_file.write_string_to_file(std::format(STR("#include \"{}\"\n\n"), generated_file.secondary_file_name.filename().c_str()));
             }
-            catch (std::exception& e)
+        }
+        auto generate_file_footer(GeneratedFile& generated_file) -> void
+        {
+            generated_file.primary_file.write_string_to_file(std::format(STR("#endif\n")));
+        }
+        auto generate_enum_declaration(File::StringType& content_buffer, UEnum* uenum) -> void
+        {
+            const auto cpp_form = uenum->GetCppForm();
+            if (cpp_form == UEnum::ECppForm::Regular)
             {
-                Output::send<LogLevel::Warning>(STR("Could not generate property '{}' because: {}\n"), property->GetFullName(), to_wstring(e.what()));
-                continue;
+                content_buffer.append(std::format(STR("enum {} {{\n"), get_native_enum_name(uenum, false)));
+            }
+            else if (cpp_form == UEnum::ECppForm::Namespaced)
+            {
+                content_buffer.append(std::format(STR("namespace {} {{\n{}enum Type {{\n"), get_native_enum_name(uenum, false), generate_tab()));
+            }
+            else if (cpp_form == UEnum::ECppForm::EnumClass)
+            {
+                content_buffer.append(std::format(STR("enum class {} {{\n"), get_native_enum_name(uenum, false)));
+            }
+        }
+        auto generate_enum_member(File::StringType& content_buffer, UEnum* uenum, const File::StringType& enum_value_name, Unreal::FEnumNamePair* elem) -> void
+        {
+            content_buffer.append(std::format(STR("{}{}{} = {},\n"), generate_tab(), uenum->GetCppForm() == UEnum::ECppForm::Namespaced ? generate_tab() : STR(""), enum_value_name, elem->Value));
+        }
+        auto generate_enum_end(File::StringType& content_buffer, UEnum* uenum) -> void
+        {
+            const auto cpp_form = uenum->GetCppForm();
+            content_buffer.append(std::format(STR("{}}};"), cpp_form == UEnum::ECppForm::Namespaced ? generate_tab() : STR("")));
+
+            if (cpp_form == UEnum::ECppForm::Namespaced)
+            {
+                content_buffer.append(STR("\n}"));
+            }
+        }
+        auto should_generate_class(UStruct* native_class) {
+            return true;
+        }
+        auto generate_class(TypeGenerator<CXXHeaderGenerator>* generator, ObjectInfo& object_info, GeneratedFile& generated_file, File::StringType& current_class_content)
+        {
+            UStruct* native_class = static_cast<UStruct*>(object_info.object);
+            File::StringType content_buffer{};
+
+            UStruct* inherits_from_class = native_class->GetSuperStruct();
+
+            // Make sure that the base class is defined
+            generator->generate_class_dependency(object_info, inherits_from_class, current_class_content);
+
+            // If any properties have dependencies, make sure that they are defined
+            // This makes sure that we don't have member variables with undefined types (if the types are local, otherwise we need to include the file that the struct exists in)
+            std::vector<PropertyInfo> properties_to_generate{};
+            native_class->ForEachProperty([&](XProperty* property) {
+                properties_to_generate.emplace_back(PropertyInfo{property, generator->generate_class_dependency_from_property(object_info, property, current_class_content)});
+                return LoopAction::Continue;
+            });
+
+            std::vector<FunctionInfo> functions_to_generate{};
+            native_class->ForEachFunction([&](UFunction* function) {
+                auto& function_info = functions_to_generate.emplace_back(FunctionInfo{function, object_info});
+
+                function->ForEachProperty([&](XProperty* param) {
+                    if (!param->HasAnyPropertyFlags(Unreal::CPF_Parm | Unreal::CPF_ReturnParm)) { return LoopAction::Continue; }
+
+                    function_info.params.emplace_back(PropertyInfo{param, generator->generate_class_dependency_from_property(object_info, param, current_class_content)});
+                    return LoopAction::Continue;
+                });
+                return LoopAction::Continue;
+            });
+
+            auto class_name = generate_class_name(native_class);
+
+            generate_class_declaration(content_buffer, native_class, inherits_from_class);
+
+            int32_t num_padding_elements{0};
+            XProperty* last_property_in_this_class{nullptr};
+
+            for (const auto& property_info : properties_to_generate)
+            {
+                XProperty* property = property_info.property;
+                int32_t current_property_offset = property->GetOffset_Internal();
+                int32_t current_property_size = property->GetSize();
+
+                StringType part_one{};
+                try
+                {
+                    part_one = std::format(STR("{}{}{} {};"),
+                                                generate_tab(),
+                                                property_info.should_forward_declare ? STR("class ") : STR(""),
+                                                generate_property_cxx_name(property, true, native_class, EnableForwardDeclarations::Yes),
+                                                property->GetName());
+                }
+                catch (std::exception& e)
+                {
+                    Output::send<LogLevel::Warning>(STR("Could not generate property '{}' because: {}\n"), property->GetFullName(), to_wstring(e.what()));
+                    continue;
+                }
+
+                content_buffer.append(std::format(STR("{}\n"), generator->generate_offset_comment(property, part_one)));
+
+                if (property->IsA<FDelegateProperty>())
+                {
+                    generator->generate_function_declaration(object_info, generator->make_function_info(object_info, static_cast<FDelegateProperty*>(property)->GetFunctionSignature(), current_class_content), generated_file, content_buffer, IsDelegateFunction::Yes);
+                }
+                else if (property->IsA<FMulticastInlineDelegateProperty>())
+                {
+                    generator->generate_function_declaration(object_info, generator->make_function_info(object_info, static_cast<FMulticastInlineDelegateProperty*>(property)->GetFunctionSignature(), current_class_content), generated_file, content_buffer, IsDelegateFunction::Yes);
+                }
+                else if (property->IsA<FMulticastSparseDelegateProperty>())
+                {
+                    generator->generate_function_declaration(object_info, generator->make_function_info(object_info, static_cast<FMulticastSparseDelegateProperty*>(property)->GetFunctionSignature(), current_class_content), generated_file, content_buffer, IsDelegateFunction::Yes);
+                }
+
+                if (UE4SSProgram::settings_manager.CXXHeaderGenerator.KeepMemoryLayout)
+                {
+                    // Check if next member-var is reflected
+                    // If it's not, add padding so that everything in the struct is aligned properly
+                    auto* next_property = property->GetNextFieldAsProperty();
+                    if (next_property)
+                    {
+                        int32_t current_property_end_location = current_property_offset + current_property_size;
+
+                        int32_t next_property_offset = next_property->GetOffset_Internal();
+
+                        if (current_property_offset != next_property_offset &&
+                            current_property_end_location != next_property_offset)
+                        {
+                            // Add padding
+                            int32_t padding_property_offset = current_property_end_location;
+                            int32_t padding_property_size = next_property_offset - padding_property_offset;
+
+                            auto padding_part_one = std::format(STR("{}char {}[0x{:X}];"), generate_tab(), std::format(STR("padding_{}"), num_padding_elements++), padding_property_size);
+                            content_buffer.append(std::format(STR("{:85} // 0x{:04X} (size: 0x{:X})\n"), padding_part_one, padding_property_offset, padding_property_size));
+                        }
+                    }
+                }
+
+                last_property_in_this_class = property;
             }
 
-            content_buffer.append(std::format(STR("{}\n"), generate_offset_comment(property, part_one)));
+            int32_t class_size = native_class->GetPropertiesSize();
+            generate_class_struct_end(content_buffer, class_name, class_size, num_padding_elements, last_property_in_this_class);
 
-            if (property->IsA<FDelegateProperty>())
+            // Functions
+            if (native_class->HasChildren())
             {
-                generate_function_declaration(object_info, make_function_info(object_info, static_cast<FDelegateProperty*>(property)->GetFunctionSignature(), current_class_content), generated_file, content_buffer, IsDelegateFunction::Yes);
-            }
-            else if (property->IsA<FMulticastInlineDelegateProperty>())
-            {
-                generate_function_declaration(object_info, make_function_info(object_info, static_cast<FMulticastInlineDelegateProperty*>(property)->GetFunctionSignature(), current_class_content), generated_file, content_buffer, IsDelegateFunction::Yes);
-            }
-            else if (property->IsA<FMulticastSparseDelegateProperty>())
-            {
-                generate_function_declaration(object_info, make_function_info(object_info, static_cast<FMulticastSparseDelegateProperty*>(property)->GetFunctionSignature(), current_class_content), generated_file, content_buffer, IsDelegateFunction::Yes);
+                content_buffer.append(STR("\n"));
+                for (const auto& function_info : functions_to_generate)
+                {
+                    generator->generate_function_declaration(object_info, function_info, generated_file, content_buffer);
+                }
             }
 
+            generate_class_end(content_buffer, class_size);
+
+            content_buffer.append(STR("\n\n"));
+
+            current_class_content.append(content_buffer);
+        }
+
+        auto generate_class_declaration(File::StringType& content_buffer, UStruct* native_class, UStruct* inherits_from_class) -> void
+        {
+            auto class_name = generate_class_name(native_class);
+            if (inherits_from_class)
+            {
+                content_buffer.append(std::format(STR("{} {} : public {}\n{{\n"), generate_prefix(native_class), class_name, generate_class_name(inherits_from_class)));
+            }
+            else
+            {
+                content_buffer.append(std::format(STR("{} {}\n{{\n"), generate_prefix(native_class), class_name));
+            }
+        }
+        auto generate_class_struct_end(File::StringType& content_buffer,
+                const File::StringType& class_name,
+                size_t class_size,
+                int32_t num_padding_elements,
+                XProperty* last_property_in_this_class) -> void
+        {
             if (UE4SSProgram::settings_manager.CXXHeaderGenerator.KeepMemoryLayout)
             {
-                // Check if next member-var is reflected
-                // If it's not, add padding so that everything in the struct is aligned properly
-                auto* next_property = property->GetNextFieldAsProperty();
-                if (next_property)
+                if (last_property_in_this_class)
                 {
-                    int32_t current_property_end_location = current_property_offset + current_property_size;
-
-                    int32_t next_property_offset = next_property->GetOffset_Internal();
-
-                    if (current_property_offset != next_property_offset &&
-                        current_property_end_location != next_property_offset)
+                    // TODO: Fix this, the padding is required for alignment when using the SDK for code injection
+                    // This commented-out code was here to provide the correct padding between classes so that everything would line up correctly
+                    // But it no longer works because it was dependent on the "generate_class_chain" function that no longer eixsts
+                    /*
+                    int32_t last_property_offset = last_property_in_this_class->get_offset_for_internal();
+                    if (first_property)
                     {
-                        // Add padding
-                        int32_t padding_property_offset = current_property_end_location;
-                        int32_t padding_property_size = next_property_offset - padding_property_offset;
+                        int32_t first_property_offset = first_property->get_offset_for_internal();
+                        if (last_property_offset != first_property_offset)
+                        {
+                            int32_t last_property_size = last_property_in_this_class->get_size();
+                            int32_t padding_size = first_property_offset - (last_property_offset + last_property_size);
+                            printf_s("class_size: %X\n", class_size);
+                            printf_s("first_property->get_size(): %X\n", first_property->get_size());
+                            printf_s("last_property_offset: %X\n", last_property_offset);
+                            printf_s("first_property_offset: %X\n", first_property_offset);
 
-                        auto padding_part_one = std::format(STR("{}char {}[0x{:X}];"), generate_tab(), std::format(STR("padding_{}"), num_padding_elements++), padding_property_size);
-                        content_buffer.append(std::format(STR("{:85} // 0x{:04X} (size: 0x{:X})\n"), padding_part_one, padding_property_offset, padding_property_size));
+                            auto padding_part_one = std::format(STR("{}char {}[0x{:X}];"), generate_tab(), std::format(STR("padding_{}"), num_padding_elements), padding_size);
+                            out.append(std::format(STR("{:85} // 0x{:04X} (size: 0x{:X})\n"), padding_part_one, last_property_offset + last_property_size, padding_size));
+                        }
+                    }
+                    //*/
+                }
+                else if (class_size > 0)
+                {
+                    // No reflected member variables exist but there are non-reflected member variables
+                    // Add padding for non-reflected member variables, for alignment purposes
+                    auto padding_part_one = std::format(STR("{}char {}[0x{:X}];"), generate_tab(), std::format(STR("padding_{}"), num_padding_elements), class_size);
+                    content_buffer.append(std::format(STR("{:85} // 0x0000 (size: 0x{:X})\n"), padding_part_one, 0x0));
+                }
+            }
+        }
+        auto generate_class_end(File::StringType& content_buffer, size_t class_size) -> void
+        {
+            if (UE4SSProgram::settings_manager.CXXHeaderGenerator.DumpOffsetsAndSizes)
+            {
+                content_buffer.append(std::format(STR("}}; // Size: 0x{:X}"), class_size));
+            }
+            else
+            {
+                content_buffer.append(STR("};"));
+            }
+        }
+
+        auto generate_function_declaration(TypeGenerator<CXXHeaderGenerator>* generator,
+                File::StringType& current_class_content,
+                ObjectInfo& owner,
+                const FunctionInfo& function_info,
+                File::StringType function_name,
+                XProperty* return_property,
+                std::optional<PropertyInfo> return_property_info) -> void
+        {
+            File::StringType function_type_name{};
+            if (return_property)
+            {
+                try
+                {
+                    function_type_name = generate_property_cxx_name(return_property, true, function_info.function, EnableForwardDeclarations::Yes);
+                }
+                catch (std::exception& e)
+                {
+                    Output::send<LogLevel::Warning>(STR("Could not generate function '{}' because: {}\n"), function_info.function->GetFullName(), to_wstring(e.what()));
+                    return;
+                }
+
+                if (return_property_info.value().should_forward_declare && !generator->check_ignore_forward_declaration(owner, return_property))
+                {
+                    function_type_name.insert(0, STR("class "));
+                }
+            }
+            else
+            {
+                function_type_name = STR("void");
+            }
+
+            current_class_content.append(std::format(STR("{}{} {}("), generate_tab(), function_type_name, function_name));
+
+            for (size_t i = 0; i < function_info.params.size(); ++i)
+            {
+                const auto& param_info = function_info.params[i];
+                if (!param_info.property->HasAnyPropertyFlags(Unreal::CPF_ReturnParm))
+                {
+                    try
+                    {
+                        current_class_content.append(std::format(STR("{}{}{}{} {}"),
+                                                                                param_info.property->HasAnyPropertyFlags(Unreal::CPF_ConstParm) ? STR("const ") : STR(""),
+                                                                                param_info.should_forward_declare ? STR("class ") : STR(""),
+                                                                                generate_property_cxx_name(param_info.property, true, function_info.function, EnableForwardDeclarations::Yes),
+                                                                                param_info.property->HasAnyPropertyFlags(Unreal::CPF_ReferenceParm | Unreal::CPF_OutParm) ? STR("&") : STR(""),
+                                                                                param_info.property->GetName()));
+                    }
+                    catch (std::exception& e)
+                    {
+                        Output::send<LogLevel::Warning>(STR("Could not generate function '{}' because: {}\n"), function_info.function->GetFullName(), to_wstring(e.what()));
+                        return;
+                    }
+
+                    if (i + 1 < function_info.params.size())
+                    {
+                        auto* next_param = function_info.params[i + 1].property;
+                        if (next_param && (!next_param->HasAnyPropertyFlags(Unreal::CPF_ReturnParm) || i + 2 < function_info.params.size()))
+                        {
+                            current_class_content.append(STR(", "));
+                        }
                     }
                 }
             }
-
-            last_property_in_this_class = property;
+            current_class_content.append(STR(");"));
         }
+    };
 
-        int32_t class_size = native_class->GetPropertiesSize();
-
-        if (UE4SSProgram::settings_manager.CXXHeaderGenerator.KeepMemoryLayout)
-        {
-            if (last_property_in_this_class)
-            {
-                // TODO: Fix this, the padding is required for alignment when using the SDK for code injection
-                // This commented-out code was here to provide the correct padding between classes so that everything would line up correctly
-                // But it no longer works because it was dependent on the "generate_class_chain" function that no longer eixsts
-                /*
-                int32_t last_property_offset = last_property_in_this_class->get_offset_for_internal();
-                if (first_property)
-                {
-                    int32_t first_property_offset = first_property->get_offset_for_internal();
-                    if (last_property_offset != first_property_offset)
-                    {
-                        int32_t last_property_size = last_property_in_this_class->get_size();
-                        int32_t padding_size = first_property_offset - (last_property_offset + last_property_size);
-                        printf_s("class_size: %X\n", class_size);
-                        printf_s("first_property->get_size(): %X\n", first_property->get_size());
-                        printf_s("last_property_offset: %X\n", last_property_offset);
-                        printf_s("first_property_offset: %X\n", first_property_offset);
-
-                        auto padding_part_one = std::format(STR("{}char {}[0x{:X}];"), generate_tab(), std::format(STR("padding_{}"), num_padding_elements), padding_size);
-                        out.append(std::format(STR("{:85} // 0x{:04X} (size: 0x{:X})\n"), padding_part_one, last_property_offset + last_property_size, padding_size));
-                    }
-                }
-                //*/
-            }
-            else if (class_size > 0)
-            {
-                // No reflected member variables exist but there are non-reflected member variables
-                // Add padding for non-reflected member variables, for alignment purposes
-                auto padding_part_one = std::format(STR("{}char {}[0x{:X}];"), generate_tab(), std::format(STR("padding_{}"), num_padding_elements), class_size);
-                content_buffer.append(std::format(STR("{:85} // 0x0000 (size: 0x{:X})\n"), padding_part_one, 0x0));
-            }
-}
-
-        // Functions
-        if (native_class->HasChildren())
-        {
-            content_buffer.append(STR("\n"));
-            for (const auto& function_info : functions_to_generate)
-            {
-                generate_function_declaration(object_info, function_info, generated_file, content_buffer);
-            }
-        }
-
-        if (UE4SSProgram::settings_manager.CXXHeaderGenerator.DumpOffsetsAndSizes)
-        {
-            content_buffer.append(std::format(STR("}}; // Size: 0x{:X}\n\n"), class_size));
-        }
-        else
-        {
-            content_buffer.append(STR("};\n\n"));
-        }
-
-        current_class_content.append(content_buffer);
-        return native_class->GetFirstProperty();
-    }
-
-    auto CXXGenerator::generate_enum(UObject* native_object, GeneratedFile& generated_file) -> void
+    class LuaTypesGenerator
     {
-        generated_file.secondary_file_has_no_contents = false;
-
-        File::StringType content_buffer;
-        UEnum* uenum = static_cast<UEnum*>(native_object);
-        auto& enum_names = uenum->GetEnumNames();
-
-        const auto cpp_form = uenum->GetCppForm();
-        if (cpp_form == UEnum::ECppForm::Regular)
+    public:
+        auto get_file_extension() -> File::StringType
         {
-            content_buffer.append(std::format(STR("enum {} {{\n"), get_native_enum_name(uenum, false)));
+            return STR(".lua");
         }
-        else if (cpp_form == UEnum::ECppForm::Namespaced)
+        auto generate_file_header(GeneratedFile& generated_file) -> void
         {
-            content_buffer.append(std::format(STR("namespace {} {{\n{}enum Type {{\n"), get_native_enum_name(uenum, false), generate_tab()));
+            generated_file.primary_file.write_string_to_file(STR("---@meta\n\n"));
         }
-        else if (cpp_form == UEnum::ECppForm::EnumClass)
+        auto generate_file_footer(GeneratedFile& generated_file) -> void {}
+        auto generate_enum_declaration(File::StringType& content_buffer, UEnum* uenum) -> void
         {
-            content_buffer.append(std::format(STR("enum class {} {{\n"), get_native_enum_name(uenum, false)));
+            auto enum_name = uenum->GetName();
+            content_buffer.append(std::format(STR("---@enum {}\n{} = {{\n"), enum_name, enum_name));
         }
-
-        enum_names.ForEach([&](Unreal::FEnumNamePair* elem, size_t index) {
-            auto enum_value_full_name = elem->Key.ToString();
-            size_t colon_pos = enum_value_full_name.rfind(STR(":"));
-            auto enum_value_name = colon_pos == enum_value_full_name.npos ? enum_value_full_name : enum_value_full_name.substr(colon_pos + 1);
-
-            content_buffer.append(std::format(STR("{}{}{} = {},\n"), generate_tab(), cpp_form == UEnum::ECppForm::Namespaced ? generate_tab() : STR(""), enum_value_name, elem->Value));
-
-            return LoopAction::Continue;
-        });
-
-        content_buffer.append(std::format(STR("{}}};"), cpp_form == UEnum::ECppForm::Namespaced ? generate_tab() : STR("")));
-
-        if (cpp_form == UEnum::ECppForm::Namespaced)
+        auto generate_enum_member(File::StringType& content_buffer, UEnum* uenum, const File::StringType& enum_value_name, Unreal::FEnumNamePair* elem) -> void
         {
-            content_buffer.append(STR("\n}"));
+            content_buffer.append(std::format(STR("{}{} = {},\n"), generate_tab(), enum_value_name, elem->Value));
+        }
+        auto generate_enum_end(File::StringType& content_buffer, UEnum* uenum) -> void
+        {
+            content_buffer.append(STR("}"));
         }
 
-        content_buffer.append(STR("\n\n"));
-
-        generated_file.ordered_secondary_file_contents.push_back(content_buffer);
-    }
-
-    auto CXXGenerator::generate_package(UObject* package, File::StringType& out) -> void
-    {
-        UObjectGlobals::ForEachUObject([&](void* object, [[maybe_unused]]int32_t chunk_index, [[maybe_unused]]int32_t object_index) {
-            return LoopAction::Continue;
-        });
-    }
-
-    auto CXXGenerator::generate_package_if_non_existent(UObject* object) -> GeneratedFile*
-    {
-        UObject* package{};
-        UObject* outer = object;
-        if (!outer) { return nullptr; }
-
-        do
-        {
-            if (object_is_package(outer))
-            {
-                package = outer;
-                break;
-            }
-
-            outer = outer->GetOuterPrivate();
-        } while (outer);
-
-        if (!package)
-        {
-            throw std::runtime_error{"[generate_package_if_non_existent] Was unable to find UPackage for this object"};
+        auto should_generate_class(UStruct* native_class) {
+            // skip UObject to define externally
+            return native_class != UObject::StaticClass();
         }
+        auto generate_class(TypeGenerator<LuaTypesGenerator>* generator, ObjectInfo& object_info, GeneratedFile& generated_file, File::StringType& current_class_content)
+        {
+            UStruct* native_class = static_cast<UStruct*>(object_info.object);
+            File::StringType content_buffer{};
 
-        FName package_fname = package->GetNamePrivate();
-        if (m_files.contains(package_fname))
-        {
-            return &m_files.at(package_fname);
-        }
-        else
-        {
-            // Get rid of everything before the last slash + the last slash, leaving only the actual name
-            File::StringType package_name = package->GetNamePrivate().ToString();
-            package_name = package_name.substr(package_name.rfind(STR("/")) + 1);
-            File::StringType package_name_all_lower = package_name;
-            std::transform(package_name_all_lower.begin(), package_name_all_lower.end(), package_name_all_lower.begin(), [](File::CharType c) {
-                return std::towlower(c);
+            UStruct* inherits_from_class = native_class->GetSuperStruct();
+
+            // Make sure that the base class is defined
+            generator->generate_class_dependency(object_info, inherits_from_class, current_class_content);
+
+            // If any properties have dependencies, make sure that they are defined
+            // This makes sure that we don't have member variables with undefined types (if the types are local, otherwise we need to include the file that the struct exists in)
+            std::vector<PropertyInfo> properties_to_generate{};
+            native_class->ForEachProperty([&](XProperty* property) {
+                properties_to_generate.emplace_back(PropertyInfo{property, generator->generate_class_dependency_from_property(object_info, property, current_class_content)});
+                return LoopAction::Continue;
             });
 
-            if (m_file_names.contains(package_name_all_lower))
-            {
-                // File name collision
-                auto& file_name = m_file_names[package_name_all_lower];
-                package_name.append(std::format(STR("_DUPL_{}"), ++file_name.num_collisions));
-                Output::send(STR("File name collision, renamed to '{}'\n"), package_name);
-            }
-            else
-            {
-                m_file_names.emplace(package_name_all_lower, FileName{});
-            }
+            std::vector<FunctionInfo> functions_to_generate{};
+            native_class->ForEachFunction([&](UFunction* function) {
+                auto& function_info = functions_to_generate.emplace_back(FunctionInfo{function, object_info});
 
-            // The '\\?\' at the beginning of the string unlocks path size restriction from MAX_PATH to 32k
-            std::filesystem::path directory_to_generate_in = std::filesystem::path("\\\\?\\");
-            directory_to_generate_in += (m_directory_to_generate_in);
+                function->ForEachProperty([&](XProperty* param) {
+                    if (!param->HasAnyPropertyFlags(Unreal::CPF_Parm | Unreal::CPF_ReturnParm)) { return LoopAction::Continue; }
 
-            std::filesystem::path primary_file_path_and_name = directory_to_generate_in;
-            primary_file_path_and_name.append(package_name);
-            primary_file_path_and_name.replace_extension(".hpp");
-
-            std::filesystem::path secondary_file_path_and_name = directory_to_generate_in;
-            secondary_file_path_and_name.append(package_name + STR("_enums"));
-            secondary_file_path_and_name.replace_extension(".hpp");
-
-            GeneratedFile generated_file{
-                .primary_file_name = primary_file_path_and_name,
-                .secondary_file_name = secondary_file_path_and_name,
-                .ordered_primary_file_contents = {},
-                .ordered_secondary_file_contents = {},
-                .package_name = package_name,
-                .primary_file = {},
-                .secondary_file = {},
-                .primary_file_has_no_contents = true,
-                .secondary_file_has_no_contents = true,
-            };
-
-            auto& file_in_map = m_files.emplace(std::move(package_fname), std::move(generated_file)).first->second;
-            return &file_in_map;
-        }
-    }
-
-    auto CXXGenerator::cleanup_old_sdk() -> void
-    {
-        if (!std::filesystem::exists(m_directory_to_generate_in)) { return; }
-
-        for (const auto& item : std::filesystem::directory_iterator(m_directory_to_generate_in))
-        {
-            if (item.is_directory()) { continue; }
-            if (item.path().extension() != STR(".hpp")) { continue; }
-
-            File::delete_file(item.path());
-        }
-    }
-
-    auto CXXGenerator::generate() -> void
-    {
-        Output::send(STR("Cleaning up old SDK files...\n"));
-        cleanup_old_sdk();
-        Output::send(STR("Generating SDK...\n"));
-
-        // 400k should be enough for most games, and it's highly unlikely to cause more than one reallocation even if the game is huge
-        m_classes_dumped.reserve(400000);
-
-        size_t num_objects_generated{};
-        UObjectGlobals::ForEachUObject([&](void* untyped_object, [[maybe_unused]]int32_t chunk_index, [[maybe_unused]]int32_t object_index) {
-            UObject* object = static_cast<UObject*>(untyped_object);
-            UClass* object_class = object->GetClassPrivate();
-
-            // Generate file for package if it doesn't already exist
-            GeneratedFile* package_file = generate_package_if_non_existent(object);
-
-            if (!package_file)
-            {
-                // Object should not be dumped
+                    function_info.params.emplace_back(PropertyInfo{param, generator->generate_class_dependency_from_property(object_info, param, current_class_content)});
+                    return LoopAction::Continue;
+                });
                 return LoopAction::Continue;
-            }
-            else if (object->IsA<UEnum>())
-            {
-                generate_enum(object, *package_file);
-                ++num_objects_generated;
+            });
 
-                return LoopAction::Continue;
-            }
-            else if ((object_class->IsChildOf<UClass>() ||
-                      object_class->IsChildOf<UScriptStruct>()) &&
-                     !m_classes_dumped.contains(object))
+            auto class_name = generate_class_name(native_class);
+
+            generate_class_declaration(content_buffer, native_class, inherits_from_class);
+
+            int32_t num_padding_elements{0};
+            XProperty* last_property_in_this_class{nullptr};
+
+            for (const auto& property_info : properties_to_generate)
             {
-                // Generate a class for this object
-                auto& object_info = m_classes_dumped.emplace(object, ObjectInfo{object}).first->second;
-                File::StringType class_content{};
-                generate_class(object_info, *package_file, class_content);
-                if (!package_file->primary_file_has_no_contents)
+                XProperty* property = property_info.property;
+                int32_t current_property_offset = property->GetOffset_Internal();
+                int32_t current_property_size = property->GetSize();
+
+                try
                 {
-                    package_file->ordered_primary_file_contents.push_back(class_content);
+                    const auto& property_name = property->GetName();
+                    if (property_name.find(' ') == File::StringType::npos) {
+                        content_buffer.append(std::format(STR("---@field {} {}\n"), property_name, generate_property_lua_name(property, true, native_class)));
+                    } else {
+                        content_buffer.append(std::format(STR("---@field ['{}'] {}\n"), property_name, generate_property_lua_name(property, true, native_class)));
+                    }
                 }
-                ++num_objects_generated;
+                catch (std::exception& e)
+                {
+                    Output::send<LogLevel::Warning>(STR("Could not generate property '{}' because: {}\n"), property->GetFullName(), to_wstring(e.what()));
+                    continue;
+                }
 
-                return LoopAction::Continue;
+                // TODO: Lua delegates
+
+                last_property_in_this_class = property;
+            }
+
+            int32_t class_size = native_class->GetPropertiesSize();
+            generate_class_struct_end(content_buffer, class_name, class_size, num_padding_elements, last_property_in_this_class);
+
+            // Functions
+            if (native_class->HasChildren())
+            {
+                content_buffer.append(STR("\n"));
+                for (const auto& function_info : functions_to_generate)
+                {
+                    generator->generate_function_declaration(object_info, function_info, generated_file, content_buffer);
+                }
+            }
+
+            generate_class_end(content_buffer, class_size);
+
+            content_buffer.append(STR("\n\n"));
+
+            current_class_content.append(content_buffer);
+        }
+        auto generate_class_declaration(File::StringType& content_buffer, UStruct* native_class, UStruct* inherits_from_class) -> void
+        {
+            auto class_name = generate_class_name(native_class);
+            if (inherits_from_class)
+            {
+                content_buffer.append(std::format(STR("---@class {} : {}\n"), class_name, generate_class_name(inherits_from_class)));
             }
             else
             {
-                // Object should not be dumped
-                return LoopAction::Continue;
+                content_buffer.append(std::format(STR("---@class {}\n"), class_name));
             }
-        });
+        }
+        auto generate_class_struct_end(File::StringType& content_buffer,
+                const File::StringType& class_name,
+                size_t class_size,
+                int32_t num_padding_elements,
+                XProperty* last_property_in_this_class) -> void
+        {
+            content_buffer.append(std::format(STR("{} = {{}}\n"), class_name));
+        }
+        auto generate_class_end(File::StringType& content_buffer, size_t class_size) -> void
+        {
+        }
 
-        create_all_files();
+        auto generate_function_declaration(TypeGenerator<LuaTypesGenerator>* generator,
+                File::StringType& current_class_content,
+                ObjectInfo& owner,
+                const FunctionInfo& function_info,
+                File::StringType function_name,
+                XProperty* return_property,
+                std::optional<PropertyInfo> return_property_info) -> void
+        {
+            for (size_t i = 0; i < function_info.params.size(); ++i)
+            {
+                const auto& param_info = function_info.params[i];
+                if (!param_info.property->HasAnyPropertyFlags(Unreal::CPF_ReturnParm))
+                {
+                    try
+                    {
+                        auto param_name = param_info.property->GetName();
+                        std::replace(param_name.begin(), param_name.end(), ' ', '_'); // TODO disambiguate renames
+                        current_class_content.append(std::format(STR("---@param {} {}\n"), param_name, generate_property_lua_name(param_info.property, true, function_info.function)));
+                    }
+                    catch (std::exception& e)
+                    {
+                        Output::send<LogLevel::Warning>(STR("Could not generate function '{}' because: {}\n"), function_info.function->GetFullName(), to_wstring(e.what()));
+                        return;
+                    }
+                }
+            }
+
+            if (return_property)
+            {
+                try
+                {
+                    current_class_content.append(std::format(STR("---@return {}\n"), generate_property_lua_name(return_property, true, function_info.function)));
+                }
+                catch (std::exception& e)
+                {
+                    Output::send<LogLevel::Warning>(STR("Could not generate function '{}' because: {}\n"), function_info.function->GetFullName(), to_wstring(e.what()));
+                    return;
+                }
+            }
+
+            auto class_name = generate_class_name(static_cast<UStruct*>(owner.object));
+
+            // check if the name contains spaces and use alternative function form
+            // TODO figure what exactly is a valid lua symbol
+            if (function_name.find(' ') == File::StringType::npos)
+            {
+                current_class_content.append(std::format(STR("function {}:{}("), class_name, function_name));
+            }
+            else
+            {
+                current_class_content.append(std::format(STR("{}['{}'] = function("), class_name, function_name));
+            }
+
+            for (size_t i = 0; i < function_info.params.size(); ++i)
+            {
+                const auto& param_info = function_info.params[i];
+                if (!param_info.property->HasAnyPropertyFlags(Unreal::CPF_ReturnParm))
+                {
+                    auto param_name = param_info.property->GetName();
+                    std::replace(param_name.begin(), param_name.end(), ' ', '_'); // TODO disambiguate renames
+                    current_class_content.append(std::format(STR("{}"), param_name));
+
+                    if (i + 1 < function_info.params.size())
+                    {
+                        auto* next_param = function_info.params[i + 1].property;
+                        if (next_param && (!next_param->HasAnyPropertyFlags(Unreal::CPF_ReturnParm) || i + 2 < function_info.params.size()))
+                        {
+                            current_class_content.append(STR(", "));
+                        }
+                    }
+                }
+            }
+            current_class_content.append(STR(") end"));
+        }
+    };
+
+    auto generate_cxx_headers(const std::filesystem::path directory_to_generate_in) -> void
+    {
+        TypeGenerator<CXXHeaderGenerator> generator{directory_to_generate_in};
+        generator.generate();
+    }
+
+    auto generate_lua_types(const std::filesystem::path directory_to_generate_in) -> void
+    {
+        TypeGenerator<LuaTypesGenerator> generator{directory_to_generate_in};
+        generator.generate();
     }
 }

--- a/src/UE4SSProgram.cpp
+++ b/src/UE4SSProgram.cpp
@@ -1071,8 +1071,34 @@ namespace RC
         {
             ScopedTimer generator_timer{&generator_duration};
 
-            UEGenerator::CXXGenerator cxx_generator{output_dir};
-            cxx_generator.generate();
+            UEGenerator::generate_cxx_headers(output_dir);
+
+            Output::send(STR("Unloading all forcefully loaded assets\n"));
+        }
+
+        UAssetRegistry::FreeAllForcefullyLoadedAssets();
+        Output::send(STR("SDK generated in {} seconds.\n"), generator_duration);
+    }
+
+    auto UE4SSProgram::generate_lua_types(const std::filesystem::path& output_dir) -> void
+    {
+        if (settings_manager.CXXHeaderGenerator.LoadAllAssetsBeforeGeneratingCXXHeaders)
+        {
+            Output::send(STR("Loading all assets...\n"));
+            double asset_loading_duration{};
+            {
+                ScopedTimer loading_timer{&asset_loading_duration};
+
+                UAssetRegistry::LoadAllAssets();
+            }
+            Output::send(STR("Loading all assets took {} seconds\n"), asset_loading_duration);
+        }
+
+        double generator_duration;
+        {
+            ScopedTimer generator_timer{&generator_duration};
+
+            UEGenerator::generate_lua_types(output_dir);
 
             Output::send(STR("Unloading all forcefully loaded assets\n"));
         }


### PR DESCRIPTION
https://user-images.githubusercontent.com/1144160/233905258-a7438c1b-8d67-4b99-8cf7-b19f883a2cd7.mp4

Adds Lua type definitions to be used by a [lua language server](https://marketplace.visualstudio.com/items?itemName=sumneko.lua).

[Annotation reference](https://github.com/LuaLS/lua-language-server/wiki/Annotations)

I decided to extend the existing CXXGenerator to generate Lua definitions as opposed to create an entirely new generator because they are more similar than they are different. I figured any quirks with how UE objects are accessed would be easier to keep updated if they weren't split between two different generators. The conditionals everywhere are undeniably ugly, however. Perhaps templates could be used to specify language at compile time? Or create intermediate structures to pass to specialized generators so the generators aren't operating directly on UE types? My experience with C++ is still quite limited so very welcome to feedback.

There are still many rough edges:
 - poor handling of properties and functions containing invalid characters
 - complex UE types
 - limited support of generics by the Lua LSP
 - probably many errors in my hasty, manual porting of the API document to Lua
 - need to implement helper functions with explicit types to get common objects
 
Usage is as simple as launching UE4SS and clicking the "Generate Lua Types" button which drops them into the `Mods/shared/types` directory. They will be picked up automatically by the LSP. Enums can be used too, but they must be `require()`'d so their values are available at runtime.