### PR TITLE
Add specifying of load order for mods used by BPModLoaderMod

### DIFF
--- a/Staging/Mods/BPModLoaderMod/Scripts/main.lua
+++ b/Staging/Mods/BPModLoaderMod/Scripts/main.lua
@@ -11,6 +11,10 @@ package.path = '.\\Mods\\ModLoaderMod\\?.lua;' .. package.path
 package.path = '.\\Mods\\ModLoaderMod\\BPMods\\?.lua;' .. package.path
 
 Mods = {}
+OrderedMods = {}
+
+-- Contains mod names from Mods/logicmods.txt and is used to determine the load order of LogicMods.
+ModOrderList = {}
 
 local DefualtModConfig = {}
 DefualtModConfig.AssetName = "ModActor_C"
@@ -30,6 +34,96 @@ function Explode(String, Delimiter)
     table.insert(ExplodedString, string.sub(String, Iterator))
 
     return ExplodedString
+end
+
+-- Checks if the beginning of a string contains a certain pattern.
+function StartsWith(String, StringToCompare)
+    return string.sub(String,1,string.len(StringToCompare))==StringToCompare
+end
+
+function FileExists(file)
+    local f = io.open(file, "rb")
+    if f then f:close() end
+    return f ~= nil
+end
+
+-- Reads lines from the specified file and returns a table of lines read. 
+-- Second argument takes a string that can be used to exclude lines starting with that string. Default ;
+function LinesFrom(file, ignoreLinesStartingWith)
+    if not FileExists(file) then return {} end
+
+    if ignoreLinesStartingWith == nil then 
+        ignoreLinesStartingWith = ";"
+    end
+
+    local lines = {}
+    for line in io.lines(file) do 
+      if not StartsWith(line, ignoreLinesStartingWith) then
+        lines[#lines + 1] = line
+      end
+    end
+    return lines
+end
+
+-- Loads mod order data from logicmods.txt and pushes it into ModOrderList.
+function LoadModOrder()
+    local file = 'Mods/logicmods.txt'
+    local lines = LinesFrom(file)
+
+    local entriesAdded = 0
+
+    for _, line in pairs(lines) do
+        ModAlreadyExists = false
+        for _, ModName in pairs(ModOrderList) do
+            if ModName == line then
+                ModAlreadyExists = true
+            end
+        end
+        -- Checks for double mod entries in the file and if a mod was already included, skip it.
+        if not ModAlreadyExists then
+            table.insert(ModOrderList, line)
+            entriesAdded = entriesAdded + 1
+        end
+    end
+
+    if entriesAdded <= 0 then
+        Log(string.format("Mods/logicmods.txt not present or no matching mods, loading all LogicMods in random order."))
+    end
+end
+
+function SetupModOrder()
+    local Priority = 1
+
+    -- Adds priority mods first by their respective order as specified in logicmods.txt
+    for _, ModOrderEntry in pairs(ModOrderList) do
+        for ModName, ModInfo in pairs(Mods) do
+            if type(ModInfo) == "table" then
+                if ModOrderEntry == ModName then
+                    OrderedMods[Priority] = ModInfo
+                    OrderedMods[Priority].Name = ModName
+                    OrderedMods[Priority].Priority = Priority
+                    Priority = Priority + 1
+                end
+            end
+        end
+    end
+
+    -- Adds the remaining mods in a random order after the prioritized mods.
+    for ModName, ModInfo in pairs(Mods) do
+        ModAlreadyIncluded = false
+        for _, OrderedModInfo in ipairs(OrderedMods) do
+            if type(OrderedModInfo) == "table" then
+                if OrderedModInfo.Name == ModName then
+                    ModAlreadyIncluded = true
+                end
+            end
+        end
+
+        if not ModAlreadyIncluded then
+            ModInfo.Name = ModName
+            table.insert(OrderedMods, ModInfo)
+        end
+    end
 end
 
 function LoadModConfigs()
@@ -76,12 +170,16 @@ function LoadModConfigs()
             Mods[ModNameNoExtension].AssetPath = string.format("/Game/Mods/%s/ModActor", ModNameNoExtension)
         end
     end
+
+    LoadModOrder()
+
+    SetupModOrder()
 end
 
 LoadModConfigs()
 
-for k,v in pairs(Mods) do
-    Log(string.format("%s == %s\n", k, v))
+for _,v in ipairs(OrderedMods) do
+    Log(string.format("%s == %s\n", v.Name, v))
     if type(v) == "table" then
         for k2,v2 in pairs(v) do
             Log(string.format("    %s == %s\n", k2, v2))
@@ -93,7 +191,12 @@ local AssetRegistryHelpers = nil
 local AssetRegistry = nil
 
 function LoadMod(ModName, ModInfo, GameMode)
-    Log(string.format("Loading mod: %s\n", ModName))
+    if ModInfo.Priority ~= nil then
+        Log(string.format("Loading mod [Priority: #%i]: %s\n", ModInfo.Priority, ModName))
+    else
+        Log(string.format("Loading mod: %s\n", ModName))
+    end
+
     if ModInfo.AssetPath == nil or ModInfo.AssetPath == nil then
         Log(string.format("Could not load mod '%s' because it has no asset path or name.\n", ModName))
     end
@@ -153,9 +256,9 @@ end
 
 function LoadMods(GameMode)
     CacheAssetRegistry()
-    for ModName, ModInfo in pairs(Mods) do
+    for _, ModInfo in ipairs(OrderedMods) do
         if type(ModInfo) == "table" then
-            LoadMod(ModName, ModInfo, GameMode)
+            LoadMod(ModInfo.Name, ModInfo, GameMode)
         end
     end
 end
@@ -166,7 +269,7 @@ end)
 
 RegisterBeginPlayPostHook(function(ContextParam)
     local Context = ContextParam:get()
-    for _,ModConfig in pairs(Mods) do
+    for _,ModConfig in ipairs(OrderedMods) do
         if Context:GetClass():GetFName() ~= ModConfig.AssetNameAsFName then return end
         local PostBeginPlay = Context.PostBeginPlay
         if PostBeginPlay:IsValid() then
@@ -200,4 +303,3 @@ end)
 RegisterCustomEvent("GetPersistentObject", function(ParamContext, ParamModName)
     -- TODO: Implement.
 end)
-

--- a/Staging/Mods/logicmods.txt
+++ b/Staging/Mods/logicmods.txt
@@ -1,0 +1,2 @@
+; You only have to include mods where load order matters, mods not included here will be loaded in any random order after loading the prioritized mods.
+; Add your LogicMods below by their name without .pak at the end. LogicMods will be loaded in top to bottom order.

--- a/StagingDev/Mods/BPModLoaderMod/Scripts/main.lua
+++ b/StagingDev/Mods/BPModLoaderMod/Scripts/main.lua
@@ -11,6 +11,10 @@ package.path = '.\\Mods\\ModLoaderMod\\?.lua;' .. package.path
 package.path = '.\\Mods\\ModLoaderMod\\BPMods\\?.lua;' .. package.path
 
 Mods = {}
+OrderedMods = {}
+
+-- Contains mod names from Mods/logicmods.txt and is used to determine the load order of LogicMods.
+ModOrderList = {}
 
 local DefualtModConfig = {}
 DefualtModConfig.AssetName = "ModActor_C"
@@ -30,6 +34,96 @@ function Explode(String, Delimiter)
     table.insert(ExplodedString, string.sub(String, Iterator))
 
     return ExplodedString
+end
+
+-- Checks if the beginning of a string contains a certain pattern.
+function StartsWith(String, StringToCompare)
+    return string.sub(String,1,string.len(StringToCompare))==StringToCompare
+end
+
+function FileExists(file)
+    local f = io.open(file, "rb")
+    if f then f:close() end
+    return f ~= nil
+end
+
+-- Reads lines from the specified file and returns a table of lines read. 
+-- Second argument takes a string that can be used to exclude lines starting with that string. Default ;
+function LinesFrom(file, ignoreLinesStartingWith)
+    if not FileExists(file) then return {} end
+
+    if ignoreLinesStartingWith == nil then 
+        ignoreLinesStartingWith = ";"
+    end
+
+    local lines = {}
+    for line in io.lines(file) do 
+      if not StartsWith(line, ignoreLinesStartingWith) then
+        lines[#lines + 1] = line
+      end
+    end
+    return lines
+end
+
+-- Loads mod order data from logicmods.txt and pushes it into ModOrderList.
+function LoadModOrder()
+    local file = 'Mods/logicmods.txt'
+    local lines = LinesFrom(file)
+
+    local entriesAdded = 0
+
+    for _, line in pairs(lines) do
+        ModAlreadyExists = false
+        for _, ModName in pairs(ModOrderList) do
+            if ModName == line then
+                ModAlreadyExists = true
+            end
+        end
+        -- Checks for double mod entries in the file and if a mod was already included, skip it.
+        if not ModAlreadyExists then
+            table.insert(ModOrderList, line)
+            entriesAdded = entriesAdded + 1
+        end
+    end
+
+    if entriesAdded <= 0 then
+        Log(string.format("Mods/logicmods.txt not present or no matching mods, loading all LogicMods in random order."))
+    end
+end
+
+function SetupModOrder()
+    local Priority = 1
+
+    -- Adds priority mods first by their respective order as specified in logicmods.txt
+    for _, ModOrderEntry in pairs(ModOrderList) do
+        for ModName, ModInfo in pairs(Mods) do
+            if type(ModInfo) == "table" then
+                if ModOrderEntry == ModName then
+                    OrderedMods[Priority] = ModInfo
+                    OrderedMods[Priority].Name = ModName
+                    OrderedMods[Priority].Priority = Priority
+                    Priority = Priority + 1
+                end
+            end
+        end
+    end
+
+    -- Adds the remaining mods in a random order after the prioritized mods.
+    for ModName, ModInfo in pairs(Mods) do
+        ModAlreadyIncluded = false
+        for _, OrderedModInfo in ipairs(OrderedMods) do
+            if type(OrderedModInfo) == "table" then
+                if OrderedModInfo.Name == ModName then
+                    ModAlreadyIncluded = true
+                end
+            end
+        end
+
+        if not ModAlreadyIncluded then
+            ModInfo.Name = ModName
+            table.insert(OrderedMods, ModInfo)
+        end
+    end
 end
 
 function LoadModConfigs()
@@ -76,12 +170,16 @@ function LoadModConfigs()
             Mods[ModNameNoExtension].AssetPath = string.format("/Game/Mods/%s/ModActor", ModNameNoExtension)
         end
     end
+
+    LoadModOrder()
+
+    SetupModOrder()
 end
 
 LoadModConfigs()
 
-for k,v in pairs(Mods) do
-    Log(string.format("%s == %s\n", k, v))
+for _,v in ipairs(OrderedMods) do
+    Log(string.format("%s == %s\n", v.Name, v))
     if type(v) == "table" then
         for k2,v2 in pairs(v) do
             Log(string.format("    %s == %s\n", k2, v2))
@@ -93,7 +191,12 @@ local AssetRegistryHelpers = nil
 local AssetRegistry = nil
 
 function LoadMod(ModName, ModInfo, GameMode)
-    Log(string.format("Loading mod: %s\n", ModName))
+    if ModInfo.Priority ~= nil then
+        Log(string.format("Loading mod [Priority: #%i]: %s\n", ModInfo.Priority, ModName))
+    else
+        Log(string.format("Loading mod: %s\n", ModName))
+    end
+
     if ModInfo.AssetPath == nil or ModInfo.AssetPath == nil then
         Log(string.format("Could not load mod '%s' because it has no asset path or name.\n", ModName))
     end
@@ -153,9 +256,9 @@ end
 
 function LoadMods(GameMode)
     CacheAssetRegistry()
-    for ModName, ModInfo in pairs(Mods) do
+    for _, ModInfo in ipairs(OrderedMods) do
         if type(ModInfo) == "table" then
-            LoadMod(ModName, ModInfo, GameMode)
+            LoadMod(ModInfo.Name, ModInfo, GameMode)
         end
     end
 end
@@ -166,7 +269,7 @@ end)
 
 RegisterBeginPlayPostHook(function(ContextParam)
     local Context = ContextParam:get()
-    for _,ModConfig in pairs(Mods) do
+    for _,ModConfig in ipairs(OrderedMods) do
         if Context:GetClass():GetFName() ~= ModConfig.AssetNameAsFName then return end
         local PostBeginPlay = Context.PostBeginPlay
         if PostBeginPlay:IsValid() then
@@ -200,4 +303,3 @@ end)
 RegisterCustomEvent("GetPersistentObject", function(ParamContext, ParamModName)
     -- TODO: Implement.
 end)
-

--- a/StagingDev/Mods/logicmods.txt
+++ b/StagingDev/Mods/logicmods.txt
@@ -1,0 +1,2 @@
+; You only have to include mods where load order matters, mods not included here will be loaded in any random order after loading the prioritized mods.
+; Add your LogicMods below by their name without .pak at the end. LogicMods will be loaded in top to bottom order.


### PR DESCRIPTION
Adds a way to specify in what order LogicMods should be loaded with BPModLoaderMod.

Load order of the mods can be specified in logicmods.txt found in the Mods folder. Example below:
```
SomeMod
AnotherMod
```
'SomeMod' will be loaded first and 'AnotherMod' will be loaded second, any mods that weren't included in the file will be loaded in random order _after_ SomeMod and AnotherMod.

This is useful in cases where a mod relies on another mod being loaded first, for example, utility mods.