### PR TITLE
Expose ImGui tab creation to CppMods

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,6 +291,7 @@ set(${TARGET}_Sources
         "${CMAKE_CURRENT_SOURCE_DIR}/src/SDKGenerator/TMapOverrideGen.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/USMapGenerator/Generator.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/GUI/GUI.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/GUI/GUITab.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/GUI/DX11.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/GUI/GLFW3_OpenGL3.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/GUI/Windows.cpp"

--- a/include/GUI/GUI.hpp
+++ b/include/GUI/GUI.hpp
@@ -7,11 +7,14 @@
 
 #include <GUI/Console.hpp>
 #include <GUI/LiveView.hpp>
+#include <GUI/GUITab.hpp>
 #include <Helpers/String.hpp>
 #include <imgui.h>
 
 namespace RC::GUI
 {
+    class GUITab; // dunno why forward declaration is necessary
+
     enum class GfxBackend
     {
         DX11,
@@ -145,6 +148,8 @@ namespace RC::GUI
         std::stop_token m_thread_stop_token{};
         bool m_is_open{};
         bool m_exit_requested{};
+        std::vector<std::shared_ptr<GUITab>> m_tabs;
+        std::mutex m_tabs_mutex;
 
     public:
         bool m_event_thread_busy{};
@@ -163,6 +168,8 @@ namespace RC::GUI
         auto get_console() -> Console& { return m_console; };
         auto get_live_view() -> LiveView& { return m_live_view; };
         auto set_gfx_backend(GfxBackend) -> void;
+        auto add_tab(std::shared_ptr<GUITab> tab) -> void;
+        auto remove_tab(std::shared_ptr<GUITab> tab) -> void;
 
     private:
         auto on_update() -> void;

--- a/include/GUI/GUITab.hpp
+++ b/include/GUI/GUITab.hpp
@@ -1,0 +1,24 @@
+#ifndef UE4SS_GUITAB_HPP
+#define UE4SS_GUITAB_HPP
+
+#include <File/Macros.hpp>
+#include <GUI/GUI.hpp>
+
+namespace RC::GUI
+{
+    class GUITab
+    {
+    friend class DebuggingGUI;
+
+    protected:
+        StringType TabName{};
+
+    public:
+        GUITab() = default;
+        ~GUITab() = default;
+
+        virtual auto render() -> void {}
+    };
+}
+
+#endif // UE4SS_GUITAB_HPP

--- a/include/UE4SSProgram.hpp
+++ b/include/UE4SSProgram.hpp
@@ -20,6 +20,17 @@
 #include <GUI/GUI.hpp>
 #include <GUI/GUITab.hpp>
 
+// Used to set up ImGui context and allocator in DLL mods
+#define UE4SS_ENABLE_IMGUI() \
+{ \
+    ImGui::SetCurrentContext(UE4SSProgram::get_current_imgui_context()); \
+    ImGuiMemAllocFunc alloc_func{}; \
+    ImGuiMemFreeFunc free_func{}; \
+    void* user_data{}; \
+    UE4SSProgram::get_current_imgui_allocator_functions(&alloc_func, &free_func, &user_data); \
+    ImGui::SetAllocatorFunctions(alloc_func, free_func, user_data); \
+}
+
 namespace RC
 {
     namespace Unreal

--- a/include/UE4SSProgram.hpp
+++ b/include/UE4SSProgram.hpp
@@ -18,6 +18,7 @@
 #include <LuaLibrary.hpp>
 #include <DynamicOutput/DynamicOutput.hpp>
 #include <GUI/GUI.hpp>
+#include <GUI/GUITab.hpp>
 
 namespace RC
 {
@@ -159,6 +160,16 @@ namespace RC
             return m_debugging_gui;
         };
         auto stop_render_thread() -> void;
+        RC_UE4SS_API auto add_gui_tab(std::shared_ptr<GUI::GUITab> tab) -> void;
+        RC_UE4SS_API auto remove_gui_tab(std::shared_ptr<GUI::GUITab> tab) -> void;
+        RC_UE4SS_API static auto get_current_imgui_context() -> ImGuiContext*
+        {
+            return ImGui::GetCurrentContext();
+        }
+        RC_UE4SS_API static auto get_current_imgui_allocator_functions(ImGuiMemAllocFunc* alloc_func, ImGuiMemFreeFunc* free_func, void** user_data) -> void
+        {
+            return ImGui::GetAllocatorFunctions(alloc_func, free_func, user_data);
+        }
         RC_UE4SS_API auto queue_event(EventCallable callable, void* data) -> void;
         RC_UE4SS_API auto is_queue_empty() -> bool;
         RC_UE4SS_API auto can_process_events() -> bool

--- a/src/GUI/GUI.cpp
+++ b/src/GUI/GUI.cpp
@@ -145,12 +145,14 @@ namespace RC::GUI
                     ImGui::EndTabItem();
                 }
 
-                std::lock_guard<std::mutex> guard(m_tabs_mutex);
-                for (const auto& tab : m_tabs)
                 {
-                    if (ImGui::BeginTabItem(to_string(tab->TabName).c_str()))
+                    std::lock_guard<std::mutex> guard(m_tabs_mutex);
+                    for (const auto& tab : m_tabs)
                     {
-                        tab->render();
+                        if (ImGui::BeginTabItem(to_string(tab->TabName).c_str()))
+                        {
+                            tab->render();
+                        }
                     }
                 }
 

--- a/src/GUI/GUI.cpp
+++ b/src/GUI/GUI.cpp
@@ -144,6 +144,16 @@ namespace RC::GUI
                     BPMods::render();
                     ImGui::EndTabItem();
                 }
+
+                std::lock_guard<std::mutex> guard(m_tabs_mutex);
+                for (const auto& tab : m_tabs)
+                {
+                    if (ImGui::BeginTabItem(to_string(tab->TabName).c_str()))
+                    {
+                        tab->render();
+                    }
+                }
+
                 ImGui::EndTabBar();
                 if (!is_unreal_initialized) { ImGui::EndDisabled(); }
             }
@@ -302,6 +312,17 @@ namespace RC::GUI
         m_os_backend->set_gfx_backend(m_gfx_backend.get());
         m_gfx_backend->on_os_backend_set();
         m_os_backend->on_gfx_backend_set();
+    }
+
+    auto DebuggingGUI::add_tab(std::shared_ptr<GUITab> tab) -> void
+    {
+        std::lock_guard<std::mutex> guard(m_tabs_mutex);
+        m_tabs.push_back(tab);
+    }
+    auto DebuggingGUI::remove_tab(std::shared_ptr<GUITab> tab) -> void
+    {
+        std::lock_guard<std::mutex> guard(m_tabs_mutex);
+        m_tabs.erase(std::remove(m_tabs.begin(), m_tabs.end(), tab), m_tabs.end());
     }
 
     DebuggingGUI::~DebuggingGUI()

--- a/src/GUI/GUITab.cpp
+++ b/src/GUI/GUITab.cpp
@@ -1,0 +1,1 @@
+#include <GUI/GUITab.hpp>

--- a/src/UE4SSProgram.cpp
+++ b/src/UE4SSProgram.cpp
@@ -152,12 +152,8 @@ namespace RC
             // Setup the log file
             auto& file_device = Output::set_default_devices<Output::NewFileDevice>();
             file_device.set_file_name_and_path(m_log_directory / m_log_file_name);
-            
-            create_simple_console();
 
-            setup_mods();
-            install_cpp_mods();
-            start_cpp_mods();
+            create_simple_console();
 
             if (settings_manager.Debug.DebugConsoleEnabled)
             {
@@ -193,6 +189,10 @@ namespace RC
 #else
             Output::send(STR("WITH_CASE_PRESERVING_NAME: No\n\n"));
 #endif
+
+            setup_mods();
+            install_cpp_mods();
+            start_cpp_mods();
 
             setup_mod_directory_path();
 
@@ -1155,6 +1155,16 @@ namespace RC
             m_render_thread.request_stop();
             m_render_thread.join();
         }
+    }
+
+    auto UE4SSProgram::add_gui_tab(std::shared_ptr<GUI::GUITab> tab) -> void
+    {
+        m_debugging_gui.add_tab(tab);
+    }
+
+    auto UE4SSProgram::remove_gui_tab(std::shared_ptr<GUI::GUITab> tab) -> void
+    {
+        m_debugging_gui.remove_tab(tab);
     }
 
     auto UE4SSProgram::queue_event(EventCallable callable, void* data) -> void


### PR DESCRIPTION
I took a quick stab at #110. Some things to note:

1. I put `DebuggingGUI::m_tabs` behind a mutex to be safe, though this means tabs won't be able to add other tabs in the middle of a frame. Perhaps queuing new tabs up to add at the end of a frame would be better?
2. I moved mod setup to after console creation so the GUI would be available in the mod constructor. Assuming this doesn't break something else, this seems better than utilizing `on_program_start` as it is only run at UE4SS startup and doesn't run again for mod restarts.
3. I've included a hack that allows the mod .dll file to be swapped and reloaded, allowing hot reloading on my system using WINE. I thought very little about how sound it is and wouldn't actually include it, but it's nice for testing purposes.

I've got a test mod here: https://github.com/trumank/ue4ss-scratch/blob/20035c1dddd8b7f76686e408da34a8c2068dcab8/MyAwesomeMod/dllmain.cpp