### PR TITLE
Fix Mod destructors not getting called

### DIFF
--- a/include/Mod/CppMod.hpp
+++ b/include/Mod/CppMod.hpp
@@ -27,7 +27,7 @@ namespace RC
         CppMod(UE4SSProgram&, std::wstring&& mod_name, std::wstring&& mod_path);
         CppMod(CppMod&) = delete;
         CppMod(CppMod&&) = delete;
-        ~CppMod();
+        ~CppMod() override;
 
     public:
         auto start_mod() -> void override;

--- a/include/Mod/LuaMod.hpp
+++ b/include/Mod/LuaMod.hpp
@@ -115,7 +115,7 @@ namespace RC
 
     public:
         LuaMod(UE4SSProgram&, std::wstring&& mod_name, std::wstring&& mod_path);
-        ~LuaMod() = default;
+        ~LuaMod() override = default;
 
     private:
         auto start_async_thread() -> void

--- a/include/Mod/Mod.hpp
+++ b/include/Mod/Mod.hpp
@@ -48,7 +48,7 @@ namespace RC
 
     public:
         Mod(UE4SSProgram&, std::wstring&& mod_name, std::wstring&& mod_path);
-        ~Mod() = default;
+        virtual ~Mod() = default;
 
     public:
         auto get_name() const -> std::wstring_view;


### PR DESCRIPTION
This fixes CppMod not freeing the library and being unable to hot reload.