### PR TITLE
Initial generators+views implementation

### DIFF
--- a/Dependencies/Constructs/include/Constructs/Generator.hpp
+++ b/Dependencies/Constructs/include/Constructs/Generator.hpp
@@ -1,0 +1,163 @@
+#ifndef UE4SS_REWRITTEN_GENERATOR_HPP
+#define UE4SS_REWRITTEN_GENERATOR_HPP
+
+#include <algorithm>
+#include <coroutine>
+#include <ranges>
+#include <algorithm>
+#include <numeric>
+#include <vector>
+
+namespace RC
+{
+    template<typename T>
+    struct Generator
+    {
+        struct promise_type;
+        using handle_type = std::coroutine_handle<promise_type>;
+        using iterator_category = std::input_iterator_tag;
+        using value_type = T;
+        using difference_type = ptrdiff_t;
+        using pointer = T const*;
+        using reference = T const&;
+
+        struct promise_type
+        {
+            T value;
+
+            auto get_return_object() -> Generator
+            {
+                return Generator(handle_type::from_promise(*this));
+            }
+
+            auto initial_suspend() -> std::suspend_always
+            {
+                return {};
+            }
+            auto final_suspend() noexcept -> std::suspend_always
+            {
+                return {};
+            }
+            auto unhandled_exception() -> void
+            {}
+
+            template<std::convertible_to<T> From>
+            auto yield_value(From&& from) -> std::suspend_always
+            {
+                value = std::forward<From>(from);
+                return {};
+            }
+
+            auto return_void() -> void
+            {}
+        };
+
+        struct iterator
+        {
+            using iterator_category = std::input_iterator_tag;
+            using value_type = T;
+            using difference_type = ptrdiff_t;
+            using pointer = T const*;
+            using reference = T const&;
+
+            iterator() = default;
+            constexpr explicit iterator(handle_type handle) : handle(handle)
+            {}
+
+            constexpr auto operator==(const iterator& other) const -> bool
+            {
+                return handle == other.handle;
+            }
+
+            constexpr auto operator!=(const iterator& other) const -> bool
+            {
+                return !(*this == other);
+            }
+
+            auto operator++() -> iterator&
+            {
+                handle.resume();
+
+                if (handle.done()) { handle = nullptr; }
+
+                return *this;
+            }
+
+            auto operator++(int) -> iterator& {
+                iterator temp = *this;
+                *++this;
+                return temp;
+            }
+
+            auto operator*() const -> T const&
+            {
+                return handle.promise().value;
+            }
+
+            auto operator->() const -> T const*
+            {
+                return std::addressof(operator*());
+            }
+
+        private:
+            handle_type handle;
+        };
+
+        Generator(handle_type handle) : handle(handle)
+        {}
+        Generator(const Generator&) = delete;
+        Generator& operator=(const Generator&) = delete;
+
+        Generator(Generator&& other) noexcept : handle(other.handle)
+        {
+            other.handle = {};
+        }
+
+        Generator& operator=(const Generator&& other) noexcept
+        {
+            if (this != &other) {
+                if (handle) handle.destroy();
+                handle = other.handle;
+                other.handle = {};
+            }
+            return *this;
+        }
+
+        ~Generator()
+        {
+            if (handle) handle.destroy();
+        }
+
+        explicit operator bool()
+        {
+            handle();
+            return !handle.done();
+        }
+
+        T operator()()
+        {
+            handle();
+            return std::move(handle.promise().value);
+        }
+
+        auto begin() const -> iterator
+        {
+            if (!handle) return {};
+
+            handle.resume();
+
+            if (handle.done()) return {};
+
+            return iterator(handle);
+        }
+
+        auto end() const -> iterator
+        {
+            return {};
+        }
+    private:
+        handle_type handle;
+    };
+}
+
+#endif // UE4SS_REWRITTEN_GENERATOR_HPP

--- a/Dependencies/Constructs/include/Constructs/Views/EnumerateView.hpp
+++ b/Dependencies/Constructs/include/Constructs/Views/EnumerateView.hpp
@@ -1,0 +1,160 @@
+#ifndef UE4SS_REWRITTEN_ENUMERATEVIEW_HPP
+#define UE4SS_REWRITTEN_ENUMERATEVIEW_HPP
+
+#include <ranges>
+#include <type_traits>
+
+namespace RC
+{
+    template<std::ranges::input_range R>
+        requires std::ranges::view<R>
+    class EnumerateView : public std::ranges::view_interface<EnumerateView<R>>
+    {
+    public:
+        struct iterator;
+
+        struct iterator
+        {
+            using iterator_concept = std::conditional_t<
+                std::ranges::random_access_range<R>,
+                std::random_access_iterator_tag,
+                std::conditional_t<std::ranges::bidirectional_range<R>, std::bidirectional_iterator_tag, std::conditional_t<std::ranges::forward_range<R>, std::forward_iterator_tag, std::input_iterator_tag>>>;
+            using value_type = std::remove_cvref_t<std::ranges::range_reference_t<R>>;
+            using difference_type = std::ranges::range_difference_t<R>;
+
+            iterator() = default;
+            constexpr explicit iterator(std::ranges::iterator_t<R> base) : base_(base)
+            {}
+
+            constexpr auto operator++() -> iterator&
+            {
+                ++base_;
+                ++index;
+                return *this;
+            }
+
+            constexpr auto operator++(int) -> iterator
+            {
+                iterator tmp = *this;
+                ++*this;
+                return tmp;
+            }
+
+            constexpr auto operator--() -> iterator&
+                requires std::ranges::bidirectional_range<R>
+            {
+                --base_;
+                --index;
+                return *this;
+            }
+
+            constexpr auto operator--(int) -> iterator
+                requires std::ranges::bidirectional_range<R>
+            {
+                auto tmp = *this;
+                --*this;
+                return tmp;
+            }
+
+            constexpr auto operator+=(const difference_type offset) -> iterator&
+                requires std::ranges::random_access_range<R>
+            {
+                base_ += offset;
+                index += offset;
+                return *this;
+            }
+
+            constexpr auto operator-=(const difference_type offset) -> iterator&
+                requires std::ranges::random_access_range<R>
+            {
+                base_ -= offset;
+                index -= offset;
+                return *this;
+            }
+
+            constexpr auto operator==(const iterator& other) const -> bool
+            {
+                return base_ == other.base_;
+            }
+
+            constexpr auto operator!=(const iterator& other) const -> bool
+            {
+                return !(*this == other);
+            }
+
+            constexpr auto operator*() const -> std::pair<value_type, size_t>
+            {
+                return {*base_, index};
+            }
+
+        private:
+            std::ranges::iterator_t<R> base_{};
+            size_t index = 0;
+        };
+
+        EnumerateView()
+            requires std::default_initializable<R>
+        = default;
+        constexpr EnumerateView(R base) : base_(std::move(base)), iter_(std::begin(base_))
+        {}
+
+        constexpr R base() const&
+        {
+            return base_;
+        }
+        constexpr R base() &&
+        {
+            return std::move(base_);
+        }
+
+        constexpr auto begin()
+        {
+            return iterator(iter_);
+        }
+        constexpr auto end()
+        {
+            return iterator(std::ranges::end(base_));
+        }
+
+        constexpr auto size() const
+            requires std::ranges::sized_range<const R>
+        {
+            return std::ranges::size(base_);
+        }
+
+    private:
+        R base_{};
+        std::ranges::iterator_t<R> iter_{};
+    };
+
+    template<class R>
+    EnumerateView(R&& base) -> EnumerateView<std::views::all_t<R>>;
+
+    namespace details
+    {
+        struct EnumerateViewClosure
+        {
+            EnumerateViewClosure() = default;
+
+            template<std::ranges::viewable_range R>
+            constexpr auto operator()(R&& range) const noexcept
+            {
+                return EnumerateView(std::forward<R>(range));
+            }
+        };
+
+        template<std::ranges::viewable_range R>
+        constexpr auto operator|(R&& r, EnumerateViewClosure const& closure)
+        {
+            return closure(std::forward<R>(r));
+        }
+    }
+
+    namespace views
+    {
+        inline constexpr details::EnumerateViewClosure enumerate;
+    }
+}
+
+
+#endif // UE4SS_REWRITTEN_ENUMERATEVIEW_HPP

--- a/include/LuaType/LuaUObject.hpp
+++ b/include/LuaType/LuaUObject.hpp
@@ -6,6 +6,7 @@
 #include <format>
 #include <functional>
 
+#include <Constructs/Generator.hpp>
 #include <LuaMadeSimple/LuaObject.hpp>
 #include <Helpers/String.hpp>
 #include <DynamicOutput/DynamicOutput.hpp>

--- a/src/GUI/BPMods.cpp
+++ b/src/GUI/BPMods.cpp
@@ -81,10 +81,10 @@ namespace RC::GUI::BPMods
             auto mod_buttons = mod_buttons_property ? mod_buttons_property->ContainerPtrToValuePtr<TArray<FString>>(mod_actor) : nullptr;
             if (mod_buttons)
             {
-                mod_buttons->ForEach([&](FString* button_name) {
-                    mod_info.ModButtons.emplace_back(to_string(button_name->GetCharArray()));
-                    return LoopAction::Continue;
-                });
+                for (FString& button_name : *mod_buttons)
+                {
+                    mod_info.ModButtons.emplace_back(to_string(button_name.GetCharArray()));
+                }
             }
 
             auto mod_full_name = mod_class->GetFullName();

--- a/src/LuaType/LuaCustomProperty.cpp
+++ b/src/LuaType/LuaCustomProperty.cpp
@@ -50,17 +50,14 @@ namespace RC::LuaType
 
             if (!class_matches)
             {
-                ptr->ForEachSuperStruct([&](Unreal::UStruct* super_struct) {
+                for (Unreal::UStruct* super_struct : ptr->ForEachSuperStruct())
+                {
                     if (super_struct == owner_or_outer)
                     {
                         class_matches = true;
-                        return LoopAction::Break;
+                        break;
                     }
-                    else
-                    {
-                        return LoopAction::Continue;
-                    }
-                });
+                }
             }
 
             if (class_matches && property_name == property_item.m_name)

--- a/src/LuaType/LuaUEnum.cpp
+++ b/src/LuaType/LuaUEnum.cpp
@@ -77,7 +77,8 @@ Overloads:
 
             auto& lua_object = lua.get_userdata<UEnum>();
 
-            lua_object.get_remote_cpp_object()->ForEachName([&](Unreal::FName name, int64_t value) {
+            for (auto& [name, value] : lua_object.get_remote_cpp_object()->ForEachName())
+            {
                 // Duplicate the Lua function so that we can use it in subsequent iterations of this loop (call_function pops the function from the stack)
                 lua_pushvalue(lua.get_lua_state(), 1);
 
@@ -92,7 +93,7 @@ Overloads:
                 // We explicitly specify index 2 because we duplicated the function earlier and that's located at index 1.
                 if (lua.is_bool(2) && lua.get_bool(2))
                 {
-                    return LoopAction::Break;
+                    break;
                 }                else
                 {
                     // There's a 'nil' on the stack because we told Lua that we expect a return value.
@@ -100,9 +101,8 @@ Overloads:
                     // We discard the 'nil' here, otherwise the Lua stack is corrupted on the next iteration of the 'ForEachFunction' loop.
                     // We explicitly specify index 2 because we duplicated the function earlier and that's located at index 1.
                     lua.discard_value(2);
-                    return LoopAction::Continue;
                 }
-            });
+            }
 
             return 0;
         });

--- a/src/LuaType/LuaUStruct.cpp
+++ b/src/LuaType/LuaUStruct.cpp
@@ -66,7 +66,8 @@ namespace RC::LuaType
         table.add_pair("ForEachFunction", [](const LuaMadeSimple::Lua& lua) -> int {
             const auto& lua_object = lua.get_userdata<UStruct>();
 
-            lua_object.get_remote_cpp_object()->ForEachFunction([&](Unreal::UFunction* function) {
+            for (Unreal::UFunction* function : lua_object.get_remote_cpp_object()->ForEachFunction())
+            {
                 // Duplicate the Lua function so that we can use it in subsequent iterations of this loop (call_function pops the function from the stack)
                 lua_pushvalue(lua.get_lua_state(), 1);
 
@@ -76,10 +77,7 @@ namespace RC::LuaType
                 lua.call_function(1, 1);
 
                 // We explicitly specify index 2 because we duplicated the function earlier and that's located at index 1.
-                if (lua.is_bool(2) && lua.get_bool(2))
-                {
-                    return LoopAction::Break;
-                }
+                if (lua.is_bool(2) && lua.get_bool(2)) { break; }
                 else
                 {
                     // There's a 'nil' on the stack because we told Lua that we expect a return value.
@@ -87,9 +85,8 @@ namespace RC::LuaType
                     // We discard the 'nil' here, otherwise the Lua stack is corrupted on the next iteration of the 'ForEachFunction' loop.
                     // We explicitly specify index 2 because we duplicated the function earlier and that's located at index 1.
                     lua.discard_value(2);
-                    return LoopAction::Continue;
                 }
-            });
+            };
 
             return 1;
         });
@@ -97,7 +94,8 @@ namespace RC::LuaType
         table.add_pair("ForEachProperty", [](const LuaMadeSimple::Lua& lua) -> int {
             const auto& lua_object = lua.get_userdata<UStruct>();
 
-            lua_object.get_remote_cpp_object()->ForEachProperty([&](Unreal::FProperty* property) {
+            for (Unreal::FProperty* property : lua_object.get_remote_cpp_object()->ForEachProperty())
+            {
                 // Duplicate the Lua function so that we can use it in subsequent iterations of this loop (call_function pops the function from the stack)
                 lua_pushvalue(lua.get_lua_state(), 1);
 
@@ -107,10 +105,7 @@ namespace RC::LuaType
                 lua.call_function(1, 1);
 
                 // We explicitly specify index 2 because we duplicated the function earlier and that's located at index 1.
-                if (lua.is_bool(2) && lua.get_bool(2))
-                {
-                    return LoopAction::Break;
-                }
+                if (lua.is_bool(2) && lua.get_bool(2)) { break; }
                 else
                 {
                     // There's a 'nil' on the stack because we told Lua that we expect a return value.
@@ -118,9 +113,8 @@ namespace RC::LuaType
                     // We discard the 'nil' here, otherwise the Lua stack is corrupted on the next iteration of the 'ForEachFunction' loop.
                     // We explicitly specify index 2 because we duplicated the function earlier and that's located at index 1.
                     lua.discard_value(2);
-                    return LoopAction::Continue;
                 }
-            });
+            };
 
             return 1;
         });

--- a/src/Mod/LuaMod.cpp
+++ b/src/Mod/LuaMod.cpp
@@ -143,18 +143,19 @@ namespace RC
         {
             //int32_t current_param_offset{};
 
-            context.TheStack.CurrentNativeFunction()->ForEachProperty([&](Unreal::FProperty* func_prop) {
+            for (Unreal::FProperty* func_prop : context.TheStack.CurrentNativeFunction()->ForEachProperty())
+            {
                 // Skip this property if it's not a parameter
                 if (!func_prop->HasAnyPropertyFlags(Unreal::EPropertyFlags::CPF_Parm))
                 {
-                    return LoopAction::Continue;
+                    continue;
                 }
 
                 // Skip if this property corresponds to the return value
                 if (lua_data.has_return_value && func_prop->GetOffset_Internal() == return_value_offset)
                 {
                     lua_data.return_property = func_prop;
-                    return LoopAction::Continue;
+                    continue;
                 }
 
                 Unreal::FName property_type = func_prop->GetClass().GetFName();
@@ -184,9 +185,7 @@ namespace RC
                 {
                     lua_data.lua.throw_error(std::format("[unreal_script_function_hook] Tried accessing unreal property without a registered handler. Property type '{}' not supported.", to_string(property_type.ToString())));
                 }
-
-                return LoopAction::Continue;
-            });
+            }
         }
 
         // Call the Lua function with the correct number of parameters & return values
@@ -3019,9 +3018,10 @@ Overloads:
 
                     if (has_return_value || num_unreal_params > 0)
                     {
-                        node->ForEachProperty([&](Unreal::FProperty* param) {
-                            if (!param->HasAnyPropertyFlags(Unreal::EPropertyFlags::CPF_Parm)) { return LoopAction::Continue; }
-                            if (has_return_value && param->GetOffset_Internal() == return_value_offset) { return LoopAction::Continue; }
+                        for (Unreal::FProperty* param : node->ForEachProperty())
+                        {
+                            if (!param->HasAnyPropertyFlags(Unreal::EPropertyFlags::CPF_Parm)) { continue; }
+                            if (has_return_value && param->GetOffset_Internal() == return_value_offset) { continue; }
 
                             auto param_type = param->GetClass().GetFName();
                             auto param_type_comparison_index = param_type.GetComparisonIndex();
@@ -3042,9 +3042,7 @@ Overloads:
                             {
                                 lua.throw_error(std::format("[script_hook] Tried accessing unreal property without a registered handler. Property type '{}' not supported.", to_string(param_type.ToString())));
                             }
-
-                            return LoopAction::Continue;
-                        });
+                        };
                     }
                     
                     lua.call_function(num_unreal_params + 1, 1);

--- a/src/ObjectDumper/ObjectToString.cpp
+++ b/src/ObjectDumper/ObjectToString.cpp
@@ -260,10 +260,10 @@ namespace RC::ObjectDumper
 
         auto* typed_this = static_cast<UEnum*>(p_this);
 
-        typed_this->ForEachName([&](Unreal::FName name, int64_t value) {
-            out_line.append(std::format(L"\n[{:016X}] {} [n: {:X}] [v: {}]", 0, name.ToString(), name.GetComparisonIndex(), static_cast<uint8_t>(value)));
-            return LoopAction::Continue;
-        });
+        for (auto& Elem : typed_this->ForEachName())
+        {
+            out_line.append(std::format(L"\n[{:016X}] {} [n: {:X}] [v: {}]", 0, Elem.Key.ToString(), Elem.Key.GetComparisonIndex(), Elem.Value));
+        }
     }
 
     auto class_to_string(void* p_this, std::wstring& out_line) -> void
@@ -283,10 +283,10 @@ namespace RC::ObjectDumper
     {
         UScriptStruct* script_struct = static_cast<UScriptStruct*>(p_this);
 
-        script_struct->ForEachProperty([&](FProperty* prop) {
+        for (FProperty* prop : script_struct->ForEachProperty())
+        {
             callable(prop);
-            return LoopAction::Continue;
-        });
+        }
     }
 
     auto init() -> void

--- a/src/SDKGenerator/Generator.cpp
+++ b/src/SDKGenerator/Generator.cpp
@@ -440,12 +440,12 @@ namespace RC::UEGenerator
                 .owner = owner,
             };
 
-            function->ForEachProperty([&](XProperty* param) {
-                if (!param->HasAnyPropertyFlags(Unreal::CPF_Parm | Unreal::CPF_ReturnParm)) { return LoopAction::Continue; }
+            for (XProperty* param : function->ForEachProperty())
+            {
+                if (!param->HasAnyPropertyFlags(Unreal::CPF_Parm | Unreal::CPF_ReturnParm)) { continue; }
 
                 function_info.params.emplace_back(PropertyInfo{param, generate_class_dependency_from_property(owner, param, current_class_content)});
-                return LoopAction::Continue;
-            });
+            }
 
             return function_info;
         }
@@ -473,15 +473,14 @@ namespace RC::UEGenerator
             specification.generate_enum_declaration(content_buffer, uenum);
             const auto cpp_form = uenum->GetCppForm();
 
-            enum_names.ForEach([&](Unreal::FEnumNamePair* elem, size_t index) {
-                auto enum_value_full_name = elem->Key.ToString();
+            for (Unreal::FEnumNamePair& elem : enum_names)
+            {
+                auto enum_value_full_name = elem.Key.ToString();
                 size_t colon_pos = enum_value_full_name.rfind(STR(":"));
                 auto enum_value_name = colon_pos == enum_value_full_name.npos ? enum_value_full_name : enum_value_full_name.substr(colon_pos + 1);
 
                 specification.generate_enum_member(content_buffer, uenum, enum_value_name, elem);
-
-                return LoopAction::Continue;
-            });
+            }
 
             specification.generate_enum_end(content_buffer, uenum);
 
@@ -682,9 +681,9 @@ namespace RC::UEGenerator
                 content_buffer.append(std::format(STR("enum class {} {{\n"), get_native_enum_name(uenum, false)));
             }
         }
-        auto generate_enum_member(File::StringType& content_buffer, UEnum* uenum, const File::StringType& enum_value_name, Unreal::FEnumNamePair* elem) -> void
+        auto generate_enum_member(File::StringType& content_buffer, UEnum* uenum, const File::StringType& enum_value_name, Unreal::FEnumNamePair& elem) -> void
         {
-            content_buffer.append(std::format(STR("{}{}{} = {},\n"), generate_tab(), uenum->GetCppForm() == UEnum::ECppForm::Namespaced ? generate_tab() : STR(""), enum_value_name, elem->Value));
+            content_buffer.append(std::format(STR("{}{}{} = {},\n"), generate_tab(), uenum->GetCppForm() == UEnum::ECppForm::Namespaced ? generate_tab() : STR(""), enum_value_name, elem.Value));
         }
         auto generate_enum_end(File::StringType& content_buffer, UEnum* uenum) -> void
         {
@@ -712,23 +711,23 @@ namespace RC::UEGenerator
             // If any properties have dependencies, make sure that they are defined
             // This makes sure that we don't have member variables with undefined types (if the types are local, otherwise we need to include the file that the struct exists in)
             std::vector<PropertyInfo> properties_to_generate{};
-            native_class->ForEachProperty([&](XProperty* property) {
+            for (XProperty* property : native_class->ForEachProperty())
+            {
                 properties_to_generate.emplace_back(PropertyInfo{property, generator->generate_class_dependency_from_property(object_info, property, current_class_content)});
-                return LoopAction::Continue;
-            });
+            }
 
             std::vector<FunctionInfo> functions_to_generate{};
-            native_class->ForEachFunction([&](UFunction* function) {
+            for (UFunction* function : native_class->ForEachFunction())
+            {
                 auto& function_info = functions_to_generate.emplace_back(FunctionInfo{function, object_info});
 
-                function->ForEachProperty([&](XProperty* param) {
-                    if (!param->HasAnyPropertyFlags(Unreal::CPF_Parm | Unreal::CPF_ReturnParm)) { return LoopAction::Continue; }
+                for (XProperty* param : function->ForEachProperty())
+                {
+                    if (!param->HasAnyPropertyFlags(Unreal::CPF_Parm | Unreal::CPF_ReturnParm)) { continue; }
 
                     function_info.params.emplace_back(PropertyInfo{param, generator->generate_class_dependency_from_property(object_info, param, current_class_content)});
-                    return LoopAction::Continue;
-                });
-                return LoopAction::Continue;
-            });
+                }
+            }
 
             auto class_name = generate_class_name(native_class);
 
@@ -1029,9 +1028,9 @@ namespace RC::UEGenerator
             auto enum_name = uenum->GetName();
             content_buffer.append(std::format(STR("---@enum {}\n{} = {{\n"), enum_name, enum_name));
         }
-        auto generate_enum_member(File::StringType& content_buffer, UEnum* uenum, const File::StringType& enum_value_name, Unreal::FEnumNamePair* elem) -> void
+        auto generate_enum_member(File::StringType& content_buffer, UEnum* uenum, const File::StringType& enum_value_name, Unreal::FEnumNamePair& elem) -> void
         {
-            content_buffer.append(std::format(STR("{}{} = {},\n"), generate_tab(), enum_value_name, elem->Value));
+            content_buffer.append(std::format(STR("{}{} = {},\n"), generate_tab(), enum_value_name, elem.Value));
         }
         auto generate_enum_end(File::StringType& content_buffer, UEnum* uenum) -> void
         {
@@ -1055,23 +1054,23 @@ namespace RC::UEGenerator
             // If any properties have dependencies, make sure that they are defined
             // This makes sure that we don't have member variables with undefined types (if the types are local, otherwise we need to include the file that the struct exists in)
             std::vector<PropertyInfo> properties_to_generate{};
-            native_class->ForEachProperty([&](XProperty* property) {
+            for (XProperty* property : native_class->ForEachProperty())
+            {
                 properties_to_generate.emplace_back(PropertyInfo{property, generator->generate_class_dependency_from_property(object_info, property, current_class_content)});
-                return LoopAction::Continue;
-            });
+            }
 
             std::vector<FunctionInfo> functions_to_generate{};
-            native_class->ForEachFunction([&](UFunction* function) {
+            for (UFunction* function : native_class->ForEachFunction())
+            {
                 auto& function_info = functions_to_generate.emplace_back(FunctionInfo{function, object_info});
 
-                function->ForEachProperty([&](XProperty* param) {
-                    if (!param->HasAnyPropertyFlags(Unreal::CPF_Parm | Unreal::CPF_ReturnParm)) { return LoopAction::Continue; }
+                for (XProperty* param : function->ForEachProperty())
+                {
+                    if (!param->HasAnyPropertyFlags(Unreal::CPF_Parm | Unreal::CPF_ReturnParm)) { continue; }
 
                     function_info.params.emplace_back(PropertyInfo{param, generator->generate_class_dependency_from_property(object_info, param, current_class_content)});
-                    return LoopAction::Continue;
-                });
-                return LoopAction::Continue;
-            });
+                }
+            }
 
             auto class_name = generate_class_name(native_class);
 

--- a/src/SDKGenerator/JSONDumper.cpp
+++ b/src/SDKGenerator/JSONDumper.cpp
@@ -151,19 +151,21 @@ namespace RC::UEGenerator::JSONDumper
             }
 
             auto& events = bp_class.new_array(STR("events"));
-            object_as_class->ForEachFunction([&](UFunction* event_function) {
-                if (should_skip_general_function(event_function)) { return LoopAction::Continue; }
-                if (!is_event(event_function)) { return LoopAction::Continue; }
+            for (UFunction* event_function : object_as_class->ForEachFunction())
+            {
+                if (should_skip_general_function(event_function)) { continue; }
+                if (!is_event(event_function)) { continue; }
 
                 auto event_name = event_function->GetName();
-                if (should_skip_event(event_name)) { return LoopAction::Continue; }
+                if (should_skip_event(event_name)) { continue; }
 
                 auto& bp_events = events.new_object();
                 bp_events.new_string(STR("name"), event_name);
 
                 auto& bp_event_args = bp_events.new_array(STR("args"));
-                event_function->ForEachProperty([&](FProperty* param) {
-                    if (should_skip_property(param)) { return LoopAction::Continue; }
+                for (FProperty* param : event_function->ForEachProperty())
+                {
+                    if (should_skip_property(param)) { continue; }
 
                     auto& bp_event_arg = bp_event_args.new_object();
                     bp_event_arg.new_string(STR("name"), param->GetName());
@@ -171,22 +173,21 @@ namespace RC::UEGenerator::JSONDumper
                     bool is_out = param->HasAnyPropertyFlags(EPropertyFlags::CPF_OutParm) && !param->HasAnyPropertyFlags(EPropertyFlags::CPF_ConstParm);
                     bp_event_arg.new_bool(STR("is_out"), is_out);
                     bp_event_arg.new_bool(STR("is_return"), param->HasAnyPropertyFlags(Unreal::EPropertyFlags::CPF_ReturnParm));
-                    return LoopAction::Continue;
-                });
-
-                return LoopAction::Continue;
-            });
+                }
+            }
 
             auto& functions = bp_class.new_array(STR("functions"));
-            object_as_class->ForEachFunction([&](UFunction* function) {
-                if (should_skip_function(function)) { return LoopAction::Continue; }
+            for (UFunction* function : object_as_class->ForEachFunction())
+            {
+                if (should_skip_function(function)) { continue; }
 
                 auto& bp_function = functions.new_object();
                 bp_function.new_string(STR("name"), function->GetName());
 
                 auto& bp_function_args = bp_function.new_array(STR("args"));
-                function->ForEachProperty([&](FProperty* param) {
-                    if (should_skip_property(param)) { return LoopAction::Continue; }
+                for (FProperty* param : function->ForEachProperty())
+                {
+                    if (should_skip_property(param)) { continue; }
 
                     auto& bp_function_arg = bp_function_args.new_object();
                     bp_function_arg.new_string(STR("name"), param->GetName());
@@ -194,34 +195,32 @@ namespace RC::UEGenerator::JSONDumper
                     bool is_out = param->HasAnyPropertyFlags(EPropertyFlags::CPF_OutParm) && !param->HasAnyPropertyFlags(EPropertyFlags::CPF_ConstParm);
                     bp_function_arg.new_bool(STR("is_out"), is_out);
                     bp_function_arg.new_bool(STR("is_return"), param->HasAnyPropertyFlags(Unreal::EPropertyFlags::CPF_ReturnParm));
-                    return LoopAction::Continue;
-                });
-
-                return LoopAction::Continue;
-            });
+                }
+            }
 
             auto& properties = bp_class.new_array(STR("properties"));
-            object_as_class->ForEachProperty([&](FProperty* property) {
-                if (should_skip_property(property)) { return LoopAction::Continue; }
+            for (FProperty* property : object_as_class->ForEachProperty())
+            {
+                if (should_skip_property(property)) { continue; }
 
                 auto& bp_property = properties.new_object();
                 bp_property.new_string(STR("name"), property->GetName());
                 bp_property.new_string(STR("type"), generate_property_cxx_name(property, true, object_as_class));
-
-                return LoopAction::Continue;
-            });
+            }
 
             auto& delegates = bp_class.new_array(STR("delegates"));
-            object_as_class->ForEachFunction([&](UFunction* delegate_function) {
-                if (should_skip_general_function(delegate_function)) { return LoopAction::Continue; }
-                if ((delegate_function->GetFunctionFlags() & EFunctionFlags::FUNC_Delegate) == 0) { return LoopAction::Continue; }
+            for (UFunction* delegate_function : object_as_class->ForEachFunction())
+            {
+                if (should_skip_general_function(delegate_function)) { continue; }
+                if ((delegate_function->GetFunctionFlags() & EFunctionFlags::FUNC_Delegate) == 0) { continue; }
 
                 auto& bp_delegate = delegates.new_object();
                 bp_delegate.new_string(STR("name"), delegate_function->GetName());
 
                 auto& bp_delegate_args = bp_delegate.new_array(STR("args"));
-                delegate_function->ForEachProperty([&](FProperty* param) {
-                    if (should_skip_property(param)) { return LoopAction::Continue; }
+                for (FProperty* param : delegate_function->ForEachProperty())
+                {
+                    if (should_skip_property(param)) { continue; }
 
                     auto& bp_delegate_arg = bp_delegate_args.new_object();
                     bp_delegate_arg.new_string(STR("name"), param->GetName());
@@ -229,11 +228,8 @@ namespace RC::UEGenerator::JSONDumper
                     bool is_out = param->HasAnyPropertyFlags(EPropertyFlags::CPF_OutParm) && !param->HasAnyPropertyFlags(EPropertyFlags::CPF_ConstParm);
                     bp_delegate_arg.new_bool(STR("is_out"), is_out);
                     bp_delegate_arg.new_bool(STR("is_return"), param->HasAnyPropertyFlags(Unreal::EPropertyFlags::CPF_ReturnParm));
-                    return LoopAction::Continue;
-                });
-
-                return LoopAction::Continue;
-            });
+                }
+            }
 
             return LoopAction::Continue;
         });

--- a/src/SDKGenerator/TMapOverrideGen.cpp
+++ b/src/SDKGenerator/TMapOverrideGen.cpp
@@ -42,8 +42,9 @@ namespace RC::UEGenerator
                 if (!as_class && !as_script_struct) { return LoopAction::Continue; }
                 if ((as_class && as_class->HasAnyClassFlags(CLASS_Native)) || (as_script_struct && as_script_struct->HasAnyStructFlags(STRUCT_Native)))
                 {
-                    casted_object->ForEachProperty([&](FProperty* property) {
-                        if (!property->IsA<FMapProperty>() || MapProperties.contains(property->GetFName())) { return LoopAction::Continue; }
+                    for (FProperty* property : casted_object->ForEachProperty())
+                    {
+                        if (!property->IsA<FMapProperty>() || MapProperties.contains(property->GetFName())) { continue; }
 
                         MapProperties.insert(property->GetFName());
 
@@ -58,7 +59,7 @@ namespace RC::UEGenerator
                         auto value_struct_type = value_as_struct_property ? value_as_struct_property->GetStruct() : nullptr;
                         auto is_value_valid = value_struct_type && value_struct_type->HasAnyStructFlags(STRUCT_SerializeNative);
 
-                        if (!is_key_valid && !is_value_valid) { return LoopAction::Continue; }
+                        if (!is_key_valid && !is_value_valid) { continue; }
                         Output::send(STR("Found Relevant TMap Property: {} in Class: {}\n"), property_name, object->GetName());
 
                         auto& fm_json_object = fm_object.new_object(property_name);
@@ -89,8 +90,7 @@ namespace RC::UEGenerator
                         }
 
                         ++num_objects_generated;
-                        return LoopAction::Continue;
-                    });
+                    }
                 }
             }
             else

--- a/src/UE4SSProgram.cpp
+++ b/src/UE4SSProgram.cpp
@@ -1366,14 +1366,12 @@ namespace RC
                     {
                         if (typed_obj->IsA<UStruct>())
                         {
-                            static_cast<UClass*>(typed_obj)->ForEachProperty([&](FProperty* prop) {
-                                if (dumped_fields.contains(prop)) { return LoopAction::Continue; }
+                            for (FProperty* prop : static_cast<UClass*>(typed_obj)->ForEachProperty()) {
+                                if (dumped_fields.contains(prop)) { continue; }
 
                                 dump_xproperty(prop);
                                 dumped_fields.emplace(prop);
-
-                                return LoopAction::Continue;
-                            });
+                            }
                         }
                     }
                 }

--- a/src/USMapGenerator/Generator.cpp
+++ b/src/USMapGenerator/Generator.cpp
@@ -280,11 +280,10 @@ namespace RC::OutTheShade
 				if (Struct->GetSuperStruct() && !NameMap.contains(Struct->GetSuperStruct()->GetNamePrivate()))
 					NameMap.insert_or_assign(Struct->GetSuperStruct()->GetNamePrivate(), 0);
 
-				Struct->ForEachProperty([&](FProperty* Prop)
-				{
-					NameMap.insert_or_assign(Prop->GetFName(), 0);
-                    return LoopAction::Continue;
-				});
+                for (FProperty* Prop : Struct->ForEachProperty())
+                {
+                    NameMap.insert_or_assign(Prop->GetFName(), 0);
+                }
 			}
 			else if (Object->GetClassPrivate() == UEnum::StaticClass())
 			{
@@ -293,11 +292,10 @@ namespace RC::OutTheShade
 
 				NameMap.insert_or_assign(Enum->GetNamePrivate(), 0);
 
-				Enum->ForEachName([&](FName Key, ...)
-				{
-					NameMap.insert_or_assign(Key, 0);
-                    return LoopAction::Continue;
-				});
+                for (auto& [Key, _] : Enum->ForEachName())
+                {
+                    NameMap.insert_or_assign(Key, 0);
+                }
 			}
             return LoopAction::Continue;
 		});
@@ -335,18 +333,16 @@ namespace RC::OutTheShade
             Buffer.Write(NameMap[Enum->GetNamePrivate()]);
 
             uint8_t EnumNameCount{};
-            Enum->ForEachName([&](...)
+            for (auto _ : Enum->ForEachName())
             {
                 ++EnumNameCount;
-                return LoopAction::Continue;
-            });
+            }
             Buffer.Write<uint8_t>(EnumNameCount);
 
-            Enum->ForEachName([&](FName Key, ...)
+            for (auto& [Key, _] : Enum->ForEachName())
             {
                 Buffer.Write<int>(NameMap[Key]);
-                return LoopAction::Continue;
-            });
+            }
         }
 
         // Warning: Converting size_t (uint64) to uint32_t.
@@ -369,7 +365,7 @@ namespace RC::OutTheShade
             uint16_t PropCount = 0;
             uint16_t SerializablePropCount = 0;
 
-            Struct->ForEachProperty([&](FProperty* Props)
+            for (FProperty* Props : Struct->ForEachProperty())
             {
                 FPropertyData Data(Props, PropCount);
 
@@ -377,9 +373,7 @@ namespace RC::OutTheShade
 
                 PropCount += Data.ArrayDim;
                 SerializablePropCount++;
-
-                return LoopAction::Continue;
-            });
+            }
 
             Buffer.Write(PropCount);
             Buffer.Write(SerializablePropCount);


### PR DESCRIPTION
This patch removes the need for passing lambdas into `ForEach` functions in a lot of places, instead replacing the iterator producing functions with coroutines that yield the results.

This change allows for more effective work with any iterable by allowing to construct STL containers from them, use ranges on the iterables, etc.

Coroutines also allow for much faster iteration than the current method when compiled with clang.