### PR TITLE
usmap ext 2

### DIFF
--- a/src/USMapGenerator/Generator.cpp
+++ b/src/USMapGenerator/Generator.cpp
@@ -205,11 +205,10 @@ namespace RC::OutTheShade
         
         StreamWriter Buffer;
         std::unordered_map<FName, int> NameMap;
+        std::unordered_map<FName, FName> ModulePathsMap;
 
         std::vector<UEnum*> Enums;
         std::vector<UStruct*> Structs; // TODO: a better way than making this completely dynamic
-        std::unordered_map<std::wstring, int> ModulePathsMap;
-        std::vector<std::wstring> ModulePathsRaw;
 
         std::function<void(class FProperty*, EPropertyType)> WriteProperty = [&](FProperty* Prop, EPropertyType Type)
         {
@@ -297,6 +296,19 @@ namespace RC::OutTheShade
                     NameMap.insert_or_assign(Key, 0);
                 }
 			}
+
+            if (Object->GetClassPrivate() == UClass::StaticClass() || Object->GetClassPrivate() == UScriptStruct::StaticClass() || Object->GetClassPrivate() == UEnum::StaticClass())
+            {
+                std::wstring RawPathName = Object->GetPathName();
+                std::wstring::size_type PathNameStart = 0; // include first bit (Script/Game) to avoid ambiguity; to drop it, replace with RawPathName.find_first_of('/', 1) + 1;
+                std::wstring::size_type PathNameLength = RawPathName.find_last_of('.') - PathNameStart;
+                std::wstring FinalPathStr = RawPathName.substr(PathNameStart, PathNameLength);
+                FName FinalPathName = FName(FinalPathStr);
+
+                NameMap.insert_or_assign(FinalPathName, 0);
+                ModulePathsMap.insert_or_assign(Object->GetNamePrivate(), FinalPathName);
+            }
+
             return LoopAction::Continue;
 		});
 
@@ -344,7 +356,7 @@ namespace RC::OutTheShade
             int numSoFar = 0;
             for (auto& [Key, _] : Enum->ForEachName())
             {
-                Buffer.Write<int>(NameMap[Key]);
+                Buffer.Write<uint32_t>(NameMap[Key]);
                 if (++numSoFar >= EnumNameCount) break;
             }
         }
@@ -354,13 +366,6 @@ namespace RC::OutTheShade
 
         for (auto Struct : Structs)
         {
-            std::wstring RawPathName = Struct->GetPathName();
-            std::wstring::size_type PathNameStart = 0; // include first bit (Script/Game) to avoid ambiguity; to drop it, replace with RawPathName.find_first_of('/', 1) + 1;
-            std::wstring::size_type PathNameLength = RawPathName.find_last_of('.') - PathNameStart;
-            std::wstring FinalPathName = RawPathName.substr(PathNameStart, PathNameLength);
-            ModulePathsMap.insert_or_assign(FinalPathName, 0);
-            ModulePathsRaw.push_back(FinalPathName);
-
             Buffer.Write(NameMap[Struct->GetNamePrivate()]);
             Buffer.Write<int32_t>(Struct->GetSuperStruct() ? NameMap[Struct->GetSuperStruct()->GetNamePrivate()] : static_cast<int32_t>(0xffffffff));
 
@@ -397,30 +402,93 @@ namespace RC::OutTheShade
         Buffer.Write<uint32_t>(0x54584543); // "CEXT"; magic
         Buffer.Write<uint8_t>(0); // extensions layout version; 0 (Initial)
 
-        Buffer.Write<uint32_t>(1); // number of extensions, only 1
+        Buffer.Write<uint32_t>(3); // number of extensions, 3 right now
 
-        // extension 1: scripts
-        Buffer.Write<uint32_t>(0x4C444F4D); // "MODL"; module paths ext id
+        // extension 1: PPTH (object paths)
+        Buffer.Write<uint32_t>(0x48545050); // ext id
         Buffer.Write<uint32_t>(0); // size; unknown for now
 
         std::streampos extStartPos = Buffer.GetBuffer().tellp();
-        int CurrentModulePathsIndex = 0;
-        int ModulePathsMapSize = ModulePathsMap.size();
-        Buffer.Write<uint16_t>(ModulePathsMapSize);
-        for (auto&& M : ModulePathsMap)
+        Buffer.Write<uint8_t>(0); // PPTH version; 0
+        Buffer.Write<uint32_t>(static_cast<uint32_t>(Enums.size()));
+        for (auto Enum : Enums)
         {
-            ModulePathsMap[M.first] = CurrentModulePathsIndex++;
-
-            std::string StringToSerialize = to_string(M.first);
-            Buffer.Write<uint8_t>(static_cast<uint8_t>(StringToSerialize.length()));
-            Buffer.WriteString(StringToSerialize);
+            Buffer.Write(NameMap[ModulePathsMap[Enum->GetNamePrivate()]]);
         }
-        bool isIdx16 = ModulePathsMapSize > 255;
-        for (auto& ky : ModulePathsRaw)
+        Buffer.Write<uint32_t>(static_cast<uint32_t>(Structs.size()));
+        for (auto Struct : Structs)
         {
-            isIdx16 ? Buffer.Write<uint16_t>(static_cast<uint16_t>(ModulePathsMap[ky])) : Buffer.Write<uint8_t>(static_cast<uint8_t>(ModulePathsMap[ky]));
+            Buffer.Write(NameMap[ModulePathsMap[Struct->GetNamePrivate()]]);
         }
         std::streampos extEndPos = Buffer.GetBuffer().tellp();
+
+        Buffer.GetBuffer().seekp(extStartPos);
+        Buffer.GetBuffer().seekp(-sizeof(uint32_t), std::ios_base::cur);
+        Buffer.Write<uint32_t>(extEndPos - extStartPos);
+        Buffer.GetBuffer().seekp(extEndPos);
+
+        // extension 2: EATR (extended attributes)
+        Buffer.Write<uint32_t>(0x52544145); // ext id
+        Buffer.Write<uint32_t>(0); // size; unknown for now
+
+        extStartPos = Buffer.GetBuffer().tellp();
+        Buffer.Write<uint8_t>(0); // EATR version; 0
+        Buffer.Write<uint32_t>(static_cast<uint32_t>(Enums.size()));
+        for (auto Enum : Enums)
+        {
+            Buffer.Write(static_cast<int32_t>(Enum->GetEnumFlags()));
+        }
+        Buffer.Write<uint32_t>(static_cast<uint32_t>(Structs.size()));
+        for (auto Struct : Structs)
+        {
+            if (Struct->GetClassPrivate() == UScriptStruct::StaticClass())
+            { 
+                Buffer.Write<uint8_t>(1);
+                Buffer.Write<int32_t>(((UScriptStruct*)Struct)->GetStructFlags());
+            }
+            else if (Struct->GetClassPrivate() == UClass::StaticClass())
+            {
+                Buffer.Write<uint8_t>(2);
+                Buffer.Write<int32_t>(((UClass*)Struct)->GetClassFlags());
+            }
+            else
+            {
+                Buffer.Write<uint8_t>(255); // ???
+                Buffer.Write<int32_t>(0);
+            }
+
+            std::vector<uint64_t> propFlags;
+            for (FProperty* Props : Struct->ForEachProperty()) propFlags.push_back(static_cast<uint64_t>(Props->GetPropertyFlags()));
+            Buffer.Write<uint32_t>(static_cast<uint32_t>(propFlags.size()));
+            for (uint64_t propFlag : propFlags) Buffer.Write<uint64_t>(propFlag);
+        }
+        extEndPos = Buffer.GetBuffer().tellp();
+
+        Buffer.GetBuffer().seekp(extStartPos);
+        Buffer.GetBuffer().seekp(-sizeof(uint32_t), std::ios_base::cur);
+        Buffer.Write<uint32_t>(extEndPos - extStartPos);
+        Buffer.GetBuffer().seekp(extEndPos);
+
+        // extension 3: ENVP (enum name/value pairs)
+        Buffer.Write<uint32_t>(0x50564E45); // ext id
+        Buffer.Write<uint32_t>(0); // size; unknown for now
+
+        extStartPos = Buffer.GetBuffer().tellp();
+        Buffer.Write<uint8_t>(0); // ENVP version; 0
+        Buffer.Write<uint32_t>(static_cast<uint32_t>(Enums.size()));
+        for (auto Enum : Enums)
+        {
+            uint32_t EnumNameCount = 0;
+            for (auto _ : Enum->ForEachName()) ++EnumNameCount;
+            Buffer.Write<uint32_t>(EnumNameCount);
+
+            for (auto& [Key, val] : Enum->ForEachName())
+            {
+                Buffer.Write<uint32_t>(NameMap[Key]);
+                Buffer.Write<int64_t>(val);
+            }
+        }
+        extEndPos = Buffer.GetBuffer().tellp();
 
         Buffer.GetBuffer().seekp(extStartPos);
         Buffer.GetBuffer().seekp(-sizeof(uint32_t), std::ios_base::cur);

--- a/src/USMapGenerator/Generator.cpp
+++ b/src/USMapGenerator/Generator.cpp
@@ -332,16 +332,20 @@ namespace RC::OutTheShade
         {
             Buffer.Write(NameMap[Enum->GetNamePrivate()]);
 
+            // limit to 255 entries; why is this a byte in the first place?
             uint8_t EnumNameCount{};
             for (auto _ : Enum->ForEachName())
             {
                 ++EnumNameCount;
+                if (EnumNameCount >= std::numeric_limits<uint8_t>::max()) break;
             }
             Buffer.Write<uint8_t>(EnumNameCount);
 
+            int numSoFar = 0;
             for (auto& [Key, _] : Enum->ForEachName())
             {
                 Buffer.Write<int>(NameMap[Key]);
+                if (++numSoFar >= EnumNameCount) break;
             }
         }
 

--- a/src/USMapGenerator/Generator.cpp
+++ b/src/USMapGenerator/Generator.cpp
@@ -205,7 +205,7 @@ namespace RC::OutTheShade
         
         StreamWriter Buffer;
         std::unordered_map<FName, int> NameMap;
-        std::unordered_map<FName, FName> ModulePathsMap;
+        std::unordered_map<UObject*, FName> ModulePathsMap;
 
         std::vector<UEnum*> Enums;
         std::vector<UStruct*> Structs; // TODO: a better way than making this completely dynamic
@@ -306,7 +306,7 @@ namespace RC::OutTheShade
                 FName FinalPathName = FName(FinalPathStr);
 
                 NameMap.insert_or_assign(FinalPathName, 0);
-                ModulePathsMap.insert_or_assign(Object->GetNamePrivate(), FinalPathName);
+                ModulePathsMap.insert_or_assign(Object, FinalPathName);
             }
 
             return LoopAction::Continue;
@@ -413,12 +413,12 @@ namespace RC::OutTheShade
         Buffer.Write<uint32_t>(static_cast<uint32_t>(Enums.size()));
         for (auto Enum : Enums)
         {
-            Buffer.Write(NameMap[ModulePathsMap[Enum->GetNamePrivate()]]);
+            Buffer.Write(NameMap[ModulePathsMap[Enum]]);
         }
         Buffer.Write<uint32_t>(static_cast<uint32_t>(Structs.size()));
         for (auto Struct : Structs)
         {
-            Buffer.Write(NameMap[ModulePathsMap[Struct->GetNamePrivate()]]);
+            Buffer.Write(NameMap[ModulePathsMap[Struct]]);
         }
         std::streampos extEndPos = Buffer.GetBuffer().tellp();
 

--- a/src/USMapGenerator/Generator.cpp
+++ b/src/USMapGenerator/Generator.cpp
@@ -453,7 +453,7 @@ namespace RC::OutTheShade
             }
             else
             {
-                Buffer.Write<uint8_t>(255); // ???
+                Buffer.Write<uint8_t>(0); // ???
                 Buffer.Write<int32_t>(0);
             }
 


### PR DESCRIPTION
Adds .usmap file dumping with 4-byte ASCII extension identifiers for decentralized extension development rather than using a fixed enum. Future pull requests can add new extensions to the dumper