### PR TITLE
CppMods fixes

### DIFF
--- a/include/UE4SSProgram.hpp
+++ b/include/UE4SSProgram.hpp
@@ -72,6 +72,9 @@ namespace RC
         RC_UE4SS_API static SettingsManager settings_manager;
         static inline bool unreal_is_shutting_down{};
 
+    public:
+        bool m_is_program_started;
+
     protected:
         Input::Handler m_input_handler{L"ConsoleWindowClass", L"UnrealWindow"};
         std::jthread m_event_loop;
@@ -158,6 +161,7 @@ namespace RC
         auto fire_program_start_for_cpp_mods() -> void;
 
     public:
+        auto is_program_started() -> bool;
         auto reinstall_mods() -> void;
         auto get_object_dumper_output_directory() -> const File::StringType;
         RC_UE4SS_API auto get_module_directory() -> File::StringViewType;

--- a/src/UE4SSProgram.cpp
+++ b/src/UE4SSProgram.cpp
@@ -1029,6 +1029,11 @@ namespace RC
         LuaMod::global_uninstall();
     }
 
+    auto UE4SSProgram::is_program_started() -> bool
+    {
+        return m_is_program_started;
+    }
+
     auto UE4SSProgram::reinstall_mods() -> void
     {
         Output::send(STR("Re-installing all mods\n"));
@@ -1074,6 +1079,15 @@ namespace RC
         setup_mods();
         start_lua_mods();
         start_cpp_mods();
+        
+        if (Unreal::UnrealInitializer::StaticStorage::bIsInitialized) {
+            fire_unreal_init_for_cpp_mods();
+        }
+
+        if (is_program_started()) {
+            fire_program_start_for_cpp_mods();
+        }
+        
         Output::send(STR("All mods re-installed\n"));
     }
 

--- a/src/UE4SSProgram.cpp
+++ b/src/UE4SSProgram.cpp
@@ -859,7 +859,7 @@ namespace RC
             {
                 // Create the mod but don't install it yet
                 if (std::filesystem::exists(sub_directory.path() / "scripts")) m_mods.emplace_back(std::make_unique<LuaMod>(*this, sub_directory.path().stem().wstring(), sub_directory.path().wstring()));
-                if (std::filesystem::exists(sub_directory.path() / "dlls")) m_mods.emplace_back(std::make_unique<CppMod>(*this, sub_directory.path().stem().wstring(), sub_directory.path().wstring()));
+                if (cpp_sdk_loaded && std::filesystem::exists(sub_directory.path() / "dlls")) m_mods.emplace_back(std::make_unique<CppMod>(*this, sub_directory.path().stem().wstring(), sub_directory.path().wstring()));
             }
         }
     }

--- a/src/UE4SSProgram.cpp
+++ b/src/UE4SSProgram.cpp
@@ -1080,11 +1080,13 @@ namespace RC
         start_lua_mods();
         start_cpp_mods();
         
-        if (Unreal::UnrealInitializer::StaticStorage::bIsInitialized) {
+        if (Unreal::UnrealInitializer::StaticStorage::bIsInitialized)
+        {
             fire_unreal_init_for_cpp_mods();
         }
 
-        if (is_program_started()) {
+        if (is_program_started())
+        {
             fire_program_start_for_cpp_mods();
         }
         


### PR DESCRIPTION
This PR fixes cppmod restarting not calling initialization functions correctly, also prevents cppmods from being loaded if no cppsdk was found.