### PR TITLE
fixes for various unload & executeingamethread gc-related crashes

### DIFF
--- a/include/Mod/LuaMod.hpp
+++ b/include/Mod/LuaMod.hpp
@@ -46,6 +46,7 @@ namespace RC
         {
             const LuaMadeSimple::Lua* lua;
             int32_t lua_action_function_ref{};
+            int32_t lua_action_thread_ref{};
         };
 
         struct AsyncAction


### PR DESCRIPTION
current behavior is to infinitely grow the mod's stack until we write out of bounds on the heap.

note that `mod->lua().get_lua_state()`, `hook_lua->get_lua_state()` and `lua.get_lua_state()` are three different states.

verified no crashes on reload now with gflags +hpa and LUA_USE_APICHECK enabled