### PR TITLE
Fix always-active O(n) console log filter

### DIFF
--- a/Dependencies/ImGuiColorTextEdit/TextEditor.cpp
+++ b/Dependencies/ImGuiColorTextEdit/TextEditor.cpp
@@ -857,7 +857,7 @@ void TextEditor::Render()
 {
     Lines originalLines{};
     bool originalLinesAltered{};
-    if (mTextFilter)
+    if (mTextFilter && mTextFilter->IsActive())
     {
         originalLines = mLines;
         mLines.erase(std::remove_if(mLines.begin(), mLines.end(), [&](Line& line) -> bool {


### PR DESCRIPTION
Skipping the filter when empty causes console render time to remain constant regardless of length.