### PR TITLE
Improve Lua UFunction call performance

### DIFF
--- a/include/LuaType/LuaUObject.hpp
+++ b/include/LuaType/LuaUObject.hpp
@@ -567,7 +567,7 @@ Overloads:
         {
             auto& lua_object = lua.get_userdata<SelfType>();
 
-            std::wstring member_name = to_wstring(lua.get_string());
+            const std::wstring& member_name = to_const_wstring(lua.get_string());
 
             // If nullptr then we assume the UObject wasn't found so lets return an invalid UObject to Lua
             // This allows the safe chaining of "__index" as long as the Lua script checks ":IsValid()" before using the object

--- a/src/LuaType/LuaUObject.cpp
+++ b/src/LuaType/LuaUObject.cpp
@@ -1229,30 +1229,7 @@ Overloads:
             // It means that the UFunction was found and is stored in 'property', so we don't need to do anything to find it
             if (!field && property_name != Unreal::FName(0u, 0u))
             {
-                std::vector<Unreal::UObject*> found_functions;
-                Unreal::UObjectGlobals::FindObjects(Unreal::GFunctionName, property_name, found_functions);
-
-                for (const auto& found_function : found_functions)
-                {
-                    Unreal::UStruct* inheritance_to_test = static_cast<Unreal::UStruct*>(found_function->GetOuterPrivate());
-                    Unreal::UStruct* base_class = base->GetClassPrivate();
-
-                    while (base_class)
-                    {
-                        if (inheritance_to_test == base_class)
-                        {
-                            func = static_cast<Unreal::UFunction*>(found_function);
-                            break;
-                        }
-
-                        Unreal::UStruct* next = base_class->GetSuperStruct();
-
-                        // This shouldn't be the case with the super struct linked list, but I'm putting this here just in case
-                        if (base_class == next) { break; }
-
-                        base_class = next;
-                    }
-                }
+                func = base->GetFunctionByNameInChain(property_name);
             }
             else
             {


### PR DESCRIPTION
Profiled 3k ufunction calls in a loop:
* 12800ms spent.
* 99% of that spent in FindObjects, fixed via GetFunctionByNameInChain
* 40ms spent allocating wstrings, fixed via introducing `to_const_wstring` pool
* 25ms spent in FindProperty, fixed via https://github.com/Re-UE4SS/UEPseudo/pull/44/commits/6e14bc4b0b5b0b08378df458609f4fd0e8d0b370

end result is 3k ufunction calls in <9ms on my machine

Testing performed was mostly running a mod on my current target that uses a variety of functionality, though I'm probably only accessing ~20 UFunctions and ~50 properties on 7 different classes of UObject.