### PR TITLE
CppMods are now loaded earlier

### DIFF
--- a/include/Mod/CppMod.hpp
+++ b/include/Mod/CppMod.hpp
@@ -37,6 +37,7 @@ namespace RC
         auto fire_unreal_init() -> void override;
         auto fire_program_start() -> void override;
         auto fire_update() -> void override;
+        auto fire_dll_load(std::wstring_view dll_name) -> void;
     };
 }
 

--- a/include/Mod/CppUserModBase.hpp
+++ b/include/Mod/CppUserModBase.hpp
@@ -38,6 +38,8 @@ namespace RC
         RC_UE4SS_API auto virtual on_unreal_init() -> void {}
 
         RC_UE4SS_API auto virtual on_program_start() -> void {}
+
+        RC_UE4SS_API auto virtual on_dll_load(std::wstring_view dll_name) -> void {}
     };
 }
 

--- a/include/UE4SSProgram.hpp
+++ b/include/UE4SSProgram.hpp
@@ -7,6 +7,7 @@
 #include <string_view>
 #include <mutex>
 
+#include <polyhook2/PE/IatHook.hpp>
 #include <Common.hpp>
 #include <MProgram.hpp>
 #include <SettingsManager.hpp>
@@ -104,6 +105,19 @@ namespace RC
         std::vector<Event> m_queued_events{};
         std::mutex m_event_queue_mutex{};
 
+    private:
+        std::unique_ptr<PLH::IatHook> m_load_library_a_hook;
+        uint64_t m_hook_trampoline_load_library_a;
+
+        std::unique_ptr<PLH::IatHook> m_load_library_ex_a_hook;
+        uint64_t m_hook_trampoline_load_library_ex_a;
+
+        std::unique_ptr<PLH::IatHook> m_load_library_w_hook;
+        uint64_t m_hook_trampoline_load_library_w;
+
+        std::unique_ptr<PLH::IatHook> m_load_library_ex_w_hook;
+        uint64_t m_hook_trampoline_load_library_ex_w;
+
     public:
         static inline std::vector<std::unique_ptr<Mod>> m_mods;
 
@@ -159,8 +173,10 @@ namespace RC
         auto uninstall_mods() -> void;
         auto fire_unreal_init_for_cpp_mods() -> void;
         auto fire_program_start_for_cpp_mods() -> void;
+        auto fire_dll_load_for_cpp_mods(std::wstring_view dll_name) -> void;
 
     public:
+        auto init() -> void;
         auto is_program_started() -> bool;
         auto reinstall_mods() -> void;
         auto get_object_dumper_output_directory() -> const File::StringType;
@@ -217,6 +233,12 @@ namespace RC
         {
             return *s_program;
         }
+
+    private:
+        friend void* HookedLoadLibraryA(const char* dll_name);
+        friend void* HookedLoadLibraryExA(const char* dll_name, void* file, int32_t flags);
+        friend void* HookedLoadLibraryW(const wchar_t* dll_name);
+        friend void* HookedLoadLibraryExW(const wchar_t* dll_name, void* file, int32_t flags);
     };
 }
 

--- a/src/Mod/CppMod.cpp
+++ b/src/Mod/CppMod.cpp
@@ -87,6 +87,11 @@ namespace RC
         if (m_mod) { m_mod->on_update(); }
     }
 
+    auto CppMod::fire_dll_load(std::wstring_view dll_name) -> void
+    {
+        if (m_mod) { m_mod->on_dll_load(dll_name); }
+    }
+
     CppMod::~CppMod()
     {
         if (m_main_dll_module) { 

--- a/src/main_ue4ss_rewritten.cpp
+++ b/src/main_ue4ss_rewritten.cpp
@@ -18,18 +18,13 @@
 using namespace RC;
 
 // We're outside DllMain here
-auto thread_dll_start([[maybe_unused]]LPVOID thread_param) -> unsigned long
+auto thread_dll_start(UE4SSProgram* program) -> unsigned long
 {
     // Wrapper for entire program
     // Everything must be channeled through MProgram
     // One of the purposes for this is to forward any errors to main so that we can close or keep the window/console open
     // There is atleast one more purpose but I forgot what it was...
-
-    HMODULE moduleHandle = reinterpret_cast<HMODULE>(thread_param);
-    wchar_t moduleFilenameBuffer[1024] {'\0'};
-    GetModuleFileNameW(moduleHandle, moduleFilenameBuffer, sizeof(moduleFilenameBuffer) / sizeof(wchar_t));
-
-    auto program = new UE4SSProgram(moduleFilenameBuffer, {});
+    program->init();
 
     if (auto e = program->get_error_object(); e->has_error())
     {
@@ -51,7 +46,11 @@ auto thread_dll_start([[maybe_unused]]LPVOID thread_param) -> unsigned long
 // We're still inside DllMain so be careful what you do here
 auto dll_process_attached(HMODULE moduleHandle) -> void
 {
-    if (HANDLE handle = CreateThread(nullptr, 0, reinterpret_cast<LPTHREAD_START_ROUTINE>(thread_dll_start), moduleHandle, 0, nullptr); handle)
+    wchar_t moduleFilenameBuffer[1024]{'\0'};
+    GetModuleFileNameW(moduleHandle, moduleFilenameBuffer, sizeof(moduleFilenameBuffer) / sizeof(wchar_t));
+
+    auto program = new UE4SSProgram(moduleFilenameBuffer, {});
+    if (HANDLE handle = CreateThread(nullptr, 0, reinterpret_cast<LPTHREAD_START_ROUTINE>(thread_dll_start), (LPVOID)program, 0, nullptr); handle)
     {
         CloseHandle(handle);
     }


### PR DESCRIPTION
This is achieved by splitting UE4SSProgram constructor into an init function, and only initializing the bare minimum in the constructor. This allows for the constructor to be in DllMain and run our code before any game code actually runs.

CppMods also got a new `dll_load` event, which notifies them when any dll got loaded into the process, this allows for mods to monitor when a dll that they're interested in loaded, and act accordingly.