### PR TITLE
Reworked the LiveView search options system

### DIFF
--- a/include/GUI/LiveView.hpp
+++ b/include/GUI/LiveView.hpp
@@ -25,24 +25,6 @@ namespace RC::GUI
     using namespace RC::Unreal;
 
     class UFunctionCallerWidget;
-    
-    struct SearchOptions
-    {
-        bool apply_when_not_searching{};
-        bool include_inheritance{};
-        bool instances_only{};
-        bool non_instances_only{};
-        bool include_default_objects{true};
-        bool default_objects_only{};
-        bool function_param_flags_required{};
-        std::array<bool, 255> function_param_checkboxes{};
-        EPropertyFlags function_param_flags{};
-        bool function_param_flags_include_return_property{};
-        std::string internal_exclude_class_name{};
-        StringType exclude_class_name{};
-        std::string internal_has_property{};
-        StringType has_property{};
-    };
 
     class LiveView
     {
@@ -139,7 +121,8 @@ namespace RC::GUI
         static std::vector<Watch> s_watches;
         static std::unordered_map<WatchIdentifier, Watch*> s_watch_map;
         static std::unordered_map<void*, std::vector<Watch*>> s_watch_containers;
-        static SearchOptions s_search_options;
+        static bool s_include_inheritance;
+        static bool s_apply_search_filters_when_not_searching;
         static bool s_create_listener_removed;
         static bool s_delete_listener_removed;
         static bool s_selected_item_deleted;

--- a/include/GUI/LiveView/Filter/DefaultObjectsOnly.hpp
+++ b/include/GUI/LiveView/Filter/DefaultObjectsOnly.hpp
@@ -1,0 +1,21 @@
+#ifndef UE4SS_GUI_DEFAULT_OBJECTS_ONLY_HPP
+#define UE4SS_GUI_DEFAULT_OBJECTS_ONLY_HPP
+
+#include <GUI/LiveView/Filter/SearchFilter.hpp>
+
+namespace RC::GUI::Filter
+{
+    class DefaultObjectsOnly
+    {
+    public:
+        static inline StringType s_debug_name{STR("DefaultObjectsOnly")};
+        static inline bool s_enabled{};
+
+        static auto pre_eval(UObject* object) -> bool
+        {
+            return s_enabled && !object->HasAnyFlags(static_cast<EObjectFlags>(RF_ClassDefaultObject | RF_ArchetypeObject));
+        }
+    };
+}
+
+#endif //UE4SS_GUI_DEFAULT_OBJECTS_ONLY_HPP

--- a/include/GUI/LiveView/Filter/ExcludeClassName.hpp
+++ b/include/GUI/LiveView/Filter/ExcludeClassName.hpp
@@ -1,0 +1,32 @@
+#ifndef UE4SS_GUI_EXCLUDE_CLASS_NAME_HPP
+#define UE4SS_GUI_EXCLUDE_CLASS_NAME_HPP
+
+#include <GUI/LiveView/Filter/SearchFilter.hpp>
+#include <Unreal/UClass.hpp>
+
+namespace RC::GUI::Filter
+{
+    class ExcludeClassName
+    {
+    public:
+        static inline StringType s_debug_name{STR("ExcludeClassName")};
+        static inline StringType s_value{};
+        static inline std::string s_internal_value{};
+
+        static auto post_eval(UObject* object) -> bool
+        {
+            if (!s_value.empty())
+            {
+                auto class_name = object->GetClassPrivate()->GetName();
+                auto pos = class_name.find(s_value);
+                return pos != class_name.npos;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    };
+}
+
+#endif //UE4SS_GUI_EXCLUDE_CLASS_NAME_HPP

--- a/include/GUI/LiveView/Filter/FunctionParamFlags.hpp
+++ b/include/GUI/LiveView/Filter/FunctionParamFlags.hpp
@@ -1,0 +1,43 @@
+#ifndef UE4SS_GUI_FUNCTION_PARAM_FLAGS_HPP
+#define UE4SS_GUI_FUNCTION_PARAM_FLAGS_HPP
+
+#include <GUI/LiveView/Filter/SearchFilter.hpp>
+#include <Unreal/UFunction.hpp>
+#include <Unreal/FProperty.hpp>
+
+namespace RC::GUI::Filter
+{
+    class FunctionParamFlags
+    {
+    public:
+        static inline StringType s_debug_name{STR("FunctionParamFlags")};
+        static inline bool s_enabled{};
+        static inline  std::array<bool, 255> s_checkboxes{};
+        static inline EPropertyFlags s_value{};
+        static inline bool s_include_return_property{};
+
+        static auto post_eval(UObject* object) -> bool
+        {
+            if (s_value != CPF_None)
+            {
+                if (!object->IsA<UFunction>()) { return true; }
+                auto as_function = static_cast<UFunction*>(object);
+                auto first_property = as_function->GetFirstProperty();
+                if (!first_property || (first_property->HasAnyPropertyFlags(CPF_ReturnParm) && !first_property->HasNext())) { return true; }
+                bool has_all_required_flags{true};
+                for (const auto& param : as_function->ForEachProperty())
+                {
+                    if (param->HasAnyPropertyFlags(CPF_ReturnParm) && !s_include_return_property) { continue; }
+                    has_all_required_flags = param->HasAllPropertyFlags(s_value);
+                }
+                return !has_all_required_flags;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    };
+}
+
+#endif //UE4SS_GUI_FUNCTION_PARAM_FLAGS_HPP

--- a/include/GUI/LiveView/Filter/HasProperty.hpp
+++ b/include/GUI/LiveView/Filter/HasProperty.hpp
@@ -1,0 +1,22 @@
+#ifndef UE4SS_GUI_HAS_PROPERTY_HPP
+#define UE4SS_GUI_HAS_PROPERTY_HPP
+
+#include <GUI/LiveView/Filter/SearchFilter.hpp>
+
+namespace RC::GUI::Filter
+{
+    class HasProperty
+    {
+    public:
+        static inline StringType s_debug_name{STR("HasProperty")};
+        static inline StringType s_value{};
+        static inline std::string s_internal_value{};
+
+        static auto post_eval(UObject* object) -> bool
+        {
+            return !s_value.empty() && !object->GetPropertyByNameInChain(s_value.c_str());
+        }
+    };
+}
+
+#endif //UE4SS_GUI_HAS_PROPERTY_HPP

--- a/include/GUI/LiveView/Filter/IncludeDefaultObjects.hpp
+++ b/include/GUI/LiveView/Filter/IncludeDefaultObjects.hpp
@@ -1,0 +1,21 @@
+#ifndef UE4SS_GUI_INCLUDE_DEFAULT_OBJECTS_HPP
+#define UE4SS_GUI_INCLUDE_DEFAULT_OBJECTS_HPP
+
+#include <GUI/LiveView/Filter/SearchFilter.hpp>
+
+namespace RC::GUI::Filter
+{
+    class IncludeDefaultObjects
+    {
+    public:
+        static inline StringType s_debug_name{STR("IncludeDefaultObjects")};
+        static inline bool s_enabled{true};
+
+        static auto pre_eval(UObject* object) -> bool
+        {
+            return !s_enabled && object->HasAnyFlags(static_cast<EObjectFlags>(RF_ClassDefaultObject | RF_ArchetypeObject));
+        }
+    };
+}
+
+#endif //UE4SS_GUI_INCLUDE_DEFAULT_OBJECTS_HPP

--- a/include/GUI/LiveView/Filter/InstancesOnly.hpp
+++ b/include/GUI/LiveView/Filter/InstancesOnly.hpp
@@ -1,0 +1,20 @@
+#ifndef UE4SS_GUI_INSTANCES_ONLY_HPP
+#define UE4SS_GUI_INSTANCES_ONLY_HPP
+
+#include <GUI/LiveView/Filter/SearchFilter.hpp>
+
+namespace RC::GUI::Filter
+{
+    class InstancesOnly
+    {
+    public:
+        static inline StringType s_debug_name{STR("InstancesOnly")};
+        static inline bool s_enabled{};
+        static auto pre_eval(UObject* object) -> bool
+        {
+            return s_enabled && !is_instance(object);
+        }
+    };
+}
+
+#endif //UE4SS_GUI_INSTANCES_ONLY_HPP

--- a/include/GUI/LiveView/Filter/NonInstancesOnly.hpp
+++ b/include/GUI/LiveView/Filter/NonInstancesOnly.hpp
@@ -1,0 +1,22 @@
+#ifndef UE4SS_GUI_NON_INSTANCES_ONLY_HPP
+#define UE4SS_GUI_NON_INSTANCES_ONLY_HPP
+
+#include <GUI/LiveView/Filter/SearchFilter.hpp>
+#include <Unreal/UFunction.hpp>
+
+namespace RC::GUI::Filter
+{
+    class NonInstancesOnly
+    {
+    public:
+        static inline StringType s_debug_name{STR("NonInstancesOnly")};
+        static inline bool s_enabled{};
+
+        static auto pre_eval(UObject* object) -> bool
+        {
+            return s_enabled && (object->IsA<UFunction>() || is_instance(object));
+        }
+    };
+}
+
+#endif //UE4SS_GUI_NON_INSTANCES_ONLY_HPP

--- a/include/GUI/LiveView/Filter/SearchFilter.hpp
+++ b/include/GUI/LiveView/Filter/SearchFilter.hpp
@@ -1,0 +1,128 @@
+#ifndef UE4SS_GUI_SEARCH_FILTER_HPP
+#define UE4SS_GUI_SEARCH_FILTER_HPP
+
+#include <Unreal/UPackage.hpp>
+#include <Unreal/UObject.hpp>
+#include <Unreal/UStruct.hpp>
+
+// To create a new filter:
+// 1. Create <FilterName>.hpp in the same directory as this file.
+// 2. Create a class that has either a 'pre_eval' or 'post_eval' function that returns true.
+//    'pre_eval' is executed before the object name has been processed if a search is currently being done.
+//    'post_eval' is executed after the object name has been processed.
+// 3. The 'pre_eval'/'post_eval' function must return true if the object is to be filtered out, and otherwise false.
+// 4. Open GUI/LiveView.cpp and find the 'SearchFilters' variable and add your new type to the list.
+// 5. In the same file, find the 'LiveView::render' function and find the 'if (ImGui::BeginPopupContextItem("##search-options"))' if-statement.
+// 6. Add a checkbox (or whatever) to control your search filter inside the if-statement.
+
+namespace RC::GUI::Filter
+{
+    using namespace Unreal;
+
+    template<typename...>
+    struct Types{};
+
+    template<typename T>
+    concept CanPreEval = requires(T t)
+    {
+        { T::pre_eval(std::declval<UObject*>()) };
+    };
+
+    template<typename T>
+    concept CanPostEval = requires(T t)
+    {
+        { T::post_eval(std::declval<UObject*>()) };
+    };
+
+    template<typename T>
+    auto eval_pre_search_filters(Types<T>&, UObject* object) -> bool
+    {
+        if constexpr (CanPreEval<T>)
+        {
+            return T::pre_eval(object);
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    template<typename T, typename... Ts>
+    auto eval_pre_search_filters(Types<T, Ts...>&, UObject* object) -> bool
+    {
+        auto eval_next_filters = [&] {
+            Types<Ts...> next_filters{};
+            return eval_pre_search_filters(next_filters, object);
+        };
+
+        if constexpr (CanPreEval<T>)
+        {
+            if (T::pre_eval(object))
+            {
+                return true;
+            }
+            else
+            {
+                return eval_next_filters();
+            }
+        }
+        else
+        {
+            return eval_next_filters();
+        }
+    }
+
+    template<typename T>
+    auto eval_post_search_filters(Types<T>&, UObject* object) -> bool
+    {
+        if constexpr (CanPostEval<T>)
+        {
+            return T::post_eval(object);
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    template<typename T, typename... Ts>
+    auto eval_post_search_filters(Types<T, Ts...>&, UObject* object) -> bool
+    {
+        auto eval_next_filters = [&] {
+            Types<Ts...> next_filters{};
+            return eval_post_search_filters(next_filters, object);
+        };
+
+        if constexpr (CanPostEval<T>)
+        {
+            if (T::post_eval(object))
+            {
+                return true;
+            }
+            else
+            {
+                return eval_next_filters();
+            }
+        }
+        else
+        {
+            return eval_next_filters();
+        }
+    }
+
+#define APPLY_PRE_SEARCH_FILTERS(Filters) \
+if (eval_pre_search_filters(Filters, object)) { return true; }
+
+#define APPLY_POST_SEARCH_FILTERS(Filters) \
+if (eval_post_search_filters(Filters, object)) { return true; }
+
+    static auto is_instance(UObject* object) -> bool
+    {
+        return !object->HasAnyFlags(static_cast<EObjectFlags>(RF_ClassDefaultObject | RF_ArchetypeObject)) &&
+               !object->IsA<UStruct>() &&
+               !object->IsA<UField>() &&
+               !object->IsA<UPackage>();
+    }
+}
+
+#endif //UE4SS_GUI_SEARCH_FILTER_HPP


### PR DESCRIPTION
Each "search option" is now referred to as a "filter". Each filter has its own file & class which keeps LiveView.cpp clean. Each filter can keep track of state but the state must be static as we're never instantiating any of these classes but this could be changed if needed.

To create a new filter:
1. Create <FilterName>.hpp in the same directory as this file.
2. Create a class that has either a 'pre_eval' or 'post_eval' function that returns true. 'pre_eval' is executed before the object name has been processed if a search is currently being done. 'post_eval' is executed after the object name has been processed.
3. The 'pre_eval'/'post_eval' function must return true if the object is to be filtered out, and otherwise false.
4. Open GUI/LiveView.cpp and find the 'SearchFilters' variable and add your new type to the list.
5. In the same file, find the 'LiveView::render' function and find the 'if (ImGui::BeginPopupContextItem("##search-options"))' if-statement.
6. Add a checkbox (or whatever) to control your search filter inside the if-statement.