### PR TITLE
Change default keybinds for cxx/object dumpers

### DIFF
--- a/assets/Mods/Keybinds/Scripts/main.lua
+++ b/assets/Mods/Keybinds/Scripts/main.lua
@@ -11,8 +11,8 @@
     Valid keys and modifier keys can be found at the bottom of this file.
 --]]
 Keybinds = {
-    ["ObjectDumper"]                 = {["Key"] = Key.J,             ["ModifierKeys"] = {}},
-    ["CXXHeaderGenerator"]           = {["Key"] = Key.D,             ["ModifierKeys"] = {ModifierKey.CONTROL}},
+    ["ObjectDumper"]                 = {["Key"] = Key.J,             ["ModifierKeys"] = {ModifierKey.CONTROL}},
+    ["CXXHeaderGenerator"]           = {["Key"] = Key.H,             ["ModifierKeys"] = {ModifierKey.CONTROL}},
     ["UHTCompatibleHeaderGenerator"] = {["Key"] = Key.NUM_NINE,      ["ModifierKeys"] = {ModifierKey.CONTROL}},
     ["DumpStaticMeshes"]             = {["Key"] = Key.NUM_EIGHT,     ["ModifierKeys"] = {ModifierKey.CONTROL}},
     ["DumpAllActors"]                = {["Key"] = Key.NUM_SEVEN,     ["ModifierKeys"] = {ModifierKey.CONTROL}},

--- a/docs/feature-overview/dumpers.md
+++ b/docs/feature-overview/dumpers.md
@@ -4,7 +4,7 @@
 
 The C++ dumper is a tool that generates C++ headers from UE4 classes and blueprints.
 
-The keybind to generate headers is by default `CTRL` + `D`, and it can be changed in `Mods/Keybinds/Scripts/main.lua`.
+The keybind to generate headers is by default `CTRL` + `H`, and it can be changed in `Mods/Keybinds/Scripts/main.lua`.
 
 It generates a `.hpp` file for each blueprint (including animation blueprint and widget blueprint), and then all of the base classes inside of `<ProjectName>.hpp` or `<EngineModule>.hpp`. All classes are at the top of the files, followed by all structs. Enums are seperated into files named the same as their class, but with `_enums` appended to the end.
 
@@ -63,7 +63,7 @@ The keybind to generate headers is by default `CTRL` + `Numpad 9`, and it can be
 
 Dumps all loaded objects to the file `UE4SS_ObjectDump.txt` (you can turn on force loading for all assets). 
 
-The keybind to dump objects is by default `J`, and can be changed in `Mods/Keybinds/Scripts/main.lua`.
+The keybind to dump objects is by default `CTRL` + `J`, and can be changed in `Mods/Keybinds/Scripts/main.lua`.
 
 Example output:
 ```


### PR DESCRIPTION
To avoid issues where you're playing the game and you accidentally hit the keybind (a mistake that is easily made with current defaults).