### PR TITLE
Simplified GUI tabs

### DIFF
--- a/include/GUI/GUITab.hpp
+++ b/include/GUI/GUITab.hpp
@@ -1,7 +1,14 @@
 #pragma once
 
+#include <utility>
+
 #include <File/Macros.hpp>
 #include <GUI/GUI.hpp>
+
+namespace RC
+{
+    class CppUserModBase;
+}
 
 namespace RC::GUI
 {
@@ -10,13 +17,16 @@ namespace RC::GUI
     friend class DebuggingGUI;
 
     protected:
+        CppUserModBase* owner{};
         StringType TabName{};
 
     public:
-        GUITab() = default;
+        GUITab() = delete;
+        explicit GUITab(StringViewType Name, CppUserModBase* owner) : TabName(Name), owner(owner) {};
         ~GUITab() = default;
 
-        virtual auto render() -> void {}
+    protected:
+        auto get_owner() -> CppUserModBase* { return owner; }
     };
 }
 

--- a/include/GUI/GUITab.hpp
+++ b/include/GUI/GUITab.hpp
@@ -16,16 +16,20 @@ namespace RC::GUI
     {
     friend class DebuggingGUI;
 
-    protected:
+    public:
+        using RenderFunctionType = void(*)(CppUserModBase*);
+
+    private:
+        RenderFunctionType render_function{};
         CppUserModBase* owner{};
         StringType tab_name{};
 
     public:
         GUITab() = delete;
-        explicit GUITab(StringViewType name, CppUserModBase* owner) : tab_name(name), owner(owner) {};
+        explicit GUITab(StringViewType name, RenderFunctionType render_function, CppUserModBase* owner) : tab_name(name), render_function(render_function), owner(owner) {};
         ~GUITab() = default;
 
-    protected:
+    private:
         auto get_owner() -> CppUserModBase* { return owner; }
     };
 }

--- a/include/GUI/GUITab.hpp
+++ b/include/GUI/GUITab.hpp
@@ -26,7 +26,8 @@ namespace RC::GUI
 
     public:
         GUITab() = delete;
-        explicit GUITab(StringViewType name, RenderFunctionType render_function, CppUserModBase* owner) : tab_name(name), render_function(render_function), owner(owner) {};
+        GUITab(StringViewType name, RenderFunctionType render_function) : tab_name(name), render_function(render_function) {};
+        GUITab(StringViewType name, RenderFunctionType render_function, CppUserModBase* owner) : tab_name(name), render_function(render_function), owner(owner) {};
         ~GUITab() = default;
 
     private:

--- a/include/GUI/GUITab.hpp
+++ b/include/GUI/GUITab.hpp
@@ -18,11 +18,11 @@ namespace RC::GUI
 
     protected:
         CppUserModBase* owner{};
-        StringType TabName{};
+        StringType tab_name{};
 
     public:
         GUITab() = delete;
-        explicit GUITab(StringViewType Name, CppUserModBase* owner) : TabName(Name), owner(owner) {};
+        explicit GUITab(StringViewType name, CppUserModBase* owner) : tab_name(name), owner(owner) {};
         ~GUITab() = default;
 
     protected:

--- a/include/Mod/CppMod.hpp
+++ b/include/Mod/CppMod.hpp
@@ -2,6 +2,7 @@
 
 #include <vector>
 
+#define NOMINMAX
 #include <Windows.h>
 
 #include <Mod/CppUserModBase.hpp>

--- a/include/Mod/CppUserModBase.hpp
+++ b/include/Mod/CppUserModBase.hpp
@@ -5,6 +5,7 @@
 
 #include <Common.hpp>
 #include <File/Macros.hpp>
+#include <GUI/GUITab.hpp>
 
 namespace RC
 {
@@ -22,17 +23,12 @@ namespace RC
         class Lua;
     }
 
-    namespace GUI
-    {
-        class GUITab;
-    }
-
     // When making C++ mods, keep in mind that they will break if UE4SS and the mod don't use the same C Runtime library version
     // This includes them being compiled in different configurations (Debug/Release).
     class CppUserModBase
     {
     protected:
-        std::shared_ptr<GUI::GUITab> GUITab{};
+        std::vector<std::shared_ptr<GUI::GUITab>> GUITabs{};
 
     public:
         StringType ModName{};
@@ -68,7 +64,7 @@ namespace RC
         RC_UE4SS_API auto virtual render_tab() -> void {};
 
     protected:
-        RC_UE4SS_API auto register_tab(std::wstring_view tab_name) -> void;
+        RC_UE4SS_API auto register_tab(std::wstring_view tab_name, GUI::GUITab::RenderFunctionType) -> void;
     };
 }
 

--- a/include/Mod/CppUserModBase.hpp
+++ b/include/Mod/CppUserModBase.hpp
@@ -43,7 +43,7 @@ namespace RC
 
     public:
         RC_UE4SS_API CppUserModBase();
-        RC_UE4SS_API virtual ~CppUserModBase() = default;
+        RC_UE4SS_API virtual ~CppUserModBase();
 
     public:
         RC_UE4SS_API auto virtual on_update() -> void {}

--- a/include/Mod/CppUserModBase.hpp
+++ b/include/Mod/CppUserModBase.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <memory>
 
 #include <Common.hpp>
 #include <File/Macros.hpp>
@@ -21,10 +22,18 @@ namespace RC
         class Lua;
     }
 
+    namespace GUI
+    {
+        class GUITab;
+    }
+
     // When making C++ mods, keep in mind that they will break if UE4SS and the mod don't use the same C Runtime library version
     // This includes them being compiled in different configurations (Debug/Release).
     class CppUserModBase
     {
+    protected:
+        std::shared_ptr<GUI::GUITab> GUITab{};
+
     public:
         StringType ModName{};
         StringType ModVersion{};
@@ -55,6 +64,11 @@ namespace RC
         RC_UE4SS_API auto virtual on_lua_start(LuaMadeSimple::Lua& lua, LuaMadeSimple::Lua& main_lua, LuaMadeSimple::Lua& async_lua, std::vector<LuaMadeSimple::Lua*>& hook_luas) -> void {}
 
         RC_UE4SS_API auto virtual on_dll_load(std::wstring_view dll_name) -> void {}
+
+        RC_UE4SS_API auto virtual render_tab() -> void {};
+
+    protected:
+        RC_UE4SS_API auto register_tab(std::wstring_view tab_name) -> void;
     };
 }
 

--- a/src/GUI/GUI.cpp
+++ b/src/GUI/GUI.cpp
@@ -152,7 +152,7 @@ namespace RC::GUI
                     std::lock_guard<std::mutex> guard(m_tabs_mutex);
                     for (const auto& tab : m_tabs)
                     {
-                        if (ImGui::BeginTabItem(to_string(tab->TabName).c_str()))
+                        if (ImGui::BeginTabItem(to_string(tab->tab_name).c_str()))
                         {
                             if (tab->get_owner()) { tab->get_owner()->render_tab(); }
                             ImGui::EndTabItem();

--- a/src/GUI/GUI.cpp
+++ b/src/GUI/GUI.cpp
@@ -154,7 +154,7 @@ namespace RC::GUI
                     {
                         if (ImGui::BeginTabItem(to_string(tab->TabName).c_str()))
                         {
-                            tab->render();
+                            if (tab->get_owner()) { tab->get_owner()->render_tab(); }
                             ImGui::EndTabItem();
                         }
                     }

--- a/src/GUI/GUI.cpp
+++ b/src/GUI/GUI.cpp
@@ -154,7 +154,7 @@ namespace RC::GUI
                     {
                         if (ImGui::BeginTabItem(to_string(tab->tab_name).c_str()))
                         {
-                            if (tab->get_owner()) { tab->get_owner()->render_tab(); }
+                            if (tab->render_function) { tab->render_function(tab->get_owner()); }
                             ImGui::EndTabItem();
                         }
                     }

--- a/src/Mod/CppUserModBase.cpp
+++ b/src/Mod/CppUserModBase.cpp
@@ -1,5 +1,7 @@
 #include <Mod/CppUserModBase.hpp>
 #include <Mod/CppMod.hpp>
+#include <GUI/GUITab.hpp>
+#include <UE4SSProgram.hpp>
 
 namespace RC
 {
@@ -9,5 +11,11 @@ namespace RC
         {
             ModIntendedSDKVersion = std::format(STR("{}.{}.{}"), UE4SS_LIB_VERSION_MAJOR, UE4SS_LIB_VERSION_MINOR, UE4SS_LIB_VERSION_HOTFIX);
         }
+    }
+
+    auto CppUserModBase::register_tab(std::wstring_view tab_name) -> void
+    {
+        GUITab = std::make_shared<GUI::GUITab>(tab_name, this);
+        UE4SSProgram::get_program().add_gui_tab(GUITab);
     }
 }

--- a/src/Mod/CppUserModBase.cpp
+++ b/src/Mod/CppUserModBase.cpp
@@ -13,6 +13,15 @@ namespace RC
         }
     }
 
+    CppUserModBase::~CppUserModBase()
+    {
+        if (GUITab)
+        {
+            UE4SSProgram::get_program().remove_gui_tab(GUITab);
+            GUITab = nullptr;
+        }
+    }
+
     auto CppUserModBase::register_tab(std::wstring_view tab_name) -> void
     {
         GUITab = std::make_shared<GUI::GUITab>(tab_name, this);

--- a/src/Mod/CppUserModBase.cpp
+++ b/src/Mod/CppUserModBase.cpp
@@ -1,6 +1,5 @@
 #include <Mod/CppUserModBase.hpp>
 #include <Mod/CppMod.hpp>
-#include <GUI/GUITab.hpp>
 #include <UE4SSProgram.hpp>
 
 namespace RC
@@ -15,16 +14,19 @@ namespace RC
 
     CppUserModBase::~CppUserModBase()
     {
-        if (GUITab)
+        for (const auto& tab : GUITabs)
         {
-            UE4SSProgram::get_program().remove_gui_tab(GUITab);
-            GUITab = nullptr;
+            if (tab)
+            {
+                UE4SSProgram::get_program().remove_gui_tab(tab);
+            }
         }
+        GUITabs.clear();
     }
 
-    auto CppUserModBase::register_tab(std::wstring_view tab_name) -> void
+    auto CppUserModBase::register_tab(std::wstring_view tab_name, GUI::GUITab::RenderFunctionType render_function) -> void
     {
-        GUITab = std::make_shared<GUI::GUITab>(tab_name, this);
-        UE4SSProgram::get_program().add_gui_tab(GUITab);
+        auto& tab = GUITabs.emplace_back(std::make_shared<GUI::GUITab>(tab_name, render_function, this));
+        UE4SSProgram::get_program().add_gui_tab(tab);
     }
 }


### PR DESCRIPTION
GUI tabs have been simplified both for use with mods and without mods.
Simply call `register_tab` in your mod constructor with a name and a render function.
The render function has this signature: `void(CppUserModBase*)`.
The `CppUserModBase*` param can be safely cast to your own mod class.
The param is nullptr if the tab wasn't created with the `register_tab` function.
The tab is automatically removed when your mod is unloaded.

Tabs can also be created with `UE4SSProgram::add_gui_tab` and in which case it requires that you construct a `GUI::GUITab` yourself and you also have to manually call `UE4SSProgram::remove_gui_tab` to remove the tab when your mod unloads.