### PR TITLE
Improvements to string conversion

### DIFF
--- a/Dependencies/Helpers/include/Helpers/String.hpp
+++ b/Dependencies/Helpers/include/Helpers/String.hpp
@@ -145,7 +145,7 @@ namespace RC
     auto inline to_wstring(std::string& input) -> std::wstring
     {
 #pragma warning(disable: 4996)
-        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter{};
+        static std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter{};
         return converter.from_bytes(input);
 #pragma warning(default: 4996)
     }
@@ -192,7 +192,7 @@ namespace RC
     auto inline to_string(std::wstring& input) -> std::string
     {
 #pragma warning(disable: 4996)
-        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter{};
+        static std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter{};
         return converter.to_bytes(input);
 #pragma warning(default: 4996)
     }


### PR DESCRIPTION
At the moment we're reinitializing std::wstring_convert every time we want to convert a string and this has a big performance impact when doing a lot of conversions. I think it'd be better to make it static and initialize it only once.

The benchmarks below are using the string "Class /Script/Engine.PlayerController"

### Before

```
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|           18,238.33 |           54,829.57 |    1.6% |      0.01 | `wstring to string conversion`
|           18,809.26 |           53,165.30 |    2.3% |      0.01 | `string to wstring conversion`
```

### After

```
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|              225.06 |        4,443,177.10 |    4.4% |      0.01 | `wstring to string conversion`
|              319.33 |        3,131,552.56 |    3.9% |      0.01 | `string to wstring conversion`
```