### PR TITLE
Added 'on_lua_stop' to C++ mods

### DIFF
--- a/UE4SS/include/Mod/CppMod.hpp
+++ b/UE4SS/include/Mod/CppMod.hpp
@@ -44,6 +44,9 @@ namespace RC
         auto fire_on_lua_start(LuaMadeSimple::Lua& lua, LuaMadeSimple::Lua& main_lua, LuaMadeSimple::Lua& async_lua, std::vector<LuaMadeSimple::Lua*>& hook_luas)
                 -> void;
 
+        auto fire_on_lua_stop(LuaMadeSimple::Lua& lua, LuaMadeSimple::Lua& main_lua, LuaMadeSimple::Lua& async_lua, std::vector<LuaMadeSimple::Lua*>& hook_luas)
+                -> void;
+
         auto fire_unreal_init() -> void override;
         auto fire_program_start() -> void override;
         auto fire_update() -> void override;

--- a/UE4SS/include/Mod/CppUserModBase.hpp
+++ b/UE4SS/include/Mod/CppUserModBase.hpp
@@ -70,6 +70,20 @@ namespace RC
         {
         }
 
+        /**
+         * Executes before a Lua mod of the same name is about to be stopped.
+         * @param lua This is the main Lua instance.
+         * @param main_lua This is the main Lua thread instance.
+         * @param async_lua This is the Lua instance for asynchronous things like ExecuteAsync and ExecuteWithDelay.
+         * @param hook_luas This is a container of Lua instances that are used for game-thread hooks like ExecuteInGameThread.
+         */
+        RC_UE4SS_API auto virtual on_lua_stop(LuaMadeSimple::Lua& lua,
+                                               LuaMadeSimple::Lua& main_lua,
+                                               LuaMadeSimple::Lua& async_lua,
+                                               std::vector<LuaMadeSimple::Lua*>& hook_luas) -> void
+        {
+        }
+
         RC_UE4SS_API auto virtual on_dll_load(std::wstring_view dll_name) -> void
         {
         }

--- a/UE4SS/include/Mod/LuaMod.hpp
+++ b/UE4SS/include/Mod/LuaMod.hpp
@@ -129,6 +129,7 @@ namespace RC
         auto setup_lua_global_functions_main_state_only() const -> void;
         auto setup_lua_classes(const LuaMadeSimple::Lua& lua) const -> void;
         auto fire_on_lua_start_for_cpp_mod() -> void;
+        auto fire_on_lua_stop_for_cpp_mod() -> void;
 
       public:
         auto start_mod() -> void override;

--- a/UE4SS/src/Mod/CppMod.cpp
+++ b/UE4SS/src/Mod/CppMod.cpp
@@ -87,6 +87,15 @@ namespace RC
         }
     }
 
+    auto CppMod::fire_on_lua_stop(LuaMadeSimple::Lua& lua, LuaMadeSimple::Lua& main_lua, LuaMadeSimple::Lua& async_lua, std::vector<LuaMadeSimple::Lua*>& hook_luas)
+            -> void
+    {
+        if (m_mod)
+        {
+            m_mod->on_lua_stop(lua, main_lua, async_lua, hook_luas);
+        }
+    }
+
     auto CppMod::fire_unreal_init() -> void
     {
         if (m_mod)

--- a/UE4SS/src/Mod/LuaMod.cpp
+++ b/UE4SS/src/Mod/LuaMod.cpp
@@ -3120,6 +3120,15 @@ Overloads:
         }
     }
 
+    auto LuaMod::fire_on_lua_stop_for_cpp_mod() -> void
+    {
+        auto cpp_mod = UE4SSProgram::find_mod_by_name<CppMod>(get_name(), UE4SSProgram::IsInstalled::Yes);
+        if (cpp_mod)
+        {
+            cpp_mod->fire_on_lua_stop(m_lua, *m_main_lua, *m_async_lua, m_hook_lua);
+        }
+    }
+
     auto LuaMod::start_mod() -> void
     {
         prepare_mod(lua());
@@ -3150,6 +3159,8 @@ Overloads:
         std::lock_guard<std::recursive_mutex> guard{LuaMod::m_thread_actions_mutex};
 
         Output::send(STR("Stopping mod '{}' for uninstall\n"), m_mod_name);
+
+        fire_on_lua_stop_for_cpp_mod();
 
         if (m_async_thread.joinable())
         {

--- a/UE4SS/src/UE4SSProgram.cpp
+++ b/UE4SS/src/UE4SSProgram.cpp
@@ -1182,9 +1182,28 @@ namespace RC
 
     auto UE4SSProgram::uninstall_mods() -> void
     {
+        std::vector<CppMod*> cpp_mods{};
+        std::vector<LuaMod*> lua_mods{};
         for (auto& mod : m_mods)
         {
+            if (auto cpp_mod = dynamic_cast<CppMod*>(mod.get()); cpp_mod)
+            {
+                cpp_mods.emplace_back(cpp_mod);
+            }
+            else if (auto lua_mod = dynamic_cast<LuaMod*>(mod.get()); lua_mod)
+            {
+                lua_mods.emplace_back(lua_mod);
+            }
+        }
+
+        for (auto& mod : lua_mods)
+        {
             // Remove any actions, or we'll get an internal error as the lua ref won't be valid
+            mod->uninstall();
+        }
+
+        for (auto& mod : cpp_mods)
+        {
             mod->uninstall();
         }
 

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -33,6 +33,9 @@ Added `on_lua_start` for C++ mods.
 This function fires whenever a Lua mod by the same name as the C++ mod is started.  
 It allows interactions with Lua from C++ mods.
 
+Added `on_lua_stop` for C++ mods.
+This function fires right before a Lua mod by the same name as the C++ mod is about to be stopped.
+
 Added `UFunction::RegisterPreHookForInstance` and `UFunction::RegisterPostHookForInstance`  
 These functions work the same as `UFunction::RegisterPreHook`/`UFunction::RegisterPostHook` except the callback is only fired if the context matches the specified instance  
 These new functions need to be handled with care as they can cause crashes if you don't validate that the instance you're passing during registration is valid inside the callback


### PR DESCRIPTION
Also, Lua mods are now guaranteed to be uninstalled before C++ mods when mods are reinstalled/hot-reloaded.