### PR TITLE
Added an optional third param to the global Lua function RegisterHook

### DIFF
--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -18,6 +18,11 @@ The shortcut (previously J) for dumping objects (generating UE4SS_ObjectDump.txt
 
 The shortcut (previously D) for generating CXX headers has been changed to CTRL + H
 
+### Lua API
+Added an optional third parameter to `RegisterHook`  
+If provided, it will act as a post callback hook where out-params can be modified  
+Note that for BP-only functions, both callbacks act as post callbacks
+
 
 ### C++ API
 Finalize C++ API. - LocalCC; Truman


### PR DESCRIPTION
If provided, it will act as a post callback hook where out-params can be modified.

The return value can be modified by simply returning the new value.
If you don't return anything, the return value from the pre callback will be used unless that callback also didn't return anything, in which case the original UFunction return value will be used.

If you return something in this function, it will override any return value from the pre callback.

Note that for BP-only functions, both callback to RegisterHook act as a post callback.