### PR TITLE
Added 'Has Property Type' search filter to live view

### DIFF
--- a/UE4SS/include/GUI/LiveView/Filter/HasPropertyType.hpp
+++ b/UE4SS/include/GUI/LiveView/Filter/HasPropertyType.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <GUI/LiveView/Filter/SearchFilter.hpp>
+#include <Unreal/NameTypes.hpp>
+
+namespace RC::GUI::Filter
+{
+    class HasPropertyType
+    {
+      public:
+        static inline StringType s_debug_name{STR("HasPropertyType")};
+        static inline FName s_value{};
+        static inline std::string s_internal_value{};
+
+        static auto post_eval(UObject* object) -> bool
+        {
+            if (!s_value || s_internal_value.empty()) { return false; }
+
+            auto as_struct = Cast<UStruct>(object);
+            if (!as_struct)
+            {
+                as_struct = object->GetClassPrivate();
+            }
+
+            bool should_filter_object_out = true;
+            for (const auto& property : as_struct->ForEachPropertyInChain())
+            {
+                if (property->GetClass().GetFName() == s_value)
+                {
+                    should_filter_object_out = false;
+                    break;
+                }
+            }
+            return should_filter_object_out;
+        }
+    };
+} // namespace RC::GUI::Filter

--- a/UE4SS/src/GUI/LiveView.cpp
+++ b/UE4SS/src/GUI/LiveView.cpp
@@ -17,6 +17,7 @@
 #include <GUI/LiveView/Filter/ExcludeClassName.hpp>
 #include <GUI/LiveView/Filter/FunctionParamFlags.hpp>
 #include <GUI/LiveView/Filter/HasProperty.hpp>
+#include <GUI/LiveView/Filter/HasPropertyType.hpp>
 #include <GUI/LiveView/Filter/IncludeDefaultObjects.hpp>
 #include <GUI/LiveView/Filter/InstancesOnly.hpp>
 #include <GUI/LiveView/Filter/NonInstancesOnly.hpp>
@@ -53,7 +54,8 @@ namespace RC::GUI
                                               Filter::DefaultObjectsOnly,
                                               Filter::FunctionParamFlags,
                                               Filter::ExcludeClassName,
-                                              Filter::HasProperty>{};
+                                              Filter::HasProperty,
+                                              Filter::HasPropertyType>{};
 
     static int s_max_elements_per_chunk{};
     static int s_chunk_id_start{};
@@ -2561,6 +2563,16 @@ namespace RC::GUI
                 if (ImGui::InputText("##HasProperty", &Filter::HasProperty::s_internal_value))
                 {
                     Filter::HasProperty::s_value = to_wstring(Filter::HasProperty::s_internal_value);
+                }
+
+                // Row 7
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
+                ImGui::Text("Has property of type");
+                ImGui::TableNextColumn();
+                if (ImGui::InputText("##HasPropertyType", &Filter::HasPropertyType::s_internal_value))
+                {
+                    Filter::HasPropertyType::s_value = FName(to_wstring(Filter::HasPropertyType::s_internal_value), FNAME_Add);
                 }
 
                 ImGui::EndTable();

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -48,6 +48,8 @@ Can now view enum values in the Live View debugger
 
 Added a search option to exclude objects of a class with a name containing the specified (case-sensitive) string
 
+Added a search option to exclude objects that don't have a property of the specified type
+
 Added a checkbox that toggles search options globally, meaning when not searching
 
 ### UHT Dumper


### PR DESCRIPTION
The type is case-senstivive, so 'arrayproperty' will not work but 'ArrayProperty' will.
It filters out any objects that doesn't contain a property of the specified type.
Very useful for locating functions that have specific types of properties for testing purposes.