### PR TITLE
Constructs: add annotated types

### DIFF
--- a/deps/first/Constructs/include/Constructs/Annotated.hpp
+++ b/deps/first/Constructs/include/Constructs/Annotated.hpp
@@ -1,0 +1,90 @@
+#pragma once
+#include <concepts>
+#include <type_traits>
+
+#include <glaze/glaze.hpp>
+
+#include <Constructs/CompileTimeString.hpp>
+
+namespace RC
+{
+    /*
+     * @brief A type which allows for annotating other types with strings
+     *
+     * A type which allows for annotating other types with strings
+     * This type is most commonly used with json properties to annotate them with comments.
+     * The type also allows for transparent access of the inner value for ease of use.
+     *
+     * @tparam C annotation strings
+     * @tparam T inner value type
+     *
+     * Example:
+     *
+     * @code{.cpp}
+     * Annotated<Strings<"Hi", "Bye">, int> annotated_integer(123);
+     *
+     * for (const auto& comment : comments) {
+     *   Output::send(STR("{}\n"), comment);
+     * }
+     * @endcode
+     */
+    template <typename C, typename T>
+    struct Annotated
+    {
+        decltype(C::strings) comments = C::strings;
+        T value;
+
+        /*
+         * Create a new Annotated instance with a value
+         */
+        Annotated(T value) : value(std::move(value))
+        {
+        }
+
+        template <typename OtherC>
+        Annotated(const Annotated<OtherC, T>& other) noexcept
+            requires std::copy_constructible<T>
+            : value(other.value)
+        {
+        }
+
+        template <typename OtherC>
+        Annotated& operator=(const Annotated<OtherC, T>& other) noexcept
+            requires std::is_copy_assignable_v<T>
+        {
+            value = other.value;
+        }
+
+        template <typename OtherC>
+        Annotated(Annotated<OtherC, T>&& other) noexcept
+            requires std::move_constructible<T>
+            : value(std::move(other.value))
+        {
+        }
+
+        template <typename OtherC>
+        Annotated& operator=(Annotated<OtherC, T>&& other) noexcept
+            requires std::is_move_assignable_v<T>
+        {
+            value = std::move(other.value);
+        }
+
+        T operator*() const noexcept
+        {
+            return value;
+        }
+
+        T& operator->() noexcept
+        {
+            return value;
+        }
+
+        struct glaze
+        {
+            using GLZ_T = Annotated;
+            [[maybe_unused]] static constexpr std::string_view name = "Annotated";
+            static constexpr auto value = glz::object("Comments", &GLZ_T::comments, "Value", &GLZ_T::value);
+        };
+    };
+
+} // namespace RC

--- a/deps/first/Constructs/include/Constructs/CompileTimeString.hpp
+++ b/deps/first/Constructs/include/Constructs/CompileTimeString.hpp
@@ -1,0 +1,51 @@
+#pragma once
+#include <cstdint>
+#include <algorithm>
+#include <array>
+#include <string_view>
+
+namespace RC
+{
+    /*
+     * A compile-time string
+     *
+     * @tparam N string size
+     */
+    template <size_t N>
+    struct ConstString
+    {
+        constexpr ConstString(const char (&str)[N])
+        {
+            std::copy_n(str, N, value);
+        }
+
+        /*
+         * String value
+         */
+        char value[N];
+    };
+
+    template <size_t N>
+    ConstString(const char (&)[N]) -> ConstString<N>;
+
+    /*
+     * A compile-time collection of compile-time strings
+     *
+     * @tparam C compile-time strings
+     *
+     * Example:
+     *
+     * @code{.cpp}
+     * Strings<"Hi", "Bye"> strings;
+     * @endcode
+     */
+    template <ConstString... C>
+    struct Strings
+    {
+        /*
+         * Compile-time strings storage
+         */
+        constexpr static std::array strings = {std::string_view{C.value}...};
+    };
+
+} // namespace RC


### PR DESCRIPTION
Annotated types allow for types to have comments at runtime. This is mostly useful for json to provide comments inside of the json file, but could have other applications as well.

The types are done using compile-time strings/arrays to improve developer experience when creating instances of annotated types.