### PR TITLE
Fix cross compiling using clang on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ foreach (target_type ${TARGET_TYPES})
             set(CMAKE_CXX_FLAGS_${triplet_upper} "${final_compiler_flags}" CACHE STRING "" FORCE)
             set(CMAKE_C_FLAGS_${triplet_upper} "${final_compiler_flags}" CACHE STRING "" FORCE)
 
-            list(APPEND TARGET_COMPILE_OPTIONS "$<$<STREQUAL:$<CONFIG>,${triplet}>:${compiler_flags}>")
+            list(APPEND TARGET_COMPILE_OPTIONS "$<$<NOT:$<COMPILE_LANGUAGE:ASM_MASM>>:$<$<STREQUAL:$<CONFIG>,${triplet}>:${compiler_flags}>>")
 
             set(linker_flags
                 ${${target_type}_LINKER_FLAGS}

--- a/UE4SS/proxy_generator/CMakeLists.txt
+++ b/UE4SS/proxy_generator/CMakeLists.txt
@@ -4,7 +4,7 @@ set(TARGET proxy_generator)
 project(${TARGET})
 
 add_executable(${TARGET} "main.cpp")
-target_link_libraries(${TARGET} PRIVATE Constructs File ImageHlp)
+target_link_libraries(${TARGET} PRIVATE Constructs File imagehlp)
 target_compile_definitions(${TARGET} PRIVATE RC_FILE_BUILD_STATIC)
 
 add_subdirectory("proxy")


### PR DESCRIPTION
Couple of changes required to build on Linux using clang.

Using [xwin](https://github.com/Jake-Shadle/xwin) to obtain Windows libraries and headers:
```bash
xwin splat --output xwin --include-debug-libs
XWIN="$(realpath xwin)"
export INCLUDE="$XWIN/crt/include;$XWIN/sdk/include/ucrt;$XWIN/sdk/include/um;$XWIN/sdk/include/shared"
export LIB="$XWIN/crt/lib/x86_64;$XWIN/sdk/lib/um/x86_64;$XWIN/sdk/lib/ucrt/x86_64"

cmake -B build -G Ninja \
  -DCMAKE_C_COMPILER=clang-cl \
  -DCMAKE_CXX_COMPILER=clang-cl \
  -DCMAKE_MT=/usr/bin/llvm-mt \
  -DCMAKE_ASM_MASM_COMPILER=/usr/bin/llvm-ml \
  -DCMAKE_ASM_MASM_FLAGS=--m64 \
  -DCMAKE_BUILD_TYPE=Game__Shipping__Win64 \
  -DCMAKE_SYSTEM_NAME=Windows \
  -DUE4SS_PROXY_PATH=/path/to/xinput1_3.dll

cmake --build build
```
