### PR TITLE
Lua hooks (RegisterHook) can now access the original return value

### DIFF
--- a/UE4SS/src/Mod/LuaMod.cpp
+++ b/UE4SS/src/Mod/LuaMod.cpp
@@ -358,7 +358,7 @@ namespace RC
             // Call the Lua function with the correct number of parameters & return values
             // Increasing the 'num_params' by one to account for the 'this / context' param
             // Increasing it again if there's a return value because we store that as the second param
-            lua_data.lua.call_function(num_unreal_params + lua_data.has_return_value ? 2 : 1, 1);
+            lua_data.lua.call_function(num_unreal_params + (lua_data.has_return_value ? 2 : 1), 1);
 
             // Processing potential return value from the second callback.
             process_return_value();

--- a/UE4SS/src/Mod/LuaMod.cpp
+++ b/UE4SS/src/Mod/LuaMod.cpp
@@ -262,13 +262,6 @@ namespace RC
             }
         };
 
-        if (lua_data.lua.get_stack_size() > 0)
-        {
-            // Processing potential return value from the first callback.
-            // This only exists to keep compatibility with mods that set return values in the first callback.
-            process_return_value();
-        }
-
         if (lua_data.lua_post_callback_ref != -1)
         {
             // Use the stored registry index to put a Lua function on the Lua stack
@@ -360,7 +353,11 @@ namespace RC
             // Increasing it again if there's a return value because we store that as the second param
             lua_data.lua.call_function(num_unreal_params + (lua_data.has_return_value ? 2 : 1), 1);
 
-            // Processing potential return value from the second callback.
+            // Processing potential return values from both callbacks.
+            // Stack pos 1: return value from callback 1 (nil if nothing returned)
+            // Stack pos 2: return value from callback 2
+            // We will always have at leaste two return values, either one can be nil, and we need to process both in case one isn't nil.
+            process_return_value();
             process_return_value();
         }
 

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -45,7 +45,8 @@ Made `FWeakObjectPtr` overridable unless used in a TArray or TMap
 ### Lua API
 Added an optional third parameter to `RegisterHook`  
 If provided, it will act as a post callback hook where out-params can be modified  
-Note that for BP-only functions, both callbacks act as post callbacks
+Note that for BP-only functions, both callbacks act as post callbacks  
+If the hooked function has a return value, the second param to the post callback will be the return value
 
 Out-params for script hooks (`RegisterCustomEvent` or `RegisterHook` on a BP-only UFunction) can now be set by doing `Param:set(<new-value>)`
 


### PR DESCRIPTION
The second function passed to 'RegisterHook' now takes an additional param after the first param if the function has a return value. The param contains the return value pointer and you can use ':get()' to retrieve the value and ':set(<new-value>)' to set it but the return value of the actual Lua function will take precedence over calling 'set'.

Example:
```lua
RegisterHook("/Script/Engine.Character:CanJumpInternal", function()
    -- Some code.
end, function(ParamContext, ParamReturnValue)
    -- This value will be the original return value in the case where the pre-hook didn't modify it.
    -- It will be the modification done by the pre-hook otherwise.
    print(string.format("Return Value: %s\n", ParamReturnValue:get()))
end)
```