### PR TITLE
Added UEHelpers.FindOrAddFName

### DIFF
--- a/UE4SS/src/Mod/LuaMod.cpp
+++ b/UE4SS/src/Mod/LuaMod.cpp
@@ -3148,6 +3148,8 @@ Overloads:
         // Without this, the metatable won't be created until an FName is constructed by another part of UE4SS
         LuaType::FName::construct(lua, Unreal::FName(static_cast<int64_t>(0)));
         lua_setglobal(lua.get_lua_state(), "FName");
+        LuaType::FName::construct(lua, Unreal::NAME_None);
+        lua_setglobal(lua.get_lua_state(), "NAME_None");
         // FName Class -> END
 
         // FPackageName -> START

--- a/assets/Mods/BPModLoaderMod/Scripts/main.lua
+++ b/assets/Mods/BPModLoaderMod/Scripts/main.lua
@@ -18,7 +18,7 @@ local ModOrderList = {}
 
 local DefaultModConfig = {}
 DefaultModConfig.AssetName = "ModActor_C"
-DefaultModConfig.AssetNameAsFName = FName("ModActor_C")
+DefaultModConfig.AssetNameAsFName = UEHelpers.FindOrAddFName("ModActor_C")
 
 -- Checks if the beginning of a string contains a certain pattern.
 local function StartsWith(String, StringToCompare)
@@ -132,7 +132,7 @@ local function LoadModConfigs()
                 dofile(ModFile.__absolute_path)
                 if type(Mods[ModDirectoryName]) ~= "table" then break end
                 if not Mods[ModDirectoryName].AssetName then break end
-                Mods[ModDirectoryName].AssetNameAsFName = FName(Mods[ModDirectoryName].AssetName)
+                Mods[ModDirectoryName].AssetNameAsFName = UEHelpers.FindOrAddFName(Mods[ModDirectoryName].AssetName)
                 break
             end
         end
@@ -188,12 +188,12 @@ local function LoadMod(ModName, ModInfo, GameMode)
     local AssetData = nil
     if UnrealVersion.IsBelow(5, 1) then
         AssetData = {
-            ["ObjectPath"] = FName(string.format("%s.%s", ModInfo.AssetPath, ModInfo.AssetName), EFindName.FNAME_Add),
+            ["ObjectPath"] = UEHelpers.FindOrAddFName(string.format("%s.%s", ModInfo.AssetPath, ModInfo.AssetName)),
         }
     else
         AssetData = {
-            ["PackageName"] = FName(ModInfo.AssetPath, EFindName.FNAME_Add),
-            ["AssetName"] = FName(ModInfo.AssetName, EFindName.FNAME_Add),
+            ["PackageName"] = UEHelpers.FindOrAddFName(ModInfo.AssetPath),
+            ["AssetName"] = UEHelpers.FindOrAddFName(ModInfo.AssetName),
         }
     end
 

--- a/assets/Mods/ConsoleCommandsMod/Scripts/dump_object.lua
+++ b/assets/Mods/ConsoleCommandsMod/Scripts/dump_object.lua
@@ -1,6 +1,8 @@
 -- This is a custom implementation of UEs "obj dump <obj>" command.
 -- It doesn't have a 1:1 feature set.
 
+local UEHelpers = require("UEHelpers")
+
 --[[
     TODO: Expand on the console command format.
           You should be able to specify a sub-object, sub-struct, sub-array, sub-map, etc.
@@ -141,7 +143,7 @@ local function GetObjectByName(ObjectName)
 end
 
 local function GetPropertyByName(ObjectIn, PropertyName)
-    local PropertyFName = FName(PropertyName)
+    local PropertyFName = UEHelpers.FindOrAddFName(PropertyName)
     local Object = nil
 
     if ObjectIn:IsA(UClassStaticClass) or ObjectIn:IsA(UScriptStructStaticClass) then

--- a/assets/Mods/ConsoleEnablerMod/Scripts/main.lua
+++ b/assets/Mods/ConsoleEnablerMod/Scripts/main.lua
@@ -10,7 +10,7 @@ local function RemapConsoleKeys()
     local ConsoleKeys = InputSettings.ConsoleKeys
     
     -- This sets the first console key to F10
-    ConsoleKeys[1].KeyName = FName("F10")
+    ConsoleKeys[1].KeyName = FName("F10", EFindName.FNAME_Find)
     
     ConsoleKeys:ForEach(function(index, elem_wrapper)
         local KeyStruct = elem_wrapper:get()

--- a/assets/Mods/shared/UEHelpers/UEHelpers.lua
+++ b/assets/Mods/shared/UEHelpers/UEHelpers.lua
@@ -90,6 +90,14 @@ function UEHelpers.GetGameMapsSettings(ForceInvalidateCache)
     return CacheDefaultObject("/Script/EngineSettings.Default__GameMapsSettings", "UEHelpers_GameMapsSettings", ForceInvalidateCache)
 end
 
+function UEHelpers.FindOrAddFName(Name)
+    local NameFound = FName(Name, EFindName.FNAME_Find)
+    if NameFound == NAME_None then
+        NameFound = FName(Name, EFindName.FNAME_Add)
+    end
+    return NameFound
+end
+
 -- Exported functions -> END
 
 return UEHelpers

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -19,6 +19,7 @@
     - [CustomPropertyInfo](./lua-api/table-definitions/custompropertyinfo.md)
     - [EObjectFlags](./lua-api/table-definitions/eobjectflags.md)
     - [EInternalObjectFlags](./lua-api/table-definitions/einternalobjectflags.md)
+    - [EFindName](./lua-api/table-definitions/efindname.md)
   - [Classes]()
     - [RemoteObject](./lua-api/classes/remoteobject.md)
     - [LocalObject](./lua-api/classes/localobject.md)

--- a/docs/lua-api/global-functions/fname.md
+++ b/docs/lua-api/global-functions/fname.md
@@ -4,19 +4,19 @@ The `FName` function is used to get an `FName` representation of a `string` or `
 
 ## Parameters (overload #1)
 
-This overload mimics [FName::FName](https://docs.unrealengine.com/4.27/en-US/API/Runtime/Core/UObject/FName/__ctor/7/) with the `FindType` param set to `EFindName::FName_Find`.
+This overload mimics [FName::FName](https://docs.unrealengine.com/4.27/en-US/API/Runtime/Core/UObject/FName/__ctor/7/) with the `FindType` param set to `EFindName::FName_Add`.
 
-| # | Type     | Information |
-|---|----------|-------------|
-| 1 | string   | String that you'd like to get an FName representation of |
-| 2 | EFindName | Finding or adding name type. It can be either `FNAME_Find` or `FNAME_Add`. Default is `FNAME_Find` if not explicitly supplied |
+| # | Type     | Information                                                                                                                  |
+|---|----------|------------------------------------------------------------------------------------------------------------------------------|
+| 1 | string   | String that you'd like to get an FName representation of                                                                     |
+| 2 | EFindName | Finding or adding name type. It can be either `FNAME_Find` or `FNAME_Add`. Default is `FNAME_Add` if not explicitly supplied |
 
 ## Parameters (overload #2)
 
-| # | Type     | Information |
-|---|----------|-------------|
-| 1 | integer  | 64-bit integer representing the `ComparisonIndex` part that you'd like to get an FName representation of |
-| 2 | EFindName | Finding or adding name type. It can be either `FNAME_Find` or `FNAME_Add`. Default is `FNAME_Find` if not explicitly supplied |
+| # | Type     | Information                                                                                                                  |
+|---|----------|------------------------------------------------------------------------------------------------------------------------------|
+| 1 | integer  | 64-bit integer representing the `ComparisonIndex` part that you'd like to get an FName representation of                     |
+| 2 | EFindName | Finding or adding name type. It can be either `FNAME_Find` or `FNAME_Add`. Default is `FNAME_Add` if not explicitly supplied |
 
 ## Return Value
 

--- a/docs/lua-api/table-definitions/efindname.md
+++ b/docs/lua-api/table-definitions/efindname.md
@@ -1,0 +1,6 @@
+# EFindName
+
+Field Name | Field Value Type
+--------- | --------------
+FNAME_Find               | 0
+FNAME_Add                | 1


### PR DESCRIPTION
This function will return the FName if it exists, and otherwise it will create it.

The UE documentation for 'EFindName::FNAME_Add' doesn't seem to be correct. It says: "Find a name or add it if it doesn't exist.", however, if the name already exists, it will add a new name with a number suffixed to it like "_0". This new UEHelpers function doesn't have this functionality and instead will return the original name without any extra suffix.

Also updated the docs to correctly point out that FNAME_Add is the default for the FName constructor, not FNAME_Find. Also added EFindName to the docs.