### PR TITLE
fix(UE4SS): fix lua FString setter

### DIFF
--- a/UE4SS/src/LuaType/LuaUObject.cpp
+++ b/UE4SS/src/LuaType/LuaUObject.cpp
@@ -1107,7 +1107,7 @@ namespace RC::LuaType
             {
                 auto lua_string = params.lua.get_string();
                 auto fstring = Unreal::FString{to_wstring(lua_string).c_str()};
-                string->SetCharArray(fstring.GetCharTArray());
+                *string = fstring;
             }
             else if (params.lua.is_userdata())
             {


### PR DESCRIPTION
This fixes the FString setter from lua which added an additional `\0`
byte at the end with each assignment.
