### PR TITLE
Fix FindObject and Mod:SetSharedVariable userdata type matching

### DIFF
--- a/UE4SS/src/LuaType/LuaModRef.cpp
+++ b/UE4SS/src/LuaType/LuaModRef.cpp
@@ -129,7 +129,7 @@ Overloads:
                 }
                 auto& userdata = lua.get_userdata<LuaType::UE4SSBaseObject>();
                 std::string_view lua_object_name = userdata.get_object_name();
-                if (lua_object_name == "UObject" || lua_object_name == "World" || lua_object_name == "Actor" || lua_object_name == "UClass" ||
+                if (lua_object_name == "UObject" || lua_object_name == "UWorld" || lua_object_name == "AActor" || lua_object_name == "UClass" ||
                     lua_object_name == "UEnum" || lua_object_name == "UScriptStruct" || lua_object_name == "UStruct")
                 {
                     RC::LuaMod::m_shared_lua_variables[variable_name] =

--- a/UE4SS/src/Mod/LuaMod.cpp
+++ b/UE4SS/src/Mod/LuaMod.cpp
@@ -2657,7 +2657,7 @@ Overloads:
                 auto& userdata = lua.get_userdata<LuaType::UE4SSBaseObject>(1, true);
                 std::string_view lua_object_name = userdata.get_object_name();
                 // TODO: Redo when there's a bette way of checking whether a lua object is derived from UObject
-                if (lua_object_name == "UObject" || lua_object_name == "World" || lua_object_name == "Actor")
+                if (lua_object_name == "UObject" || lua_object_name == "UWorld" || lua_object_name == "AActor")
                 {
                     in_outer = lua.get_userdata<LuaType::UObject>().get_remote_cpp_object();
                     could_be_in_outer = true;


### PR DESCRIPTION
Tested locally, passing UWorld and AActor instances to second param of `FindObject(UClass InClass, UObject InOuter, string Name, bool ExactClass)` (overload 2) does not error with "No overload found for function 'FindObject'" anymore. Fix is good if there's still no solution to the todo comment.

Currently, `userdata.get_object_name()` is compared against `"Actor"` and `"World"`, whereas `userdata.get_object_name()` will return `"AActor"` and `"UWorld"` instead, so should keep those prefixes in the comparison strings.

note: Unsure if `FindObject`'s `InOuter` param should also accept `UClass`, `UScriptStruct`, and/or `UStruct` types like in `SetSharedVariable`.