### PR TITLE
Reset changelog for future experimental releases

### DIFF
--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -1,3 +1,56 @@
+v3.1.0
+==============
+TBD
+## New
+
+### General
+
+### Live View
+
+### UHT Dumper
+
+### Lua API
+
+### C++ API
+
+### Experimental
+
+
+## Changes
+
+### General
+
+### Live View
+
+### UHT Dumper
+
+### Lua API
+
+### C++ API
+
+### Repo & Build Process
+
+
+## Fixes
+
+### General
+
+### Live View
+
+### UHT Dumper
+
+### Lua API
+
+### C++ API
+
+
+## Settings
+
+### Added
+
+### Removed
+
+
 v3.0.0
 ==============
 2024-02-04


### PR DESCRIPTION
@UE4SS Just to check, this is the correct thing that needs to be done right? I had a look at the build script and am slightly confused how it tells the difference between releasing experimental version and an entirely new version based on how the changelog is (before 3.0.0 it was 2.6.0 which wasn't a tag that existed, and the -e passed into the py script doesn't seem to do anything). I tried to ask the actual guy who wrote it (truman) but he won't answer so I just want to make sure, if you know.