### PR TITLE
Added mods directory zip as an explicit step to the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,6 +19,10 @@ Game where the bug occurred, and the UE engine version of the game.
 A clear and concise description of what the bug is.
 
 
+**Mods directory**
+A zip of your Mods folder if you've installed any mods that don't come with UE4SS by default
+
+
 **To Reproduce**
 Steps to reproduce the behavior:
 1. Launch game


### PR DESCRIPTION
It directs people to zip their Mods directory if they've installed any mods that didn't come directly from us.