### PR TITLE
Clarify Lua metamethod usage for some classes; Minor docs edits

### DIFF
--- a/docs/lua-api/classes/tarray.md
+++ b/docs/lua-api/classes/tarray.md
@@ -3,14 +3,24 @@
 ## Inheritance
 [RemoteObject](./remoteobject.md)
 
-## Methods
+## Metamethods
 
-### __index(integer ArrayIndex)
-- Attempts to retrieve the value at the specified offset in the array.
+### __index
+- **Usage:** `TArray[ArrayIndex]`
+- **Return type:** `auto`
+- Attempts to retrieve the value at the specified integer offset `ArrayIndex` in the array.
 - Can return any type, you can use the `type()` function on the returned value to figure out what Lua class it's using (if non-trivial type).
 
-### __newindex(integer ArrayIndex, auto NewValue)
-- Attempts to set the value at the specified offset in the array.
+### __newindex
+- **Usage:** `TArray[ArrayIndex] = NewValue`
+- Attempts to set the value at the specified integer offset `ArrayIndex` in the array to `NewValue`.
+
+### __len
+- **Usage:** `#TArray`
+- **Return type:** `integer`
+- Returns the number of current elements in the array.
+
+## Methods
 
 ### GetArrayAddress()
 - **Return type:** `integer`

--- a/docs/lua-api/classes/ufunction.md
+++ b/docs/lua-api/classes/ufunction.md
@@ -3,10 +3,15 @@
 ## Inheritance
 [UObject](./uobject.md)
 
-## Methods
+## Metamethods
 
-### __call(UFunctionParams...)
-- Attempts to call the `UFunction`
+### __call
+- **Usage:** `UFunction(UFunctionParams...)`
+- **Return type:** `auto`
+- Attempts to call the `UFunction` and returns the result, if any.
+- If the `UFunction` is obtained without a context (e.g. from `StaticFindObject`), a `UObject` context must be passed as the first parameter.
+
+## Methods
 
 ### GetFunctionFlags()
 
@@ -14,4 +19,4 @@
 - **Returns:** the flags for the `UFunction`.
 
 ### SetFunctionFlags(integer Flags)
-- Sets the flags for the `UFuction`.
+- Sets the flags for the `UFunction`.

--- a/docs/lua-api/classes/uobject.md
+++ b/docs/lua-api/classes/uobject.md
@@ -5,11 +5,13 @@ The `UObject` class is the base class that most other Unreal Engine game objects
 ## Inheritance
 [RemoteObject](./remoteobject.md)
 
-## Methods
+## Metamethods
 
-### __index(string MemberVariableName)
+### __index
 
-- **Returns:** either a member variable (reflected property or custom property) or a UFunction.
+- **Usage:** `UObject["ObjectMemberName"]` or `UObject.ObjectMemberName`
+
+- Returns either a member variable (reflected property or custom property) or a UFunction.
 
 - This method can return any type, and you can use the UObject-specific `type()` function on the returned value to figure out the type if the type is non-trivial. 
 
@@ -30,11 +32,18 @@ The `UObject` class is the base class that most other Unreal Engine game objects
 
     -- Retrieve a trivial type
     local JumpMaxCount = Character.JumpMaxCount
+
+    -- Call a UFunction member on the object
+    -- Remember to use a colon (:) for calls
+    local CanCharacterJump = Character:CanJump()
+
     ```
 
-### __newindex(string MemberVariableName, auto NewValue)
+### __newindex
 
-- **Sets:** the value of a member variable.
+- **Usage:** `UObject["ObjectMemberName"] = NewValue` or `UObject.ObjectMemberName = NewValue`
+
+- Sets the value of a member variable to `NewValue`.
 
 - **Example:**
     Sets the value of `MaxParticleResize` in the first instance of class `UEngine` in memory.
@@ -42,6 +51,8 @@ The `UObject` class is the base class that most other Unreal Engine game objects
     local Engine = FindFirstOf("Engine")
     Engine.MaxParticleResize = 4
     ```
+
+## Methods
 
 ### GetFullName()
 
@@ -149,11 +160,11 @@ The `UObject` class is the base class that most other Unreal Engine game objects
 ### GetPropertyValue(string MemberVariableName)
 
 - **Return type:** `auto`
-- Identical to `__index`
+- Identical to `__index` metamethod (doing `UObject["ObjectMemberName"]`)
 
-### SetPropertyValue(string MemberVariableName auto NewValue)
+### SetPropertyValue(string MemberVariableName, auto NewValue)
 
-- Identical to `__newindex`
+- Identical to `__newindex` metamethod (doing `UObject["ObjectMemberName"] = NewValue`)
 
 ### IsClass()
 
@@ -190,7 +201,7 @@ The `UObject` class is the base class that most other Unreal Engine game objects
 - **Return type:** `bool`
 - **Returns:** whether the object has any of the specified internal flags.
 
-### CallFunction(UFunction function, auto Params...)
+### CallFunction(UFunction Function, auto Params...)
 
 - Calls the supplied `UFunction` on this `UObject`.
 
@@ -203,3 +214,4 @@ The `UObject` class is the base class that most other Unreal Engine game objects
 - **Return type:** `string`
 - **Returns:** the type of this object as known by UE4SS
 - This does not return the type as known by Unreal
+- Not equivalent to doing `type(UObject)`, which returns the type as known by Lua (a 'userdata')

--- a/docs/lua-api/classes/uscriptstruct.md
+++ b/docs/lua-api/classes/uscriptstruct.md
@@ -3,14 +3,14 @@
 ## Inheritance
 [LocalObject](./localobject.md)
 
-## Methods
+## Metamethods
 
-### __index(string StructMemberVarName) 
+### __index
 
+- **Usage:** `UScriptStruct["StructMemberName"]` or `UScriptStruct.StructMemberName`
 - **Return type:** `auto`
-- **Returns:** the value for the supplied variable
-- Can return any type, you can use the `type()` function on the returned value to figure out what Lua class it's using (if non-trivial type)
-> Note: `__index` is a Lua [metamethod](https://gist.github.com/oatmealine/655c9e64599d0f0dd47687c1186de99f#indexing) and allows the access operation `userdata[key]`
+- Returns the value for the supplied member name.
+- Can return any type, you can use the `type()` function on the returned value to figure out what Lua class it's using (if non-trivial type).
 
 - **Example:**
 ```lua
@@ -21,10 +21,10 @@ local item = scriptStruct['Item']
 local item = scriptStruct.Item
 ```
 
-### __newindex(string StructMemberVarName, auto NewValue)
+### __newindex
 
-- Attempts to set the value for the supplied variable
-> Note: `__newindex` is a Lua [metamethod](https://gist.github.com/oatmealine/655c9e64599d0f0dd47687c1186de99f#indexing) and is an indexing assignment of `userdata[key] = value`
+- **Usage:** `UScriptStruct["StructMemberName"] = NewValue` or `UScriptStruct.StructMemberName = NewValue`
+- Attempts to set the value for the supplied member name to `NewValue`.
 
 - **Example:**
 ```lua
@@ -34,6 +34,8 @@ local scriptStruct = FindFirstOf('_UI_Items_C')
 scriptStruct['Item'] = 5
 scriptStruct.Item = 5
 ```
+
+## Methods
 
 ### GetBaseAddress()
 


### PR DESCRIPTION
Resolves #374 

- Clarified usage of `__index`, `__newindex`, `__call` in multiple classes, placing them in a separate Metamethods category.
- Added `__len` metamethod description for TArray.
- UFunction `__call`: mention return val and specify the need for a context parameter if not part of an object instance.
- UObject `__index`: added example of a UFunction call.
- UObject `type()`: clarify that `type(object)` is not equivalent.
- Minor edits (spelling)

For initial review.
