### PR TITLE
Fix invalid BPLoader mod subdir behavior

### DIFF
--- a/assets/Mods/BPModLoaderMod/Scripts/main.lua
+++ b/assets/Mods/BPModLoaderMod/Scripts/main.lua
@@ -138,8 +138,15 @@ local function LoadModConfigs()
         end
     end
 
+    local Files = LogicModsDir.__files
+    for _, ModDirectory in pairs(LogicModsDir) do
+        for _, ModFile in pairs(ModDirectory.__files) do
+            table.insert(Files, ModFile)
+        end
+    end
+
     -- Load a default configuration for mods that didn't have their own configuration.
-    for _, ModFile in pairs(LogicModsDir.__files) do
+    for _, ModFile in pairs(Files) do
         local ModName = ModFile.__name
         local ModNameNoExtension = ModName:match("(.+)%..+$")
         local FileExtension = ModName:match("^.+(%..+)$");


### PR DESCRIPTION
This PR fixes a small error which prevented BPLoader from loading mods contained within subdirs of `LogicMods`.

Prior to this change, `LogicMods/Author-ModName/ModName.pak` would be _recognized_ by BPLoader but not actually loaded. If this file was moved into the top-level dir `LogicMods/ModName.pak`, it would then work. 
