### PR TITLE
Implemented "Write to file" for UFunction watches in the watches tab & fixed a crash on shutdown

### DIFF
--- a/UE4SS/src/GUI/LiveView.cpp
+++ b/UE4SS/src/GUI/LiveView.cpp
@@ -1644,7 +1644,6 @@ namespace RC::GUI
         }
         if (auto struct_property = CastField<FStructProperty>(property); struct_property && struct_property->GetStruct()->GetFirstProperty())
         {
-            is_watchable = false;
             ImGui::SameLine();
             auto tree_node_id = std::format("{}{}", static_cast<void*>(container_ptr), property_name);
             if (ImGui_TreeNodeEx(std::format("{}", to_string(property_text.GetCharArray())).c_str(), tree_node_id.c_str(), ImGuiTreeNodeFlags_NoAutoOpenOnLog))
@@ -1679,7 +1678,6 @@ namespace RC::GUI
         }
         else if (auto array_property = CastField<FArrayProperty>(property); array_property)
         {
-            is_watchable = false;
             ImGui::SameLine();
             auto tree_node_id = std::format("{}{}", static_cast<void*>(container_ptr), property_name);
             if (ImGui_TreeNodeEx(std::format("{}", to_string(property_text.GetCharArray())).c_str(), tree_node_id.c_str(), ImGuiTreeNodeFlags_NoAutoOpenOnLog))

--- a/UE4SS/src/GUI/LiveView.cpp
+++ b/UE4SS/src/GUI/LiveView.cpp
@@ -2695,6 +2695,11 @@ namespace RC::GUI
 
     auto LiveView::process_function_post_watch(Unreal::UnrealScriptFunctionCallableContext& context, void*) -> void
     {
+        if (!UnrealInitializer::StaticStorage::bIsInitialized)
+        {
+            return;
+        }
+
         auto function = context.TheStack.Node();
         std::lock_guard<decltype(LiveView::Watch::s_watch_lock)> lock{LiveView::Watch::s_watch_lock};
         auto it = s_watch_containers.find(function);
@@ -2782,6 +2787,11 @@ namespace RC::GUI
 
     auto LiveView::process_watches() -> void
     {
+        if (!UnrealInitializer::StaticStorage::bIsInitialized)
+        {
+            return;
+        }
+
         std::lock_guard<decltype(Watch::s_watch_lock)> lock{Watch::s_watch_lock};
         for (auto& watch : s_watches)
         {

--- a/UE4SS/src/GUI/LiveView.cpp
+++ b/UE4SS/src/GUI/LiveView.cpp
@@ -2816,7 +2816,6 @@ namespace RC::GUI
         {
             return;
         }
-
         if (!m_is_initialized)
         {
             return;

--- a/UE4SS/src/GUI/LiveView.cpp
+++ b/UE4SS/src/GUI/LiveView.cpp
@@ -2686,26 +2686,6 @@ namespace RC::GUI
         }
     }
 
-    struct UObjectArrayLock
-    {
-        UObjectArrayLock()
-        {
-            // TODO: Implement this in UVTD and UObjectArray.hpp if this works.
-            //       This is just a test for now, do not let this make it into main.
-            auto UObjectDeleteListenersCritical = std::bit_cast<CRITICAL_SECTION*>(static_cast<uint8_t*>(Container::UnrealVC->UObjectArray_get_internal_storage_ptr()) + 0x88);
-            EnterCriticalSection(std::bit_cast<::CRITICAL_SECTION*>(UObjectDeleteListenersCritical));
-            //UObjectArray::LockGUObjectArray();
-        }
-        ~UObjectArrayLock()
-        {
-            // TODO: Implement this in UVTD and UObjectArray.hpp if this works.
-            //       This is just a test for now, do not let this make it into main.
-            auto UObjectDeleteListenersCritical = std::bit_cast<CRITICAL_SECTION*>(static_cast<uint8_t*>(Container::UnrealVC->UObjectArray_get_internal_storage_ptr()) + 0x88);
-            LeaveCriticalSection(std::bit_cast<::CRITICAL_SECTION*>(UObjectDeleteListenersCritical));
-            //UObjectArray::UnlockGUObjectArray();
-        }
-    };
-
     auto LiveView::process_function_pre_watch(Unreal::UnrealScriptFunctionCallableContext& context, void*) -> void
     {
         // TODO: Log params in pre-state ?
@@ -2713,13 +2693,10 @@ namespace RC::GUI
 
     auto LiveView::process_function_post_watch(Unreal::UnrealScriptFunctionCallableContext& context, void*) -> void
     {
-        // The if-statement makes sure that we don't render anything if UE has already begun shutting down.
-        // The lock makes sure that UE can't shut down while we're rendering.
         if (!UnrealInitializer::StaticStorage::bIsInitialized)
         {
             return;
         }
-        UObjectArrayLock obj_array_lock{};
 
         auto function = context.TheStack.Node();
         std::lock_guard<decltype(LiveView::Watch::s_watch_lock)> lock{LiveView::Watch::s_watch_lock};
@@ -2808,13 +2785,10 @@ namespace RC::GUI
 
     auto LiveView::process_watches() -> void
     {
-        // The if-statement makes sure that we don't render anything if UE has already begun shutting down.
-        // The lock makes sure that UE can't shut down while we're rendering.
         if (!UnrealInitializer::StaticStorage::bIsInitialized)
         {
             return;
         }
-        UObjectArrayLock obj_array_lock{};
 
         std::lock_guard<decltype(Watch::s_watch_lock)> lock{Watch::s_watch_lock};
         for (auto& watch : s_watches)
@@ -2838,13 +2812,10 @@ namespace RC::GUI
 
     auto LiveView::render() -> void
     {
-        // The if-statement makes sure that we don't render anything if UE has already begun shutting down.
-        // The lock makes sure that UE can't shut down while we're rendering.
         if (!UnrealInitializer::StaticStorage::bIsInitialized)
         {
             return;
         }
-        UObjectArrayLock obj_array_lock{};
 
         if (!m_is_initialized)
         {

--- a/UE4SS/src/GUI/LiveView.cpp
+++ b/UE4SS/src/GUI/LiveView.cpp
@@ -2686,6 +2686,26 @@ namespace RC::GUI
         }
     }
 
+    struct UObjectArrayLock
+    {
+        UObjectArrayLock()
+        {
+            // TODO: Implement this in UVTD and UObjectArray.hpp if this works.
+            //       This is just a test for now, do not let this make it into main.
+            auto UObjectDeleteListenersCritical = std::bit_cast<CRITICAL_SECTION*>(static_cast<uint8_t*>(Container::UnrealVC->UObjectArray_get_internal_storage_ptr()) + 0x88);
+            EnterCriticalSection(std::bit_cast<::CRITICAL_SECTION*>(UObjectDeleteListenersCritical));
+            //UObjectArray::LockGUObjectArray();
+        }
+        ~UObjectArrayLock()
+        {
+            // TODO: Implement this in UVTD and UObjectArray.hpp if this works.
+            //       This is just a test for now, do not let this make it into main.
+            auto UObjectDeleteListenersCritical = std::bit_cast<CRITICAL_SECTION*>(static_cast<uint8_t*>(Container::UnrealVC->UObjectArray_get_internal_storage_ptr()) + 0x88);
+            LeaveCriticalSection(std::bit_cast<::CRITICAL_SECTION*>(UObjectDeleteListenersCritical));
+            //UObjectArray::UnlockGUObjectArray();
+        }
+    };
+
     auto LiveView::process_function_pre_watch(Unreal::UnrealScriptFunctionCallableContext& context, void*) -> void
     {
         // TODO: Log params in pre-state ?
@@ -2693,10 +2713,13 @@ namespace RC::GUI
 
     auto LiveView::process_function_post_watch(Unreal::UnrealScriptFunctionCallableContext& context, void*) -> void
     {
+        // The if-statement makes sure that we don't render anything if UE has already begun shutting down.
+        // The lock makes sure that UE can't shut down while we're rendering.
         if (!UnrealInitializer::StaticStorage::bIsInitialized)
         {
             return;
         }
+        UObjectArrayLock obj_array_lock{};
 
         auto function = context.TheStack.Node();
         std::lock_guard<decltype(LiveView::Watch::s_watch_lock)> lock{LiveView::Watch::s_watch_lock};
@@ -2785,10 +2808,13 @@ namespace RC::GUI
 
     auto LiveView::process_watches() -> void
     {
+        // The if-statement makes sure that we don't render anything if UE has already begun shutting down.
+        // The lock makes sure that UE can't shut down while we're rendering.
         if (!UnrealInitializer::StaticStorage::bIsInitialized)
         {
             return;
         }
+        UObjectArrayLock obj_array_lock{};
 
         std::lock_guard<decltype(Watch::s_watch_lock)> lock{Watch::s_watch_lock};
         for (auto& watch : s_watches)
@@ -2812,10 +2838,14 @@ namespace RC::GUI
 
     auto LiveView::render() -> void
     {
+        // The if-statement makes sure that we don't render anything if UE has already begun shutting down.
+        // The lock makes sure that UE can't shut down while we're rendering.
         if (!UnrealInitializer::StaticStorage::bIsInitialized)
         {
             return;
         }
+        UObjectArrayLock obj_array_lock{};
+
         if (!m_is_initialized)
         {
             return;

--- a/UE4SS/src/GUI/LiveView.cpp
+++ b/UE4SS/src/GUI/LiveView.cpp
@@ -2773,6 +2773,11 @@ namespace RC::GUI
 
         buffer.append(STR("\n\n"));
         watch.history.append(to_string(buffer));
+
+        if (watch.write_to_file)
+        {
+            watch.output.send(STR("{}"), buffer);
+        }
     }
 
     auto LiveView::process_watches() -> void

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -39,6 +39,7 @@ Fixed BPModLoaderMod giving "bad conversion" errors.
 
 ### Live View
 Fixed the "Write to file" checkbox not working for functions in the `Watches` tab.
+Fixed a crash on shutdown that happened when at least one watch was enabled.
 
 ### UHT Dumper
 

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -22,6 +22,7 @@ TBD
 ### General
 
 ### Live View
+Added support for watching ArrayProperty and StructProperty.
 
 ### UHT Dumper
 

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -38,6 +38,7 @@ TBD
 Fixed BPModLoaderMod giving "bad conversion" errors.
 
 ### Live View
+Fixed the "Write to file" checkbox not working for functions in the `Watches` tab.
 
 ### UHT Dumper
 

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -39,7 +39,7 @@ Fixed BPModLoaderMod giving "bad conversion" errors.
 
 ### Live View
 Fixed the "Write to file" checkbox not working for functions in the `Watches` tab.
-Fixed a crash on shutdown that happened when at least one watch was enabled.
+Reduced the likelihood of a crash happening on shutdown when at least one watch is enabled.
 
 ### UHT Dumper
 


### PR DESCRIPTION
I logged this as a fix in the changelog because even though it's technically a new feature, it's much more likely to be seen as a bug by people.

**Description**

See commit messages.

Partially fixes #418

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

I tested this by adding a watch to `CanJumpInternal` and ticking `Write to file` and proceeding to jump in the game and then confirming that `ue4ss_watch_Character.CanJumpInternal_.txt` existed in the `watches` directory.

**Checklist**

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
- [x] Any dependent changes have been merged and published in downstream modules.

**Screenshots (if appropriate)**

**Additional context**

Add any other context about the pull request here.
