### PR TITLE
fix: lua FText param handling

### DIFF
--- a/UE4SS/src/LuaType/LuaUObject.cpp
+++ b/UE4SS/src/LuaType/LuaUObject.cpp
@@ -1078,7 +1078,7 @@ namespace RC::LuaType
             return;
         }
         case Operation::GetParam:
-            params.lua.throw_error("[push_textproperty] Operation::GetParam is not supported");
+            RemoteUnrealParam::construct(params.lua, params.data, params.base, params.property);
             return;
         default:
             params.lua.throw_error("[push_textproperty] Unhandled Operation");

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -44,6 +44,8 @@ Fixed BPModLoaderMod giving "bad conversion" errors.
 ### Lua API
 Fixed the "IterateGameDirectories" global function throwing "bad conversion" errors.
 
+Fixed `FText` not working as a parameter (in `RegisterHook`, etc.).
+
 ### C++ API
 
 


### PR DESCRIPTION
**Description**

Fixes FText param handling in Hooks/etc.

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Tested by using `RegisterHook` on a sample project, then reading the received FText value, as well as replacing the return value.

**Checklist**

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
- [x] Any dependent changes have been merged and published in downstream modules.

