### PR TITLE
fix: make FString a local lua param

### DIFF
--- a/UE4SS/include/LuaType/LuaFString.hpp
+++ b/UE4SS/include/LuaType/LuaFString.hpp
@@ -16,7 +16,7 @@ namespace RC::LuaType
             return "FString";
         }
     };
-    class FString : public RemoteObjectBase<Unreal::FString, FStringName>
+    class FString : public LocalObjectBase<Unreal::FString, FStringName>
     {
       private:
         explicit FString(Unreal::FString* object);

--- a/UE4SS/src/LuaType/LuaFString.cpp
+++ b/UE4SS/src/LuaType/LuaFString.cpp
@@ -6,7 +6,7 @@
 
 namespace RC::LuaType
 {
-    FString::FString(Unreal::FString* object) : RemoteObjectBase<Unreal::FString, FStringName>(object)
+    FString::FString(Unreal::FString* object) : LocalObjectBase<Unreal::FString, FStringName>(std::move(Unreal::FString(*object)))
     {
     }
 
@@ -20,7 +20,7 @@ namespace RC::LuaType
         if (lua.is_nil(-1))
         {
             lua.discard_value(-1);
-            LuaMadeSimple::Type::RemoteObject<Unreal::FString>::construct(lua, lua_object);
+            lua.prepare_new_table();
             setup_metamethods(lua_object);
             setup_member_functions<LuaMadeSimple::Type::IsFinal::Yes>(table);
             lua.new_metatable<LuaType::FString>(metatable_name, lua_object.get_metamethods());
@@ -52,9 +52,9 @@ namespace RC::LuaType
     auto FString::setup_member_functions(const LuaMadeSimple::Lua::Table& table) -> void
     {
         table.add_pair("ToString", [](const LuaMadeSimple::Lua& lua) -> int {
-            const auto& lua_object = lua.get_userdata<LuaType::FString>();
+            auto& lua_object = lua.get_userdata<LuaType::FString>();
 
-            const wchar_t* string_data = lua_object.get_remote_cpp_object()->GetCharArray();
+            const wchar_t* string_data = lua_object.get_local_cpp_object().GetCharArray();
             if (string_data)
             {
                 lua.set_string(to_string(string_data));
@@ -68,9 +68,9 @@ namespace RC::LuaType
         });
 
         table.add_pair("Clear", [](const LuaMadeSimple::Lua& lua) -> int {
-            const auto& lua_object = lua.get_userdata<LuaType::FString>();
+            auto& lua_object = lua.get_userdata<LuaType::FString>();
 
-            lua_object.get_remote_cpp_object()->Clear();
+            lua_object.get_local_cpp_object().Clear();
 
             return 0;
         });

--- a/UE4SS/src/LuaType/LuaUObject.cpp
+++ b/UE4SS/src/LuaType/LuaUObject.cpp
@@ -1112,7 +1112,7 @@ namespace RC::LuaType
             else if (params.lua.is_userdata())
             {
                 auto& rhs = params.lua.get_userdata<LuaType::FString>();
-                string->SetCharArray(rhs.get_remote_cpp_object()->GetCharTArray());
+                string->SetCharArray(rhs.get_local_cpp_object().GetCharTArray());
             }
             else
             {

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -42,6 +42,8 @@ Fixed BPModLoaderMod giving "bad conversion" errors.
 ### UHT Dumper
 
 ### Lua API
+Fixed FString use after free.
+
 Fixed the "IterateGameDirectories" global function throwing "bad conversion" errors.
 
 ### C++ API


### PR DESCRIPTION


**Description**

This fixes some issues related to FString lifetime causing it to become
garbage data, FString should be stored by value instead.

Credits: @yangff
Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change.

Fixes #397

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Tested on an Unreal 5.1 game with calling/hooking different functions returning FString, doing stuff on the stack and trying to read the value back.

**Checklist**

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
- [x] Any dependent changes have been merged and published in downstream modules.

