### PR TITLE
feat(lua): allow NotifyOnNewObject callback to unregister itself

### DIFF
--- a/UE4SS/include/Mod/LuaMod.hpp
+++ b/UE4SS/include/Mod/LuaMod.hpp
@@ -83,7 +83,14 @@ namespace RC
             Unreal::UClass* instance_of_class;
             std::vector<std::pair<const LuaMadeSimple::Lua*, RegistryIndex>> registry_indexes;
         };
-        static inline std::vector<LuaCallbackData> m_static_construct_object_lua_callbacks;
+        struct LuaCancellableCallbackData
+        {
+            const LuaMadeSimple::Lua* lua;
+            Unreal::UClass* instance_of_class;
+            int32_t lua_callback_function_ref{};
+            int32_t lua_callback_thread_ref{};
+        };
+        static inline std::vector<LuaCancellableCallbackData> m_static_construct_object_lua_callbacks;
         static inline std::vector<LuaCallbackData> m_process_console_exec_pre_callbacks;
         static inline std::vector<LuaCallbackData> m_process_console_exec_post_callbacks;
         static inline std::vector<LuaCallbackData> m_call_function_by_name_with_arguments_pre_callbacks;

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -28,6 +28,8 @@ TBD
 ### Lua API
 `print` now behaves like vanilla Lua (can now accept zero, one, or multiple arguments of any type).
 
+The callback of `NotifyOnNewObject` can now optionally return `true` to unregister itself.
+
 ### C++ API
 
 ### Repo & Build Process

--- a/docs/lua-api/global-functions/notifyonnewobject.md
+++ b/docs/lua-api/global-functions/notifyonnewobject.md
@@ -4,6 +4,8 @@ The `NotifyOnNewObject` function executes a callback whenever an instance of the
 
 Inheritance is taken into account, so if you provide `"/Script/Engine.Actor"` as the class then it will execute the callback when any object is constructed that's either an `AActor` or is derived from `AActor`.
 
+The callback can return `true` to remove (unregister) that specific `NotifyOnNewObject` callback.
+
 > The provided class must exist before this calling this function.
 
 ## Parameters
@@ -19,10 +21,26 @@ Inheritance is taken into account, so if you provide `"/Script/Engine.Actor"` as
 |---|---------|-------------|
 | 1 | UObject | The constructed object |
 
+
+## Callback Return Value
+
+| # | Type    | Information |
+|---|---------|-------------|
+| 1 | boolean | If true, remove the current callback from listening to any more notifications |
+
+
 ## Example
 ```lua
+NotifyOnNewObject("/Script/Engine.World", function(ConstructedObject)
+    print(string.format("World Constructed: %s\n", ConstructedObject:GetFullName()))
+end)
+
 NotifyOnNewObject("/Script/Engine.Actor", function(ConstructedObject)
-    print(string.format("Constructed: %s\n", ConstructedObject:GetFullName()))
+    print(string.format("Actor Constructed: %s\n", ConstructedObject:GetFullName()))
+
+    -- Unregister this callback after the first actor is found,
+    -- meaning this current function will only be called exactly once
+    return true
 end)
 ```
 


### PR DESCRIPTION
### Description

The callback of `NotifyOnNewObject` can now optionally return true to unregister itself. Technically, this would probably be breaking as `return true` (specifically) in a `NotifyOnNewObject` callback will suddenly have a meaning, but I do not think anyone will do that (as there is no documentation that says to return something in there), much less think that it is not for "cancelling" the callback.

Any other value as return won't unregister the callback though, even if they coerce to true, only an explicit `true` as the first return value will work. This is to minimize the (low) possibility of the change to break things in case someone did return values from the callback.

### Type of change
- [x] New feature (non-breaking change which adds functionality) -- I guess?

### How Has This Been Tested?

I've done:
- Call sequence + cancel checks to:
  - check if callbacks are still called the same sequence as they're registered,
  - check if they unregister correctly;
- Return value tests to check that only `true` is valid to unregister the callback; and
- GC tests, to ensure that the Lua threads are cleared correctly, comparing them to a build without this change. (Please do check if there's something I forgot to free, especially in the C++ side).

<details>
<summary>Script - Call sequence and cancel checks</summary>

```lua
local AACTOR_C = nil

-- Sanity check for param (to see if stack got corrupted somehow)
local function CHECK(actor)
    if not AACTOR_C then
        AACTOR_C = StaticFindObject("/Script/Engine.Actor")
    end
    if actor == nil or (not actor:IsValid()) or (not actor:IsA(AACTOR_C)) then
        error("actor param is not an AActor!!!")
    end
end



local nAll = 0
local n5 = 0
local n10 = 0
local n2 = 0

print "=== START ==="
ExecuteInGameThread(function() print "--- EIGTF ---" end)

NotifyOnNewObject("/Script/Engine.Actor", function(actor)
    CHECK(actor)

    nAll = nAll + 1

    -- Print just to check call sequence
    print("----------")
    print("All\t"..nAll)
end)

NotifyOnNewObject("/Script/Engine.Actor", function(actor)
    CHECK(actor)

    n5 = n5 + 1
    print("n5 \t"..n5)

    if n5 >= 5 then return true end
end)

NotifyOnNewObject("/Script/Engine.Actor", function(actor)
    CHECK(actor)

    n10 = n10 + 1
    print("n10\t"..n10)

    if n10 >= 10 then return true end
end)

NotifyOnNewObject("/Script/Engine.Actor", function(actor)
    CHECK(actor)

    n2 = n2 + 1
    print("n2 \t"..n2)

    if n2 >= 2 then return true end
end)



ExecuteWithDelay(2000, function()
    print("----------")
    print(([[Counter totals:
        %d total actors == N
        %d actors, stopping at N >= 2
        %d actors, stopping at N >= 5
        %d actors, stopping at N >= 10
    ]]):format(nAll, n2, n5, n10))
end)

do return end
```
</details>

<details>
<summary>Output - Call sequence and cancel checks</summary>

<b>Without changes</b>
```ini
[10:34:15] Starting Lua mod 'TestMod'
[10:34:15] [Lua] === START ===
[10:34:15] Starting Lua mod 'Keybinds'
[10:34:15] Starting mods (from enabled.txt, no defined load order)...
[10:34:15] Event loop start
[10:34:15] [Lua] ----------
[10:34:15] [Lua] All	1
[10:34:15] [Lua] n5 	1
[10:34:15] [Lua] n10	1
[10:34:15] [Lua] n2 	1
[10:34:15] [Lua] ----------
[10:34:15] [Lua] All	2
[10:34:15] [Lua] n5 	2
[10:34:15] [Lua] n10	2
[10:34:15] [Lua] n2 	2
[10:34:15] [Lua] --- EIGTF ---
[10:34:15] [Lua] ----------
[10:34:15] [Lua] All	3
[10:34:15] [Lua] n5 	3
[10:34:15] [Lua] n10	3
[10:34:15] [Lua] n2 	3
[10:34:15] [Lua] ----------
[10:34:15] [Lua] All	4
[10:34:15] [Lua] n5 	4
[10:34:15] [Lua] n10	4
[10:34:15] [Lua] n2 	4
[10:34:15] [Lua] ----------
[10:34:15] [Lua] All	5
[10:34:15] [Lua] n5 	5
[10:34:15] [Lua] n10	5
[10:34:15] [Lua] n2 	5
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	6
[10:34:16] [Lua] n5 	6
[10:34:16] [Lua] n10	6
[10:34:16] [Lua] n2 	6
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	7
[10:34:16] [Lua] n5 	7
[10:34:16] [Lua] n10	7
[10:34:16] [Lua] n2 	7
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	8
[10:34:16] [Lua] n5 	8
[10:34:16] [Lua] n10	8
[10:34:16] [Lua] n2 	8
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	9
[10:34:16] [Lua] n5 	9
[10:34:16] [Lua] n10	9
[10:34:16] [Lua] n2 	9
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	10
[10:34:16] [Lua] n5 	10
[10:34:16] [Lua] n10	10
[10:34:16] [Lua] n2 	10
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	11
[10:34:16] [Lua] n5 	11
[10:34:16] [Lua] n10	11
[10:34:16] [Lua] n2 	11
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	12
[10:34:16] [Lua] n5 	12
[10:34:16] [Lua] n10	12
[10:34:16] [Lua] n2 	12
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	13
[10:34:16] [Lua] n5 	13
[10:34:16] [Lua] n10	13
[10:34:16] [Lua] n2 	13
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	14
[10:34:16] [Lua] n5 	14
[10:34:16] [Lua] n10	14
[10:34:16] [Lua] n2 	14
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	15
[10:34:16] [Lua] n5 	15
[10:34:16] [Lua] n10	15
[10:34:16] [Lua] n2 	15
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	16
[10:34:16] [Lua] n5 	16
[10:34:16] [Lua] n10	16
[10:34:16] [Lua] n2 	16
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	17
[10:34:16] [Lua] n5 	17
[10:34:16] [Lua] n10	17
[10:34:16] [Lua] n2 	17
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	18
[10:34:16] [Lua] n5 	18
[10:34:16] [Lua] n10	18
[10:34:16] [Lua] n2 	18
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	19
[10:34:16] [Lua] n5 	19
[10:34:16] [Lua] n10	19
[10:34:16] [Lua] n2 	19
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	20
[10:34:16] [Lua] n5 	20
[10:34:16] [Lua] n10	20
[10:34:16] [Lua] n2 	20
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	21
[10:34:16] [Lua] n5 	21
[10:34:16] [Lua] n10	21
[10:34:16] [Lua] n2 	21
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	22
[10:34:16] [Lua] n5 	22
[10:34:16] [Lua] n10	22
[10:34:16] [Lua] n2 	22
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	23
[10:34:16] [Lua] n5 	23
[10:34:16] [Lua] n10	23
[10:34:16] [Lua] n2 	23
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	24
[10:34:16] [Lua] n5 	24
[10:34:16] [Lua] n10	24
[10:34:16] [Lua] n2 	24
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	25
[10:34:16] [Lua] n5 	25
[10:34:16] [Lua] n10	25
[10:34:16] [Lua] n2 	25
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	26
[10:34:16] [Lua] n5 	26
[10:34:16] [Lua] n10	26
[10:34:16] [Lua] n2 	26
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	27
[10:34:16] [Lua] n5 	27
[10:34:16] [Lua] n10	27
[10:34:16] [Lua] n2 	27
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	28
[10:34:16] [Lua] n5 	28
[10:34:16] [Lua] n10	28
[10:34:16] [Lua] n2 	28
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	29
[10:34:16] [Lua] n5 	29
[10:34:16] [Lua] n10	29
[10:34:16] [Lua] n2 	29
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	30
[10:34:16] [Lua] n5 	30
[10:34:16] [Lua] n10	30
[10:34:16] [Lua] n2 	30
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	31
[10:34:16] [Lua] n5 	31
[10:34:16] [Lua] n10	31
[10:34:16] [Lua] n2 	31
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	32
[10:34:16] [Lua] n5 	32
[10:34:16] [Lua] n10	32
[10:34:16] [Lua] n2 	32
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	33
[10:34:16] [Lua] n5 	33
[10:34:16] [Lua] n10	33
[10:34:16] [Lua] n2 	33
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	34
[10:34:16] [Lua] n5 	34
[10:34:16] [Lua] n10	34
[10:34:16] [Lua] n2 	34
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	35
[10:34:16] [Lua] n5 	35
[10:34:16] [Lua] n10	35
[10:34:16] [Lua] n2 	35
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	36
[10:34:16] [Lua] n5 	36
[10:34:16] [Lua] n10	36
[10:34:16] [Lua] n2 	36
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	37
[10:34:16] [Lua] n5 	37
[10:34:16] [Lua] n10	37
[10:34:16] [Lua] n2 	37
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	38
[10:34:16] [Lua] n5 	38
[10:34:16] [Lua] n10	38
[10:34:16] [Lua] n2 	38
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	39
[10:34:16] [Lua] n5 	39
[10:34:16] [Lua] n10	39
[10:34:16] [Lua] n2 	39
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	40
[10:34:16] [Lua] n5 	40
[10:34:16] [Lua] n10	40
[10:34:16] [Lua] n2 	40
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	41
[10:34:16] [Lua] n5 	41
[10:34:16] [Lua] n10	41
[10:34:16] [Lua] n2 	41
[10:34:16] [Lua] ----------
[10:34:16] [Lua] All	42
[10:34:16] [Lua] n5 	42
[10:34:16] [Lua] n10	42
[10:34:16] [Lua] n2 	42
[10:34:17] [Lua] ----------
[10:34:17] [Lua] All	43
[10:34:17] [Lua] n5 	43
[10:34:17] [Lua] n10	43
[10:34:17] [Lua] n2 	43
[10:34:17] [Lua] ----------
[10:34:17] [Lua] All	44
[10:34:17] [Lua] n5 	44
[10:34:17] [Lua] n10	44
[10:34:17] [Lua] n2 	44
[10:34:17] [Lua] ----------
[10:34:17] [Lua] All	45
[10:34:17] [Lua] n5 	45
[10:34:17] [Lua] n10	45
[10:34:17] [Lua] n2 	45
[10:34:17] [Lua] ----------
[10:34:17] [Lua] All	46
[10:34:17] [Lua] n5 	46
[10:34:17] [Lua] n10	46
[10:34:17] [Lua] n2 	46
[10:34:17] [Lua] ----------
[10:34:17] [Lua] All	47
[10:34:17] [Lua] n5 	47
[10:34:17] [Lua] n10	47
[10:34:17] [Lua] n2 	47
[10:34:17] [Lua] ----------
[10:34:17] [Lua] All	48
[10:34:17] [Lua] n5 	48
[10:34:17] [Lua] n10	48
[10:34:17] [Lua] n2 	48
[10:34:17] [Lua] ----------
[10:34:17] [Lua] All	49
[10:34:17] [Lua] n5 	49
[10:34:17] [Lua] n10	49
[10:34:17] [Lua] n2 	49
[10:34:17] [Lua] ----------
[10:34:17] [Lua] All	50
[10:34:17] [Lua] n5 	50
[10:34:17] [Lua] n10	50
[10:34:17] [Lua] n2 	50
[10:34:17] [Lua] ----------
[10:34:17] [Lua] All	51
[10:34:17] [Lua] n5 	51
[10:34:17] [Lua] n10	51
[10:34:17] [Lua] n2 	51
[10:34:17] [Lua] ----------
[10:34:17] [Lua] All	52
[10:34:17] [Lua] n5 	52
[10:34:17] [Lua] n10	52
[10:34:17] [Lua] n2 	52
[10:34:17] [Lua] ----------
[10:34:17] [Lua] All	53
[10:34:17] [Lua] n5 	53
[10:34:17] [Lua] n10	53
[10:34:17] [Lua] n2 	53
[10:34:17] [Lua] ----------
[10:34:17] [Lua] All	54
[10:34:17] [Lua] n5 	54
[10:34:17] [Lua] n10	54
[10:34:17] [Lua] n2 	54
[10:34:17] [Lua] ----------
[10:34:17] [Lua] All	55
[10:34:17] [Lua] n5 	55
[10:34:17] [Lua] n10	55
[10:34:17] [Lua] n2 	55
[10:34:17] [Lua] ----------
[10:34:17] [Lua] All	56
[10:34:17] [Lua] n5 	56
[10:34:17] [Lua] n10	56
[10:34:17] [Lua] n2 	56
[10:34:17] [Lua] ----------
[10:34:17] [Lua] All	57
[10:34:17] [Lua] n5 	57
[10:34:17] [Lua] n10	57
[10:34:17] [Lua] n2 	57
[10:34:18] [Lua] ----------
[10:34:18] [Lua] Counter totals:
        57 total actors == N
        57 actors, stopping at N >= 2
        57 actors, stopping at N >= 5
        57 actors, stopping at N >= 10
    
```

<b>With callback changes</b>
```ini
[11:42:22] Starting Lua mod 'TestMod'
[11:42:22] [Lua] === START ===
[11:42:22] Starting Lua mod 'Keybinds'
[11:42:22] Starting mods (from enabled.txt, no defined load order)...
[11:42:22] Event loop start
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	1
[11:42:22] [Lua] n5 	1
[11:42:22] [Lua] n10	1
[11:42:22] [Lua] n2 	1
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	2
[11:42:22] [Lua] n5 	2
[11:42:22] [Lua] n10	2
[11:42:22] [Lua] n2 	2
[11:42:22] [Lua] --- EIGTF ---
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	3
[11:42:22] [Lua] n5 	3
[11:42:22] [Lua] n10	3
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	4
[11:42:22] [Lua] n5 	4
[11:42:22] [Lua] n10	4
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	5
[11:42:22] [Lua] n5 	5
[11:42:22] [Lua] n10	5
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	6
[11:42:22] [Lua] n10	6
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	7
[11:42:22] [Lua] n10	7
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	8
[11:42:22] [Lua] n10	8
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	9
[11:42:22] [Lua] n10	9
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	10
[11:42:22] [Lua] n10	10
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	11
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	12
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	13
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	14
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	15
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	16
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	17
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	18
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	19
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	20
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	21
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	22
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	23
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	24
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	25
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	26
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	27
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	28
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	29
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	30
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	31
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	32
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	33
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	34
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	35
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	36
[11:42:22] [Lua] ----------
[11:42:22] [Lua] All	37
[11:42:23] [Lua] ----------
[11:42:23] [Lua] All	38
[11:42:23] [Lua] ----------
[11:42:23] [Lua] All	39
[11:42:23] [Lua] ----------
[11:42:23] [Lua] All	40
[11:42:23] [Lua] ----------
[11:42:23] [Lua] All	41
[11:42:23] [Lua] ----------
[11:42:23] [Lua] All	42
[11:42:24] [Lua] ----------
[11:42:24] [Lua] All	43
[11:42:24] [Lua] ----------
[11:42:24] [Lua] All	44
[11:42:24] [Lua] ----------
[11:42:24] [Lua] All	45
[11:42:24] [Lua] ----------
[11:42:24] [Lua] All	46
[11:42:24] [Lua] ----------
[11:42:24] [Lua] All	47
[11:42:24] [Lua] ----------
[11:42:24] [Lua] All	48
[11:42:24] [Lua] ----------
[11:42:24] [Lua] All	49
[11:42:24] [Lua] ----------
[11:42:24] [Lua] All	50
[11:42:24] [Lua] ----------
[11:42:24] [Lua] All	51
[11:42:24] [Lua] ----------
[11:42:24] [Lua] All	52
[11:42:24] [Lua] ----------
[11:42:24] [Lua] All	53
[11:42:24] [Lua] ----------
[11:42:24] [Lua] All	54
[11:42:24] [Lua] ----------
[11:42:24] [Lua] All	55
[11:42:24] [Lua] ----------
[11:42:24] [Lua] All	56
[11:42:24] [Lua] ----------
[11:42:24] [Lua] All	57
[11:42:25] [Lua] ----------
[11:42:25] [Lua] Counter totals:
        57 total actors == N
        2 actors, stopping at N >= 2
        5 actors, stopping at N >= 5
        10 actors, stopping at N >= 10
    
```
</details>

<details>
<summary>Script - Callback return value tests</summary>

```lua
local testvals = {
    {0, false},
    {0, true},
    {1, false},
    {{}, true},
    {"thing", "test"},
    {nil, "a"},
    {FName("Actor"), FName("World")},
    {false, false},
    {false, true},
    {true, false}, -- index 9
    {false, "unreachable"},
    {0, "unreachable"},
    {"a", "unreachable"},
}

local totest = 0
NotifyOnNewObject("/Script/Engine.Actor", function(actor)
    totest = totest + 1

    if not testvals[totest] then return end

    print(("Trying returns: [%s,%s]"):format( table.unpack(testvals[totest]) ))

    return table.unpack(testvals[totest])
end)

ExecuteWithDelay(2000, function() print("totest is at "..totest) end)

do return end
```
</details>

<details>
<summary>Output - Callback return value tests</summary>

<b>Without changes</b>
```ini
[12:04:45] Starting Lua mod 'TestMod'
[12:04:45] Starting Lua mod 'Keybinds'
[12:04:45] Starting mods (from enabled.txt, no defined load order)...
[12:04:45] Event loop start
[12:04:45] [Lua] Trying returns: [0,false]
[12:04:45] [Lua] Trying returns: [0,true]
[12:04:45] [Lua] Trying returns: [1,false]
[12:04:45] [Lua] Trying returns: [table: 000002A582B10F20,true]
[12:04:45] [Lua] Trying returns: [thing,test]
[12:04:45] [Lua] Trying returns: [nil,a]
[12:04:45] [Lua] Trying returns: [FNameUserdata: 000002A582400EC8,FNameUserdata: 000002A582402AC8]
[12:04:45] [Lua] Trying returns: [false,false]
[12:04:45] [Lua] Trying returns: [false,true]
[12:04:45] [Lua] Trying returns: [true,false]
[12:04:45] [Lua] Trying returns: [false,unreachable]
[12:04:45] [Lua] Trying returns: [0,unreachable]
[12:04:45] [Lua] Trying returns: [a,unreachable]
[12:04:47] [Lua] totest is at 57

```

<b>With callback changes</b>
```ini
[12:05:34] Starting Lua mod 'TestMod'
[12:05:34] Starting Lua mod 'Keybinds'
[12:05:34] Starting mods (from enabled.txt, no defined load order)...
[12:05:34] Event loop start
[12:05:35] [Lua] Trying returns: [0,false]
[12:05:35] [Lua] Trying returns: [0,true]
[12:05:35] [Lua] Trying returns: [1,false]
[12:05:35] [Lua] Trying returns: [table: 0000029E2E37B3C0,true]
[12:05:35] [Lua] Trying returns: [thing,test]
[12:05:35] [Lua] Trying returns: [nil,a]
[12:05:35] [Lua] Trying returns: [FNameUserdata: 0000029E2DB52AD8,FNameUserdata: 0000029E2DB54DD8]
[12:05:35] [Lua] Trying returns: [false,false]
[12:05:35] [Lua] Trying returns: [false,true]
[12:05:35] [Lua] Trying returns: [true,false]
[12:05:36] [Lua] totest is at 10
```
</details>

<details>
<summary>Script - GC test</summary>

```lua
ExecuteAsync(function()
    local x = 0
    local fn = function() x = x + 1; return true; end

    collectgarbage("stop") -- disable automatic lua GC

    collectgarbage()
    collectgarbage()    -- perform manual GC (twice intentional)
    local startcnt = collectgarbage("count")*1024   -- get mem usage in bytes

    for _ = 1, 30 do    -- thirty hooks (might need to be lower depending on game/machine)
        NotifyOnNewObject("/Script/Engine.Actor", fn)
    end

    collectgarbage()
    collectgarbage()    -- perform manual GC
    local midcnt = collectgarbage("count")*1024
    print(("Alloc: %d bytes"):format(midcnt - startcnt))


    ExecuteWithDelay(2000, function()
        collectgarbage()
        collectgarbage()    -- perform manual GC
        local endcnt = collectgarbage("count")*1024

        print(("Calls: %d"):format(x))
        print(("Remnant: %d bytes"):format(endcnt - startcnt))
    end)
end)

do return end
```
</details>

<details>
<summary>Output - GC tests (3x)</summary>

<b>Without changes</b>
```ini
### Opened and closed game three times ###

[12:32:05] Starting Lua mod 'TestMod'
[12:32:05] Starting Lua mod 'Keybinds'
[12:32:05] Starting mods (from enabled.txt, no defined load order)...
[12:32:05] Event loop start
[12:32:05] [Lua] Alloc: 28320 bytes
[12:32:07] [Lua] Calls: 1710
[12:32:07] [Lua] Remnant: 33224 bytes

[12:32:45] Starting Lua mod 'TestMod'
[12:32:45] Starting Lua mod 'Keybinds'
[12:32:45] Starting mods (from enabled.txt, no defined load order)...
[12:32:45] Event loop start
[12:32:45] [Lua] Alloc: 28320 bytes
[12:32:47] [Lua] Calls: 1710
[12:32:47] [Lua] Remnant: 33224 bytes

[12:33:03] Starting Lua mod 'TestMod'
[12:33:03] Starting Lua mod 'Keybinds'
[12:33:03] Starting mods (from enabled.txt, no defined load order)...
[12:33:03] Event loop start
[12:33:03] [Lua] Alloc: 28320 bytes
[12:33:05] [Lua] Calls: 1710
[12:33:05] [Lua] Remnant: 33224 bytes

```

<b>With callback changes</b>
```ini
### Opened and closed game three times ###

[12:33:34] Starting Lua mod 'TestMod'
[12:33:34] Starting Lua mod 'Keybinds'
[12:33:34] Starting mods (from enabled.txt, no defined load order)...
[12:33:34] Event loop start
[12:33:34] [Lua] Alloc: 28832 bytes
[12:33:36] [Lua] Calls: 30
[12:33:36] [Lua] Remnant: 3976 bytes

[12:33:59] Starting Lua mod 'TestMod'
[12:33:59] Starting Lua mod 'Keybinds'
[12:33:59] Starting mods (from enabled.txt, no defined load order)...
[12:33:59] Event loop start
[12:33:59] [Lua] Alloc: 28832 bytes
[12:34:01] [Lua] Calls: 30
[12:34:01] [Lua] Remnant: 3976 bytes

[12:34:18] Starting Lua mod 'TestMod'
[12:34:18] Starting Lua mod 'Keybinds'
[12:34:18] Starting mods (from enabled.txt, no defined load order)...
[12:34:18] Event loop start
[12:34:18] [Lua] Alloc: 28832 bytes
[12:34:20] [Lua] Calls: 30
[12:34:20] [Lua] Remnant: 3976 bytes

```
</details>

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
- [x] Any dependent changes have been merged and published in downstream modules.


### Additional context
<details>
<summary><b>Notes</b></summary>

- I made a new struct `LuaCancellableCallbackData` because I needed to replace `const LuaMadeSimple::Lua& lua;` (reference) into a pointer member, to make it work with `::erase` and `::remove_if`. Modifying `LuaCallbackData` would be more difficult and would cause the PR to have a broader scope than intended, as I'd have to refactor the member's usages too.
- `bool cancel` should `false` *even if* an error occurs, so that the behavior-on-error is still identical to how the `NotifyOnNewObject` callback previously worked.
- I may have missed the implications of making `LuaMadeSimple::Lua` a pointer instead of a reference, been only a few months since I dived into C++, as I'm more of a C dragon myself. <sub><sub>haha 'sea dragon', get it? 💀</sub></sub> Do I need to somehow "free" `callback_data.lua`? Do I also need to free `instance_of_class` somehow? I pretty much mostly looked at `LuaMod::process_delayed_actions` where the action neither has its own Lua state nor another pointer member in the struct.

</details>