### PR TITLE
Added 'HookAActorTick' to UE4SS-settings.ini

### DIFF
--- a/UE4SS/include/SettingsManager.hpp
+++ b/UE4SS/include/SettingsManager.hpp
@@ -91,6 +91,7 @@ namespace RC
             bool HookCallFunctionByNameWithArguments{true};
             bool HookBeginPlay{true};
             bool HookLocalPlayerExec{true};
+            bool HookAActorTick{true};
             int64_t FExecVTableOffsetInLocalPlayer{0x28};
         } Hooks;
 

--- a/UE4SS/src/SettingsManager.cpp
+++ b/UE4SS/src/SettingsManager.cpp
@@ -114,6 +114,7 @@ namespace RC
         REGISTER_BOOL_SETTING(Hooks.HookCallFunctionByNameWithArguments, section_hooks, HookCallFunctionByNameWithArguments)
         REGISTER_BOOL_SETTING(Hooks.HookBeginPlay, section_hooks, HookBeginPlay)
         REGISTER_BOOL_SETTING(Hooks.HookLocalPlayerExec, section_hooks, HookLocalPlayerExec)
+        REGISTER_BOOL_SETTING(Hooks.HookAActorTick, section_hooks, HookAActorTick)
         REGISTER_INT64_SETTING(Hooks.FExecVTableOffsetInLocalPlayer, section_hooks, FExecVTableOffsetInLocalPlayer)
 
         constexpr static File::CharType section_experimental_features[] = STR("ExperimentalFeatures");

--- a/UE4SS/src/UE4SSProgram.cpp
+++ b/UE4SS/src/UE4SSProgram.cpp
@@ -749,6 +749,7 @@ namespace RC
         config.bHookCallFunctionByNameWithArguments = settings_manager.Hooks.HookCallFunctionByNameWithArguments;
         config.bHookBeginPlay = settings_manager.Hooks.HookBeginPlay;
         config.bHookLocalPlayerExec = settings_manager.Hooks.HookLocalPlayerExec;
+        config.bHookAActorTick = settings_manager.Hooks.HookAActorTick;
         config.FExecVTableOffsetInLocalPlayer = settings_manager.Hooks.FExecVTableOffsetInLocalPlayer;
 
         Unreal::UnrealInitializer::Initialize(config);

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -60,6 +60,7 @@ Fixed `FText` not working as a parameter (in `RegisterHook`, etc.).
 ```
 [Hooks]
 HookLoadMap = 1
+HookAActorTick = 1
 ```
 
 ### Removed

--- a/assets/UE4SS-settings.ini
+++ b/assets/UE4SS-settings.ini
@@ -132,6 +132,7 @@ HookLoadMap = 1
 HookCallFunctionByNameWithArguments = 1
 HookBeginPlay  = 1
 HookLocalPlayerExec = 1
+HookAActorTick = 1
 FExecVTableOffsetInLocalPlayer = 0x28
 
 [CrashDump]


### PR DESCRIPTION
**Description**

We've had the ability to hook AActor::Tick for a while now, but we never actually made use of this hook.
If https://github.com/Re-UE4SS/UEPseudo/pull/83 is merged, then this won't come with any performance penalties unless a C++ mod decides that they want to register an AActor::Tick hook.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

Together with #442, I created a C++ mod with a custom ACharacter class with a Tick function, and verified that the Tick function was being executed when `HookAActorTick` was set to 1.

**Checklist**

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
- [x] Any dependent changes have been merged and published in downstream modules.
