### PR TITLE
Fixed keybinds created from C++ mods executing multiple times

### DIFF
--- a/UE4SS/include/Mod/CppUserModBase.hpp
+++ b/UE4SS/include/Mod/CppUserModBase.hpp
@@ -6,6 +6,7 @@
 #include <Common.hpp>
 #include <File/Macros.hpp>
 #include <GUI/GUITab.hpp>
+#include <Input/Handler.hpp>
 
 namespace RC
 {
@@ -126,5 +127,8 @@ namespace RC
 
       protected:
         RC_UE4SS_API auto register_tab(std::wstring_view tab_name, GUI::GUITab::RenderFunctionType) -> void;
+        RC_UE4SS_API auto register_keydown_event(Input::Key, const Input::EventCallbackCallable&, uint8_t custom_data = 0) -> void;
+        RC_UE4SS_API auto register_keydown_event(Input::Key, const Input::Handler::ModifierKeyArray&, const Input::EventCallbackCallable&, uint8_t custom_data = 0)
+                -> void;
     };
 } // namespace RC

--- a/UE4SS/include/UE4SSProgram.hpp
+++ b/UE4SS/include/UE4SSProgram.hpp
@@ -62,8 +62,21 @@ namespace RC
         uint64_t safety_padding[8]{0};
     };
 
+    struct KeyDownEventData
+    {
+        // Custom data from the C++ mod.
+        // The 'custom_data' variable to UE4SSProgram::register_keydown_event will be used to determine the type of custom_data2.
+        uint8_t custom_data{};
+
+        // The C++ mod that created this event.
+        CppUserModBase* mod{};
+    };
+
     class UE4SSProgram : public MProgram
     {
+      public:
+        friend class CppUserModBase; // m_input_handler
+
       public:
         constexpr static wchar_t m_settings_file_name[] = L"UE4SS-settings.ini";
         constexpr static wchar_t m_log_file_name[] = L"UE4SS.log";
@@ -213,9 +226,12 @@ namespace RC
 
       public:
         // API pass-through for use outside the private scope of UE4SSProgram
-        RC_UE4SS_API auto register_keydown_event(Input::Key, const Input::EventCallbackCallable&, uint8_t custom_data = 0) -> void;
-        RC_UE4SS_API auto register_keydown_event(Input::Key, const Input::Handler::ModifierKeyArray&, const Input::EventCallbackCallable&, uint8_t custom_data = 0)
-                -> void;
+        RC_UE4SS_API auto register_keydown_event(Input::Key, const Input::EventCallbackCallable&, uint8_t custom_data = 0, void* custom_data2 = nullptr) -> void;
+        RC_UE4SS_API auto register_keydown_event(Input::Key,
+                                                 const Input::Handler::ModifierKeyArray&,
+                                                 const Input::EventCallbackCallable&,
+                                                 uint8_t custom_data = 0,
+                                                 void* custom_data2 = nullptr) -> void;
         RC_UE4SS_API auto is_keydown_event_registered(Input::Key) -> bool;
         RC_UE4SS_API auto is_keydown_event_registered(Input::Key, const Input::Handler::ModifierKeyArray&) -> bool;
 

--- a/UE4SS/src/Mod/CppUserModBase.cpp
+++ b/UE4SS/src/Mod/CppUserModBase.cpp
@@ -22,11 +22,49 @@ namespace RC
             }
         }
         GUITabs.clear();
+
+        auto& key_events = UE4SSProgram::get_program().m_input_handler.get_events();
+        std::erase_if(key_events, [&](Input::KeySet& input_event) -> bool {
+            bool were_all_events_registered_from_this_mod = true;
+            for (auto& [key, vector_of_key_data] : input_event.key_data)
+            {
+                std::erase_if(vector_of_key_data, [&](Input::KeyData& key_data) -> bool {
+                    // custom_data == 1: Bind came from Lua, and custom_data2 is nullptr.
+                    // custom_data == 2: Bind came from C++, and custom_data2 is a pointer to KeyDownEventData. Must free it.
+                    auto event_data = static_cast<KeyDownEventData*>(key_data.custom_data2);
+                    if (key_data.custom_data == 2 && event_data && event_data->mod == this)
+                    {
+                        delete event_data;
+                        return true;
+                    }
+                    else
+                    {
+                        were_all_events_registered_from_this_mod = false;
+                        return false;
+                    }
+                });
+            }
+
+            return were_all_events_registered_from_this_mod;
+        });
     }
 
     auto CppUserModBase::register_tab(std::wstring_view tab_name, GUI::GUITab::RenderFunctionType render_function) -> void
     {
         auto& tab = GUITabs.emplace_back(std::make_shared<GUI::GUITab>(tab_name, render_function, this));
         UE4SSProgram::get_program().add_gui_tab(tab);
+    }
+
+    auto CppUserModBase::register_keydown_event(Input::Key key, const Input::EventCallbackCallable& callback, uint8_t custom_data) -> void
+    {
+        UE4SSProgram::get_program().register_keydown_event(key, callback, 2, new KeyDownEventData{custom_data, this});
+    }
+
+    auto CppUserModBase::register_keydown_event(Input::Key key,
+                                                const Input::Handler::ModifierKeyArray& callback,
+                                                const Input::EventCallbackCallable& modifier_keys,
+                                                uint8_t custom_data) -> void
+    {
+        UE4SSProgram::get_program().register_keydown_event(key, callback, modifier_keys, 2, new KeyDownEventData{custom_data, this});
     }
 } // namespace RC

--- a/UE4SS/src/UE4SSProgram.cpp
+++ b/UE4SS/src/UE4SSProgram.cpp
@@ -1275,6 +1275,8 @@ namespace RC
             for (auto& [key, vector_of_key_data] : input_event.key_data)
             {
                 std::erase_if(vector_of_key_data, [&](Input::KeyData& key_data) -> bool {
+                    // custom_data == 1: Bind came from Lua, and custom_data2 is nullptr.
+                    // custom_data == 2: Bind came from C++, and custom_data2 is a pointer to KeyDownEventData. Must free it.
                     if (key_data.custom_data == 1)
                     {
                         return true;
@@ -1445,17 +1447,18 @@ namespace RC
         return m_queued_events.empty();
     }
 
-    auto UE4SSProgram::register_keydown_event(Input::Key key, const Input::EventCallbackCallable& callback, uint8_t custom_data) -> void
+    auto UE4SSProgram::register_keydown_event(Input::Key key, const Input::EventCallbackCallable& callback, uint8_t custom_data, void* custom_data2) -> void
     {
-        m_input_handler.register_keydown_event(key, callback, custom_data);
+        m_input_handler.register_keydown_event(key, callback, custom_data, custom_data2);
     }
 
     auto UE4SSProgram::register_keydown_event(Input::Key key,
                                               const Input::Handler::ModifierKeyArray& modifier_keys,
                                               const Input::EventCallbackCallable& callback,
-                                              uint8_t custom_data) -> void
+                                              uint8_t custom_data,
+                                              void* custom_data2) -> void
     {
-        m_input_handler.register_keydown_event(key, modifier_keys, callback, custom_data);
+        m_input_handler.register_keydown_event(key, modifier_keys, callback, custom_data, custom_data2);
     }
 
     auto UE4SSProgram::is_keydown_event_registered(Input::Key key) -> bool

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -13,6 +13,9 @@ TBD
 ### Lua API
 
 ### C++ API
+Key binds created with `UE4SSProgram::register_keydown_event` end up being duplicated upon mod hot-reload.  
+To fix this, `CppUserModBase::register_keydown_event` has been introduced.  
+It's used exactly the same way except without the `UE4SSProgram::` part.
 
 ### Experimental
 

--- a/deps/first/Input/include/Input/Handler.hpp
+++ b/deps/first/Input/include/Input/Handler.hpp
@@ -22,6 +22,7 @@ namespace RC::Input
         std::vector<ModifierKey> required_modifier_keys{};
         std::vector<EventCallbackCallable> callbacks{};
         uint8_t custom_data{};
+        void* custom_data2{};
         bool requires_modifier_keys{};
         bool is_down{};
     };
@@ -73,10 +74,11 @@ namespace RC::Input
 
       public:
         auto process_event() -> void;
-        auto register_keydown_event(Input::Key, EventCallbackCallable, uint8_t custom_data = 0) -> void;
+        auto register_keydown_event(Input::Key, EventCallbackCallable, uint8_t custom_data = 0, void* custom_data2 = nullptr) -> void;
 
         using ModifierKeyArray = std::array<Input::ModifierKey, max_modifier_keys>;
-        auto register_keydown_event(Input::Key, const ModifierKeyArray&, const EventCallbackCallable&, uint8_t custom_data = 0) -> void;
+        auto register_keydown_event(Input::Key, const ModifierKeyArray&, const EventCallbackCallable&, uint8_t custom_data = 0, void* custom_data2 = nullptr)
+                -> void;
 
         auto is_keydown_event_registered(Input::Key) -> bool;
         auto is_keydown_event_registered(Input::Key, const ModifierKeyArray&) -> bool;

--- a/deps/first/Input/src/Handler.cpp
+++ b/deps/first/Input/src/Handler.cpp
@@ -159,7 +159,7 @@ namespace RC::Input
         }
     }
 
-    auto Handler::register_keydown_event(Input::Key key, EventCallbackCallable callback, uint8_t custom_data) -> void
+    auto Handler::register_keydown_event(Input::Key key, EventCallbackCallable callback, uint8_t custom_data, void* custom_data2) -> void
     {
         KeySet& key_set = [&]() -> KeySet& {
             for (auto& key_set : m_key_sets)
@@ -176,9 +176,11 @@ namespace RC::Input
         KeyData& key_data = key_set.key_data[key].emplace_back();
         key_data.callbacks.emplace_back(callback);
         key_data.custom_data = custom_data;
+        key_data.custom_data2 = custom_data2;
     }
 
-    auto Handler::register_keydown_event(Input::Key key, const ModifierKeyArray& modifier_keys, const EventCallbackCallable& callback, uint8_t custom_data) -> void
+    auto Handler::register_keydown_event(
+            Input::Key key, const ModifierKeyArray& modifier_keys, const EventCallbackCallable& callback, uint8_t custom_data, void* custom_data2) -> void
     {
         KeySet& key_set = [&]() -> KeySet& {
             for (auto& key_set : m_key_sets)
@@ -195,6 +197,7 @@ namespace RC::Input
         KeyData& key_data = key_set.key_data[key].emplace_back();
         key_data.callbacks.emplace_back(callback);
         key_data.custom_data = custom_data;
+        key_data.custom_data2 = custom_data2;
         key_data.requires_modifier_keys = true;
 
         for (const auto& modifier_key : modifier_keys)


### PR DESCRIPTION
**Description**

This only happened if the hot-reload feature was used to reload all mods.

This was fixed by introducing `CppUserModBase::register_keydown_event`.
It's identical to the one in UE4SSProgram, except it keeps track of which C++ mod registered the event so that it can be "unregistered" when the mod is reloaded.

Mods that continue to use the UE4SSProgram version will continue to have the same problem.

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

I created a C++ mod that registered a keybind with the new function that output something to the console, and verified that only one message in the console appeared after using the bind after spamming the "Restart All Mods" button.

**Checklist**

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
- [x] Any dependent changes have been merged and published in downstream modules.
