### PR TITLE
Fixed BPModLoaderMod RegisterBeginPlayPostHook

### DIFF
--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -39,6 +39,10 @@ Added support for watching ArrayProperty and StructProperty.
 ### General
 Fixed BPModLoaderMod giving "bad conversion" errors.
 
+Fixed BPModLoaderMod calling `PostBeginPlay` multiple times for each ModActor
+
+Fixed BPModLoaderMod displaying 'PostBeginPlay not valid' when VerboseLogging is set to false
+
 Fixed some debug GUI layout alignments, especially with different GUI font scaling settings.
 
 ### Live View

--- a/assets/Mods/BPModLoaderMod/Scripts/main.lua
+++ b/assets/Mods/BPModLoaderMod/Scripts/main.lua
@@ -266,7 +266,7 @@ RegisterBeginPlayPostHook(function(ContextParam)
     local Context = ContextParam:get()
     for _,ModConfig in ipairs(OrderedMods) do
         if Context:GetClass():GetFName() ~= ModConfig.AssetNameAsFName then return end
-        local AssetPathWithClassPrefix = "BlueprintGeneratedClass " .. ModConfig.AssetPath .. "." .. ModConfig.AssetNameAsFName:ToString()
+        local AssetPathWithClassPrefix = "BlueprintGeneratedClass " .. ModConfig.AssetPath .. "." .. ModConfig.AssetName
         if AssetPathWithClassPrefix == Context:GetClass():GetFullName() then
             local PostBeginPlay = Context.PostBeginPlay
             if PostBeginPlay:IsValid() then

--- a/assets/Mods/BPModLoaderMod/Scripts/main.lua
+++ b/assets/Mods/BPModLoaderMod/Scripts/main.lua
@@ -266,12 +266,15 @@ RegisterBeginPlayPostHook(function(ContextParam)
     local Context = ContextParam:get()
     for _,ModConfig in ipairs(OrderedMods) do
         if Context:GetClass():GetFName() ~= ModConfig.AssetNameAsFName then return end
-        local PostBeginPlay = Context.PostBeginPlay
-        if PostBeginPlay:IsValid() then
-            Log(string.format("Executing 'PostBeginPlay' for mod '%s'\n", Context:GetFullName()))
-            PostBeginPlay()
-        else
-            Log(string.format("PostBeginPlay not valid for mod %s\n", Context:GetFullName(), true))
+        local AssetPathWithClassPrefix = "BlueprintGeneratedClass " .. ModConfig.AssetPath .. "." .. ModConfig.AssetNameAsFName:ToString()
+        if AssetPathWithClassPrefix == Context:GetClass():GetFullName() then
+            local PostBeginPlay = Context.PostBeginPlay
+            if PostBeginPlay:IsValid() then
+                Log(string.format("Executing 'PostBeginPlay' for mod '%s'\n", Context:GetFullName()))
+                PostBeginPlay()
+            else
+                Log(string.format("PostBeginPlay not valid for mod %s\n", Context:GetFullName()), true)
+            end
         end
     end
 end)

--- a/assets/Mods/BPModLoaderMod/Scripts/main.lua
+++ b/assets/Mods/BPModLoaderMod/Scripts/main.lua
@@ -266,7 +266,7 @@ RegisterBeginPlayPostHook(function(ContextParam)
     local Context = ContextParam:get()
     for _,ModConfig in ipairs(OrderedMods) do
         if Context:GetClass():GetFName() ~= ModConfig.AssetNameAsFName then return end
-        local AssetPathWithClassPrefix = "BlueprintGeneratedClass " .. ModConfig.AssetPath .. "." .. ModConfig.AssetName
+        local AssetPathWithClassPrefix = string.format("BlueprintGeneratedClass %s.%s", ModConfig.AssetPath, ModConfig.AssetName)
         if AssetPathWithClassPrefix == Context:GetClass():GetFullName() then
             local PostBeginPlay = Context.PostBeginPlay
             if PostBeginPlay:IsValid() then


### PR DESCRIPTION
**Description**

I noticed we're only checking for the class name `ModActor_C` inside `RegisterBeginPlayPostHook` rather than the full class path so I added a check against the full class path which will only trigger `PostBeginPlay` once for the ModActor that fired BeginPlay.

The boolean for `Log` was accidentally placed inside string.format so it'd still be printing `PostBeginPlay not valid` with `VerboseLogging` set to false.

Fixes #433, #91

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Tested on 4.27 and 5.1 with multiple ModActors.

**Checklist**

- [x] I have performed a self-review of my own code.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
