### PR TITLE
Replaced usage of 'SetDefaultDllDirectories'

### DIFF
--- a/UE4SS/src/Mod/CppMod.cpp
+++ b/UE4SS/src/Mod/CppMod.cpp
@@ -22,7 +22,7 @@ namespace RC
         auto dll_path = m_dlls_path + L"\\main.dll";
         // Add mods dlls directory to search path for dynamic/shared linked libraries in mods
         m_dlls_path_cookie = AddDllDirectory(m_dlls_path.c_str());
-        m_main_dll_module = LoadLibraryW(dll_path.c_str());
+        m_main_dll_module = LoadLibraryExW(dll_path.c_str(), NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
 
         if (!m_main_dll_module)
         {

--- a/UE4SS/src/UE4SSProgram.cpp
+++ b/UE4SS/src/UE4SSProgram.cpp
@@ -391,9 +391,7 @@ namespace RC
         m_game_path_and_exe_name = game_exe_path;
         m_object_dumper_output_directory = m_game_executable_directory;
 
-        // Allow loading of DLLs from mod folders
-        SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
-        // Make sure game directory DLLs are also included
+        // Allow loading of DLLs from the game directory
         AddDllDirectory(game_exe_path.c_str());
 
         for (const auto& item : std::filesystem::directory_iterator(m_root_directory))

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -49,6 +49,8 @@ Fixed BPModLoaderMod displaying 'PostBeginPlay not valid' when VerboseLogging is
 
 Fixed some debug GUI layout alignments, especially with different GUI font scaling settings.
 
+Fixed PalServer not accepting connections from players.
+
 ### Live View
 Fixed the "Write to file" checkbox not working for functions in the `Watches` tab.
 Reduced the likelihood of a crash happening on shutdown when at least one watch is enabled.


### PR DESCRIPTION
**Description**

This was done to fix PalServer not working properly after an update. The usage of 'SetDefaultDllDirectories' was there to allow C++ mods that have dynamic dependencies to store those dependencies right next to main.dll instead of in the Win64 directory.

This behavior remains intact, but we're using 'LoadLibraryEx' instead of 'LoadLibrary' to set the path specifically for main.dll instead of globally with 'SetDefaultDllDirectories'.

See #452 for discussion around this problem.
Fixes #452.

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

I made a C++ mod and a dependency with at least one export and dynamically linked that dependency with my C++ mod.
I then added both dlls (main.dll & dep.dll) to my UE4SS installation for PalServer.
After that, I launched PalServer and made sure that both my C++ mod and the dependency loaded.
I did this by adding an export in the dependency (global function) that calls printf, and then I checked for that output in the Win32 console after starting PalServer, and it was there.
I then started PalWorld and made sure I could connect to my server.

**Checklist**

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
- [x] Any dependent changes have been merged and published in downstream modules.
