### PR TITLE
fix(proxy): fix proxy dll not exporting symbols

### DIFF
--- a/UE4SS/proxy_generator/proxy/xmake.lua
+++ b/UE4SS/proxy_generator/proxy/xmake.lua
@@ -43,7 +43,7 @@ target("proxy")
         target:set("basename", filename)
     end)
 
-    on_config(function (target)
+    after_load(function (target)
         local projectRoot = get_config("ue4ssRoot")
 
         local scriptsRoot = get_config("scriptsRoot")
@@ -51,6 +51,7 @@ target("proxy")
         import("build_configs", { rootdir = scriptsRoot })
 
         build_configs:config(target)
+        build_configs:set_output_dir(target)
 
         local output_path = path.join(os.projectdir(), target:dep("proxy_files"):autogendir())
         local proxy_name = target_helpers.get_path_filename(get_config("ue4ssProxyPath"))


### PR DESCRIPTION
### Description

The proxy target did not export any symbols, causing UE4SS to fail loading with "The application was unable to start correctly (0xc000007b)" when using the new xmake-built proxy (dwmapi.dll). 

~~Correcting the proxy build issue also fixed the OpenGL white screen issue in the debugging GUI.~~ ~~Possibly relevant to discussion in #344.~~ My local builds with this change seem to fix the OpenGL white screen issue, but the issue remains on Github runner-built releases.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Use new dwmapi.dll with UE4SS. Should load fine with the changes.

### Checklist

- [x] Any dependent changes have been merged and published in downstream modules.
