### PR TITLE
fix: UNICODE exports

### DIFF
--- a/tools/xmakescripts/build_configs.lua
+++ b/tools/xmakescripts/build_configs.lua
@@ -49,7 +49,9 @@ PLATFORM_TYPES = {
             "PLATFORM_WINDOWS",
             "PLATFORM_MICROSOFT",
             "OVERRIDE_PLATFORM_HEADER_NAME=Windows",
-            "UBT_COMPILED_PLATFORM=Win64"
+            "UBT_COMPILED_PLATFORM=Win64",
+            "UNICODE",
+            "_UNICODE"
         }
     }
 }
@@ -130,7 +132,7 @@ end
 -- Apply targe options
 function apply_target_options(self, target, options)
     for option, values in pairs(options) do
-        target:add(option, values)
+        target:add(option, values, { public = true })
     end
 end
 


### PR DESCRIPTION
**Description**

Fixes UNICODE and _UNICODE macros not being exported correctly breaking the `TEXT` macro.

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Compiling a mod that includes `UE4SSProgram.hpp`.

**Screenshots (if appropriate)**

**Additional context**
