### PR TITLE
fix: compilation quirk with vs2019

### DIFF
--- a/UE4SS/src/Mod/LuaMod.cpp
+++ b/UE4SS/src/Mod/LuaMod.cpp
@@ -2199,17 +2199,18 @@ Overloads:
                                     }
                                     const auto current_path = std::string{lua.get_string()};
                                     auto files_table = lua.prepare_new_table();
-                                    for (int i = 1; const auto& item : std::filesystem::directory_iterator(current_path))
+                                    auto index = 1;
+                                    for (const auto& item : std::filesystem::directory_iterator(current_path))
                                     {
                                         if (!item.is_directory())
                                         {
-                                            files_table.add_key(i);
+                                            files_table.add_key(index);
                                             auto file_table = lua.prepare_new_table();
                                             file_table.add_pair("__name", to_string(item.path().filename().wstring()).c_str());
                                             file_table.add_pair("__absolute_path", to_string(item.path().wstring()).c_str());
                                             files_table.fuse_pair();
                                         }
-                                        ++i;
+                                        ++index;
                                     }
                                     return 1;
                                 }


### PR DESCRIPTION
### Description

It seems that VS2019 should still be supported according to the readme. This should work around the issue with building with (some versions of?) VS2019, where [LuaMod.cpp#L2206](https://github.com/UE4SS-RE/RE-UE4SS/blob/73d337852d004f71bd1b5d24ad703263854e44e7/UE4SS/src/Mod/LuaMod.cpp#L2206) fails with "`error C3493: 'i' cannot be implicitly captured because no default capture mode has been specified`," which I assume is a MSVC quirk, as it doesn't make sense otherwise. Happened on a windows-2019 Github runner, and coincidentally on one other person too.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<details>
<summary>Testing</summary>

Test code:
```lua
ExecuteInGameThread(function()
    local dirs = IterateGameDirectories()
    for k, GameDirectory in pairs(dirs) do
        print(("%s: %s [%s]"):format(k, GameDirectory.__name, GameDirectory.__absolute_path))
        for i, File in pairs(GameDirectory.__files) do
            print(("    - %s: %s [%s]"):format(i, File.__name, File.__absolute_path))
        end
    end
end)
```

Directory layout:
![image](https://github.com/UE4SS-RE/RE-UE4SS/assets/38674984/08f0ba0c-acb1-4660-ba58-f6a96bc8bb41)

Output (Release [UE4SS - v3.0.1 Beta #0 - Git SHA #d935b5b]):
![image](https://github.com/UE4SS-RE/RE-UE4SS/assets/38674984/46433458-94f6-4311-a342-93c4ce0dd0cb)

Output (this change):
![image](https://github.com/UE4SS-RE/RE-UE4SS/assets/38674984/0ae9f877-503a-4997-b12f-8ecc611bcbe2)

</details>

### Checklist

- [x] Any dependent changes have been merged and published in downstream modules.

### Additional context

Unsure about appending to changelog again, because the xmake change might or *might not* be involved in this, given that the error has not appeared before for anyone it seems, except recently (today).
