### PR TITLE
fix: use GitHub PAT to avoid 'early EOF' errors in workflow runner

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -21,18 +21,12 @@ jobs:
     runs-on: windows-2022
 
     steps:
-      - name: Setup github SSH
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.UEPSEUDO_SSH_KEY }}
-          known_hosts: unnecessary
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0 # needed to get commits since last tag
-          ssh-key: ${{ secrets.UEPSEUDO_SSH_KEY }}
+          token: ${{ secrets.UEPSEUDO_PAT }}
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,18 +10,12 @@ jobs:
     runs-on: windows-2022
 
     steps:
-      - name: Setup github SSH
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.UEPSEUDO_SSH_KEY }}
-          known_hosts: unnecessary
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0 # needed to get commits since last tag
-          ssh-key: ${{ secrets.UEPSEUDO_SSH_KEY }}
+          token: ${{ secrets.UEPSEUDO_PAT }}
 
       - name: Setup Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
### Description

Use GitHub PAT (personal access token) to avoid 'early EOF' errors in workflow runner. This essentially replaces the use of SSH in the workflows.

Resolves #437.

### Required changes on GitHub for this PR:

- Generate a PAT on the user that holds [UEPseudo](https://github.com/Re-UE4SS/UEPseudo), either a "fine-grained token" or a "classic token" (more on that below), under Settings, Developer Settings, Personal access tokens.
- Add the PAT to RE-UE4SS repository action secrets (under repo's Settings, Secrets and variables, Actions), with secret name being `UEPSEUDO_PAT`, and with the personal access token as the value.

Note: The SSH key is still used in other workflows other than experimental and release.

Personal access tokens can be either classic or fine-grained. __**Fine-grained tokens**__ allows for read-only access to private repositories you specify that the user is a (direct) owner of, but has an expiration date of 1 year at most, and *will need* to be regenerated and replaced when it expires. __**Classic tokens**__ can be specified to never expire, but has less control over access - to be able to *just* read private repositories, *full `repo` access* must be given to the token, i.e., read/write access to user repositories.

**Configuration of the token:**
<details>
<summary><i>Configuration for Fine-grained tokens</i></summary>
<ul>
<li>Everything is default unless specified</li>
<li><b><u>Name:</u></b>  any descriptive name</li>
<li><b><u>Expiration:</u></b>  to preference, at most 1 year</li>
<li><b><u>Repository access:</u></b>  Only select repositories. Add <b>UEPseudo</b> into the selection list. RE-UE4SS does not need to be selected as long as it remains a public repository.</li>
<li><b><u>Permissions:</u></b>  Under Repository permissions, set <b>Contents</b> to Access: Read-only.</li>
<li>Overview should now say "2 permissions for 1 of your repositories" (Contents and Metadata). Generate the token.</li>
</ul>
</details>

<details>
<summary><i>Configuration for Classic tokens</i></summary>
<ul>
<li>Everything is default unless specified</li>
<li><b><u>Note:</u></b>  any descriptive name</li>
<li><b><u>Expiration:</u></b>  to preference, indefinite expiration is allowed</li>
<li><b><u>Select scopes:</u></b>  <b>repo</b> checkbox must be checked. Will also unconditionally enable the options below it.</li>
<li>Generate the token.</li>
</ul>
</details>

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

All 7 test workflow runs have passed the Checkout step with no git 'early EOF' errors nor retries.

[Complete workflow run 1](https://github.com/Lyrth/RE-UE4SS/actions/runs/8629858934/job/23654896383#step:2:43) - using fine-grained PAT
[Workflow run 2](https://github.com/Lyrth/RE-UE4SS/actions/runs/8629878126/job/23654953321#step:2:43) - using fine-grained PAT - cancelled after the Checkout step succeeded to save resources.
[Workflow run 3](https://github.com/Lyrth/RE-UE4SS/actions/runs/8629888452/job/23654983254#step:2:43) - ^
[Workflow run 4](https://github.com/Lyrth/RE-UE4SS/actions/runs/8629900046/job/23655017554#step:2:43) - ^
[Workflow run 5](https://github.com/Lyrth/RE-UE4SS/actions/runs/8629913808/job/23655059496#step:2:43) - ^
[Workflow run 6](https://github.com/Lyrth/RE-UE4SS/actions/runs/8630051426/job/23655513762#step:2:43) - using classic PAT - also cancelled after the Checkout step succeeded.
[Workflow run 7](https://github.com/Lyrth/RE-UE4SS/actions/runs/8630063926/job/23655555371#step:2:43) - ^

**Checklist**

- [x] Any dependent changes have been merged and published in downstream modules.
