### PR TITLE
fix: Live View constantly searching

### DIFF
--- a/UE4SS/src/GUI/LiveView.cpp
+++ b/UE4SS/src/GUI/LiveView.cpp
@@ -108,7 +108,8 @@ namespace RC::GUI
     {
         // TODO: Stop using the 'HashObject' function when needing the address of an FFieldClassVariant because it's not designed to return an address.
         //       Maybe make the ToFieldClass/ToUClass functions public (append 'Unsafe' to the function names).
-        if (LiveView::s_need_to_filter_out_properties && object->IsA(std::bit_cast<UClass*>(FProperty::StaticClass().HashObject())))
+        if (LiveView::s_name_to_search_by.empty() ||
+            LiveView::s_need_to_filter_out_properties && object->IsA(std::bit_cast<UClass*>(FProperty::StaticClass().HashObject())))
         {
             return;
         }

--- a/UE4SS/src/UE4SSProgram.cpp
+++ b/UE4SS/src/UE4SSProgram.cpp
@@ -793,7 +793,6 @@ namespace RC
             if (settings_manager.General.UseUObjectArrayCache)
             {
                 m_debugging_gui.get_live_view().set_listeners_allowed(true);
-                m_debugging_gui.get_live_view().set_listeners();
             }
             else
             {

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -56,10 +56,14 @@ Fixes BPModLoaderMod not loading when UE4SS initializes too late ([UE4SS #454](h
 
 Fixed PalServer not accepting connections from players ([UE4SS #453](https://github.com/UE4SS-RE/RE-UE4SS/pull/453))
 
+Fixed a crash that would occur randomly due to accidental execution of Live View search code ([UE4SS #475](https://github.com/UE4SS-RE/RE-UE4SS/pull/475))
+
 ### Live View
 Fixed the "Write to file" checkbox not working for functions in the `Watches` tab ([UE4SS #419](https://github.com/UE4SS-RE/RE-UE4SS/pull/419))
 
 Reduced the likelihood of a crash happening on shutdown when at least one watch is enabled ([UE4SS #419](https://github.com/UE4SS-RE/RE-UE4SS/pull/419))
+
+Fixed constantly searching even if the search field is empty, and even if not on the tab ([UE4SS #475](https://github.com/UE4SS-RE/RE-UE4SS/pull/475))
 
 ### UHT Dumper
 


### PR DESCRIPTION
**Description**

This happened even if the user wasn't on the live view tab. It didn't happen if the GUI was turned off in the ini file.

Also fixed a bug where 'object_full_name.find(name_to_search_by)' would return 0 instead of npos if 'name_to_search_by' was an empty string.

Fixes #473 

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Checklist**

Please delete options that are not relevant. Update the list as the PR progresses.

- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
