### PR TITLE
fix(Lua): Crash when calling functions taking Array<T> as an 'Out' param

### DIFF
--- a/UE4SS/src/LuaType/LuaUObject.cpp
+++ b/UE4SS/src/LuaType/LuaUObject.cpp
@@ -246,7 +246,8 @@ namespace RC::LuaType
                 lua.registry().get_table_ref(lua_table_ref);
                 auto lua_table = lua.get_table();
 
-                if (!param->IsA<Unreal::FStructProperty>())
+                auto reuse_same_table = param->IsA<Unreal::FArrayProperty>() || param->IsA<Unreal::FStructProperty>();
+                if (!reuse_same_table)
                 {
                     lua_table.add_key(to_string(param->GetName()).c_str());
                 }
@@ -264,7 +265,7 @@ namespace RC::LuaType
                             .base = static_cast<Unreal::UObject*>(static_cast<void*>(dynamic_unreal_function_data.data)),
                             .data = data,
                             .property = param,
-                            .create_new_if_get_non_trivial_local = false,
+                            .create_new_if_get_non_trivial_local = !reuse_same_table,
                     };
                     StaticState::m_property_value_pushers[name_comparison_index](pusher_params);
                 }
@@ -274,7 +275,7 @@ namespace RC::LuaType
                     lua.throw_error(std::format("Tried calling UFunction without a registered handler 'Out' param. Type '{}' not supported.", param_type_name));
                 }
 
-                if (!param->IsA<Unreal::FStructProperty>())
+                if (!reuse_same_table)
                 {
                     lua_table.fuse_pair();
                 }

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -70,6 +70,8 @@ Fixed the "IterateGameDirectories" global function throwing "bad conversion" err
 
 Fixed `FText` not working as a parameter (in `RegisterHook`, etc.) ([UE4SS #422](https://github.com/UE4SS-RE/RE-UE4SS/pull/422)) - localcc
 
+Fixed crash when calling UFunctions that take one or more 'out' params of type TArray<T>. ([UE4SS #477](https://github.com/UE4SS-RE/RE-UE4SS/pull/477))
+
 ### C++ API
 
 


### PR DESCRIPTION
**Description**

Fixes #474

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

With the following script, and also LineTraceMod.
```lua
function printf(...)
  print(string.format(...))
end
function IterateTable(t)
    for k,v in pairs(t) do
        print(string.format("%s == %s\n", k, v))
    end
end
RegisterKeyBind(Key.I, function()
    local Math = StaticFindObject("/Script/Engine.Default__KismetMathLibrary")
    local Val = Math:Add_IntInt(2, 3)
    print(string.format("Val: %s\n", Val))
    
    local class = StaticFindObject("/Script/Engine.Actor")
    local gameplayStatics = StaticFindObject("/Script/Engine.Default__GameplayStatics")
    local worldctx = FindFirstOf("GameInstance")
    
    local results = {}
    print("GetAllActorsOfClass() before\n")
    gameplayStatics:GetAllActorsOfClass(worldctx, class, results);
    print("GetAllActorsOfClass() after\n")
    
    printf("GetAllActorsOfClass() len: %d\n", #results)
    for k,v in pairs(results) do
        print(string.format("%s == %s\n", k, v:get():GetFName():ToString()))
    end
    
    local RootComponent = FindFirstOf("Character").RootComponent
    print(string.format("RootComponent: %s\n", RootComponent:IsValid() and RootComponent:GetFullName() or "None"))
    local UpVector = RootComponent:GetUpVector()
    for k, v in pairs(UpVector) do
        print(string.format("%s == %s\n", k, v))
    end
    
    local PlayerController = FindFirstOf("PlayerController")
    local Tilt = {}
    local RotationRate = {}
    local Gravity = {}
    local Acceleration = {}
    PlayerController:GetInputMotionState(Tilt, RotationRate, Gravity, Acceleration)
    IterateTable(Tilt)
    IterateTable(RotationRate)
    IterateTable(Gravity)
    IterateTable(Acceleration)
    local SizeX = {}
    local SizeY = {}
    PlayerController:GetViewportSize(SizeX, SizeY)
    IterateTable(SizeX)
    IterateTable(SizeY)
end)
```

**Checklist**

Please delete options that are not relevant. Update the list as the PR progresses.

- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.