### PR TITLE
fix(C++ Mods): Delayed mod constructor until imgui is initialized

### DIFF
--- a/UE4SS/include/Mod/CppMod.hpp
+++ b/UE4SS/include/Mod/CppMod.hpp
@@ -60,6 +60,7 @@ namespace RC
                 -> void;
 
         auto fire_unreal_init() -> void override;
+        auto fire_ui_init() -> void override;
         auto fire_program_start() -> void override;
         auto fire_update() -> void override;
         auto fire_dll_load(std::wstring_view dll_name) -> void;

--- a/UE4SS/include/Mod/CppUserModBase.hpp
+++ b/UE4SS/include/Mod/CppUserModBase.hpp
@@ -53,6 +53,12 @@ namespace RC
         {
         }
 
+        // The UI module has been initialized.
+        // This is where you need to use the 'UE4SS_ENABLE_IMGUI' macro if you want to utilize the imgui context of UE4SS.
+        RC_UE4SS_API virtual auto on_ui_init() -> void
+        {
+        }
+
         RC_UE4SS_API virtual auto on_program_start() -> void
         {
         }

--- a/UE4SS/include/Mod/Mod.hpp
+++ b/UE4SS/include/Mod/Mod.hpp
@@ -66,6 +66,8 @@ namespace RC
 
         virtual auto fire_unreal_init() -> void{};
 
+        virtual auto fire_ui_init() -> void{};
+
         // Called once when the program is starting, after mods are setup but before any mods have been started
         virtual auto fire_program_start() -> void{};
 

--- a/UE4SS/src/Mod/CppMod.cpp
+++ b/UE4SS/src/Mod/CppMod.cpp
@@ -128,6 +128,14 @@ namespace RC
         }
     }
 
+    auto CppMod::fire_ui_init() -> void
+    {
+        if (m_mod)
+        {
+            m_mod->on_ui_init();
+        }
+    }
+
     auto CppMod::fire_program_start() -> void
     {
         if (m_mod)

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -17,6 +17,10 @@ Key binds created with `UE4SSProgram::register_keydown_event` end up being dupli
 To fix this, `CppUserModBase::register_keydown_event` has been introduced.  
 It's used exactly the same way except without the `UE4SSProgram::` part.
 
+Added `on_ui_init()`, it fires when the UI is initialized.  
+It's intended to use the `UE4SS_ENABLE_IMGUI` macro in this function.  
+Failing to do so will cause a crash when you try to render something with imgui.
+
 ### Experimental
 
 
@@ -82,7 +86,7 @@ Fixed `FText` not working as a parameter (in `RegisterHook`, etc.) ([UE4SS #422]
 Fixed crash when calling UFunctions that take one or more 'out' params of type TArray<T>. ([UE4SS #477](https://github.com/UE4SS-RE/RE-UE4SS/pull/477))
 
 ### C++ API
-
+Fixed a crash caused by a race condition enabled by C++ mods using `UE4SS_ENABLE_IMGUI` in their constructor ([UE4SS #481](https://github.com/UE4SS-RE/RE-UE4SS/pull/481))
 
 ## Settings
 

--- a/docs/guides/creating-gui-tabs-with-c++-mod.md
+++ b/docs/guides/creating-gui-tabs-with-c++-mod.md
@@ -21,10 +21,6 @@ public:
         ModDescription = STR("This is my awesome mod");
         ModAuthors = STR("UE4SS Team");
         
-        // It's critical that you enable ImGui before you create your tab.
-        // If you don't do this, a crash will occur as soon as ImGui tries to render anything in your tab.
-        UE4SS_ENABLE_IMGUI()
-        
         // The 'register_tab' function will tell UE4SS to render a tab.
         // Tabs registered this way will be automatically cleaned up when this C++ mod is destructed.
         // The first param is the display name of your tab.
@@ -63,6 +59,13 @@ public:
         // Because you created a tab with 'UE4SSProgram::add_gui_tab', you must manually remove it.
         // Failure to remove the tab will result in a crash.
         UE4SSProgram::get_program().remove_gui_tab(m_less_safe_tab);
+    }
+    
+    auto on_ui_init() -> void override
+    {
+        // It's critical that you enable ImGui if you intend to use ImGui within the context of UE4SS.
+        // If you don't do this, a crash will occur as soon as ImGui tries to render anything, for example in your tab.
+        UE4SS_ENABLE_IMGUI()
     }
     
     auto render_some_stuff(int Number) -> void


### PR DESCRIPTION
**Description**

This only happens if the mod uses `UE4SS_ENABLE_IMGU`' macro in the constructor.

The purpose of this is to guarantee that imgui context has been set before a mod uses any imgui functions. Previously, we were assuming that the context would be set by the time the mod construct was called, however this was actually a race condition. It was possible for the mod constructor to be called before the UI code in UE4SS created the imgui context.

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

See #469

**Checklist**

Please delete options that are not relevant. Update the list as the PR progresses.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
