### PR TITLE
feat: Added File::OpenFor::ReadWrite

### DIFF
--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -25,6 +25,9 @@ Failing to do so will cause a crash when you try to render something with imgui.
 
 BREAKING: Changed `FTransform` constructor to be identical to unreal.
 
+Added `OpenFor::ReadWrite`, to be used when calling `File::open`.  
+This can be used when calling `FileHandle::memory_map`, unlike `OpenFor::Writing`.  ([UE4SS #507](https://github.com/UE4SS-RE/RE-UE4SS/pull/507))
+
 ### BPModLoader
 
 ### Experimental
@@ -90,6 +93,8 @@ Fixed crash when calling UFunctions that take one or more 'out' params of type T
 
 ### C++ API
 Fixed a crash caused by a race condition enabled by C++ mods using `UE4SS_ENABLE_IMGUI` in their constructor ([UE4SS #481](https://github.com/UE4SS-RE/RE-UE4SS/pull/481))
+
+Fixed the `std::span` returned by `FileHandle::memory_map` being improperly sized. ([UE4SS #507](https://github.com/UE4SS-RE/RE-UE4SS/pull/507))
 
 ### BPModLoader
 Fixed "bad conversion" errors ([UE4SS #398](https://github.com/UE4SS-RE/RE-UE4SS/pull/398))

--- a/deps/first/File/include/File/Enums.hpp
+++ b/deps/first/File/include/File/Enums.hpp
@@ -7,6 +7,7 @@ namespace RC::File
         Writing,
         Appending,
         Reading,
+        ReadWrite,
     };
 
     enum class OverwriteExistingFile

--- a/deps/first/File/src/FileType/WinFile.cpp
+++ b/deps/first/File/src/FileType/WinFile.cpp
@@ -492,6 +492,7 @@ namespace RC::File
         {
         case OpenFor::Writing:
         case OpenFor::Appending:
+        case OpenFor::ReadWrite:
             handle_desired_access = PAGE_READWRITE;
             mapping_desired_access = FILE_MAP_WRITE;
             break;
@@ -516,8 +517,8 @@ namespace RC::File
         }
 
         MEMORY_BASIC_INFORMATION buffer{};
-        auto size = VirtualQuery(m_memory_map, &buffer, sizeof(decltype(buffer)));
-        return std::span(m_memory_map, size);
+        VirtualQuery(m_memory_map, &buffer, sizeof(decltype(buffer)));
+        return std::span(m_memory_map, buffer.RegionSize);
     }
 
     auto WinFile::open_file(const std::filesystem::path& file_name_and_path, const OpenProperties& open_properties) -> WinFile
@@ -542,6 +543,9 @@ namespace RC::File
             break;
         case OpenFor::Reading:
             desired_access = GENERIC_READ;
+            break;
+        case OpenFor::ReadWrite:
+            desired_access = GENERIC_READ | GENERIC_WRITE;
             break;
         default:
             THROW_INTERNAL_FILE_ERROR("[WinFile::open_file] Tried to open file but received invalid data for the 'OpenFor' parameter.")


### PR DESCRIPTION
**Description**

This fixes a problem with FileHandle::memory_map where it was impossible to successfully memory map a file if it was opened using File::open with any value other than OpenFor::Reading.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

By creating a file (with `File::open`), and then calling `memory_map` on it.

**Checklist**

- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.