### PR TITLE
feat: build caching

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -41,6 +41,16 @@ jobs:
         with:
           xmake-version: latest
 
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .xmake
+            Binaries
+            Intermediates
+            C:/Users/runneradmin/AppData/Local/.xmake
+          key: ${{ runner.os }}-xmake-${{ hashFiles('**/xmake.lua') }}
+
       - name: Build
         run: |
           xmake f -m "Game__Shipping__Win64" -y

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,16 @@ jobs:
         run: python build.py release_commit ${{ github.actor }}
         working-directory: ./tools/buildscripts
 
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .xmake
+            Binaries
+            Intermediates
+            C:/Users/runneradmin/AppData/Local/.xmake
+          key: ${{ runner.os }}-xmake-${{ hashFiles('**/xmake.lua') }}
+
       - name: Build
         run: |
           xmake f -m "Game__Shipping__Win64" -y


### PR DESCRIPTION
**Description**

Adds github action caching to the release actions. Currently it only works for xmake dependency downloads, so cuts down about 30% of the build time. Could not get it to work for incremental compiling though (tried adding `--ccache=y` to build target command, and adding `build.cache` policy in `xmake.lua`).

**Type of change**

- [x] New feature (non-breaking change which adds functionality)
- [x] Other... Github action

**How Has This Been Tested?**

Ran experimental action on branch a few times to check that the caching is being done properly.

**Checklist**

N/A