### PR TITLE
fix: mappings file dump location

### DIFF
--- a/UE4SS/src/USMapGenerator/Generator.cpp
+++ b/UE4SS/src/USMapGenerator/Generator.cpp
@@ -21,6 +21,8 @@
 #include <Unreal/UScriptStruct.hpp>
 #include <Unreal/UnrealVersion.hpp>
 
+#include "UE4SSProgram.hpp"
+
 namespace RC::OutTheShade
 {
     using namespace ::RC::Unreal;
@@ -504,7 +506,8 @@ namespace RC::OutTheShade
         UsmapData.resize(UncompressedStream.size());
         memcpy(UsmapData.data(), UncompressedStream.data(), UsmapData.size());
 
-        auto FileOutput = FileWriter("Mappings.usmap");
+        auto filename = to_string(UE4SSProgram::get_program().get_working_directory()) + "//Mappings.usmap";
+        auto FileOutput = FileWriter(filename.c_str());
 
         FileOutput.Write<uint16_t>(0x30C4); // magic
         FileOutput.Write<uint8_t>(0);       // version

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -2,6 +2,11 @@ v3.1.0
 ==============
 TBD
 
+some notes about most important changes such as:
+- changing of default ue4ss install location, overriding and its backwards compatibility
+- new build system
+- linux port
+
 ## New
 Added support for UE Version 5.4 - ([UE4SS #503](https://github.com/UE4SS-RE/RE-UE4SS/pull/503))
 
@@ -39,7 +44,7 @@ This can be used when calling `FileHandle::memory_map`, unlike `OpenFor::Writing
 ## Changes
 
 ### General
-Changed the default location of the UE4SS release assets to be in `game executable directory/ue4ss/`. ([UE4SS #506](https://github.com/UE4SS-RE/RE-UE4SS/pull/506)) - Buckminsterfullerene
+Changed the default location of the UE4SS release assets to be in `game executable directory/ue4ss/`. This change is backwards compatible with the old location. ([UE4SS #506](https://github.com/UE4SS-RE/RE-UE4SS/pull/506)) - Buckminsterfullerene
 
 ### Live View
 Fixed the majority of the lag ([UE4SS #512](https://github.com/UE4SS-RE/RE-UE4SS/pull/512))


### PR DESCRIPTION
**Description**

mappings file now dumps to working dir instead of root dir

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Ran mappings dumper with working dir both in root dir and in root/ue4ss folder

**Checklist**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
- [x] Any dependent changes have been merged and published in downstream modules.
