### PR TITLE
Update ImGui ini location; make os window position and size persistent across runs

### DIFF
--- a/UE4SS/include/GUI/GLFW3_OpenGL3.hpp
+++ b/UE4SS/include/GUI/GLFW3_OpenGL3.hpp
@@ -25,6 +25,7 @@ namespace RC::GUI
         auto handle_window_resize(int64_t param_1, int64_t param_2) -> void override;
         auto on_os_backend_set() -> void override;
         auto get_window_size() -> WindowSize override;
+        auto get_window_position() -> WindowPosition override;
         auto exit_requested() -> bool override;
     };
 } // namespace RC::GUI

--- a/UE4SS/include/GUI/GUI.hpp
+++ b/UE4SS/include/GUI/GUI.hpp
@@ -29,14 +29,14 @@ namespace RC::GUI
 
     struct WindowSize
     {
-        long x;
-        long y;
+        int32_t x;
+        int32_t y;
     };
 
     struct WindowPosition
     {
-        long x;
-        long y;
+        int32_t x;
+        int32_t y;
     };
 
     class GfxBackendBase
@@ -101,7 +101,7 @@ namespace RC::GUI
       public:
         virtual auto init() -> void = 0;
         virtual auto imgui_backend_newframe() -> void = 0;
-        virtual auto create_window(int Loc_X = 100, int Loc_Y = 100, int Size_X = 1280, int Size_Y = 800) -> void = 0;
+        virtual auto create_window(int loc_x = 100, int loc_y = 100, int size_x = 1280, int size_y = 800) -> void = 0;
         virtual auto exec_message_loop(bool* exit_requested) -> void = 0;
         virtual auto shutdown() -> void = 0;
         virtual auto cleanup() -> void = 0;
@@ -127,7 +127,7 @@ namespace RC::GUI
         inline auto imgui_backend_newframe() -> void override
         {
         }
-        inline auto create_window(int Loc_X, int Loc_Y, int Size_X, int Size_Y) -> void override
+        inline auto create_window(int loc_x, int loc_y, int size_x, int size_y) -> void override
         {
         }
         inline auto exec_message_loop([[maybe_unused]] bool* exit_requested) -> void override
@@ -200,13 +200,11 @@ namespace RC::GUI
 
         struct WindowSettings
         {
-            int Pos_X = 100;
-            int Pos_Y = 100;
-            int Size_X = 1280;
-            int Size_Y = 800;
+            int pos_x = 100;
+            int pos_y = 100;
+            int size_x = 1280;
+            int size_y = 800;
         };
-
-        WindowSettings backend_window_settings;
 
       private:
         std::unique_ptr<GfxBackendBase> m_gfx_backend{};
@@ -219,6 +217,7 @@ namespace RC::GUI
         std::vector<std::shared_ptr<GUITab>> m_tabs;
         std::mutex m_tabs_mutex;
         std::string m_imgui_ini_file{};
+        WindowSettings m_backend_window_settings;
 
       public:
         bool m_event_thread_busy{};
@@ -253,8 +252,9 @@ namespace RC::GUI
         auto on_update() -> void;
         auto main_loop_internal() -> void;
 
+      private:
         // TODO: Move ImGui data saves to their own object
-        std::chrono::time_point<std::chrono::steady_clock> ImGui_Last_Save = std::chrono::steady_clock::now();
+        std::chrono::time_point<std::chrono::steady_clock> m_imgui_last_save = std::chrono::steady_clock::now();
         static auto ImGuiUE4SSData_ShouldSave() -> bool;
         static auto ImGuiUE4SSData_ReadOpen(ImGuiContext*, ImGuiSettingsHandler*, const char* name) -> void*;
         static auto ImGuiUE4SSData_ReadLine(ImGuiContext*, ImGuiSettingsHandler*, void* entry, const char* line) -> void;

--- a/UE4SS/include/GUI/GUI.hpp
+++ b/UE4SS/include/GUI/GUI.hpp
@@ -255,10 +255,10 @@ namespace RC::GUI
       private:
         // TODO: Move ImGui data saves to their own object
         std::chrono::time_point<std::chrono::steady_clock> m_imgui_last_save = std::chrono::steady_clock::now();
-        static auto ImGuiUE4SSData_ShouldSave() -> bool;
-        static auto ImGuiUE4SSData_ReadOpen(ImGuiContext*, ImGuiSettingsHandler*, const char* name) -> void*;
-        static auto ImGuiUE4SSData_ReadLine(ImGuiContext*, ImGuiSettingsHandler*, void* entry, const char* line) -> void;
-        static auto ImGuiUE4SSData_WriteAll(ImGuiContext* ctx, ImGuiSettingsHandler* handler, ImGuiTextBuffer* buf) -> void;
+        static auto imgui_ue4ss_data_should_save() -> bool;
+        static auto imgui_ue4ss_data_read_open(ImGuiContext*, ImGuiSettingsHandler*, const char* name) -> void*;
+        static auto imgui_ue4ss_data_read_line(ImGuiContext*, ImGuiSettingsHandler*, void* entry, const char* line) -> void;
+        static auto imgui_ue4ss_data_write_all(ImGuiContext* ctx, ImGuiSettingsHandler* handler, ImGuiTextBuffer* buf) -> void;
 
       public:
         static auto execute_at_end_of_frame(EndOfFrameCallback callback) -> void;

--- a/UE4SS/include/GUI/GUI.hpp
+++ b/UE4SS/include/GUI/GUI.hpp
@@ -198,7 +198,7 @@ namespace RC::GUI
       public:
         using EndOfFrameCallback = std::function<void()>;
 
-        struct window_settings
+        struct WindowSettings
         {
             int Pos_X = 100;
             int Pos_Y = 100;
@@ -206,7 +206,7 @@ namespace RC::GUI
             int Size_Y = 800;
         };
 
-        window_settings backend_window_settings;
+        WindowSettings backend_window_settings;
 
       private:
         std::unique_ptr<GfxBackendBase> m_gfx_backend{};
@@ -218,6 +218,7 @@ namespace RC::GUI
         bool m_exit_requested{};
         std::vector<std::shared_ptr<GUITab>> m_tabs;
         std::mutex m_tabs_mutex;
+        std::string m_imgui_ini_file{};
 
       public:
         bool m_event_thread_busy{};

--- a/UE4SS/include/GUI/Windows.hpp
+++ b/UE4SS/include/GUI/Windows.hpp
@@ -12,12 +12,13 @@ namespace RC::GUI
       public:
         auto init() -> void override;
         auto imgui_backend_newframe() -> void override;
-        auto create_window() -> void override;
+        auto create_window(int Loc_X, int Loc_Y, int Size_X, int Size_Y) -> void override;
         auto exec_message_loop(bool* exit_requested) -> void override;
         auto shutdown() -> void override;
         auto cleanup() -> void override;
         auto get_window_handle() -> void* override;
         auto get_window_size() -> WindowSize override;
+        auto get_window_position() -> WindowPosition override;
         auto on_gfx_backend_set() -> void override;
     };
 } // namespace RC::GUI

--- a/UE4SS/include/GUI/Windows.hpp
+++ b/UE4SS/include/GUI/Windows.hpp
@@ -12,7 +12,7 @@ namespace RC::GUI
       public:
         auto init() -> void override;
         auto imgui_backend_newframe() -> void override;
-        auto create_window(int Loc_X, int Loc_Y, int Size_X, int Size_Y) -> void override;
+        auto create_window(int loc_x, int loc_y, int size_x, int size_y) -> void override;
         auto exec_message_loop(bool* exit_requested) -> void override;
         auto shutdown() -> void override;
         auto cleanup() -> void override;

--- a/UE4SS/src/GUI/GLFW3_OpenGL3.cpp
+++ b/UE4SS/src/GUI/GLFW3_OpenGL3.cpp
@@ -113,6 +113,14 @@ namespace RC::GUI
         return {w + left + right, h + top + bottom};
     }
 
+    auto Backend_GLFW3_OpenGL3::get_window_position() -> WindowPosition
+    {
+        int left, top, right, bottom;
+        glfwGetWindowFrameSize(m_window, &left, &top, &right, &bottom);
+
+        return {left, top};
+    }
+
     auto Backend_GLFW3_OpenGL3::exit_requested() -> bool
     {
         return glfwWindowShouldClose(m_window);

--- a/UE4SS/src/GUI/GUI.cpp
+++ b/UE4SS/src/GUI/GUI.cpp
@@ -63,7 +63,7 @@ namespace RC::GUI
         {
             if (ImGuiUE4SSData_ShouldSave())
             {
-                ImGui::SaveIniSettingsToDisk(to_string(StringType{UE4SSProgram::get_program().get_working_directory()} + STR("\\imgui.ini")).c_str());
+                ImGui::SaveIniSettingsToDisk(m_imgui_ini_file.c_str());
             }
             
             ImGui::SetNextWindowPos({0, 0});
@@ -381,7 +381,7 @@ namespace RC::GUI
             return false;
         }
         
-        window_settings& settings = debugging_gui.backend_window_settings;
+        WindowSettings& settings = debugging_gui.backend_window_settings;
         
         auto const current_window_size = debugging_gui.m_os_backend->is_valid() ? debugging_gui.m_os_backend->get_window_size() : debugging_gui.m_gfx_backend->get_window_size();
         if (current_window_size.x != settings.Size_X || current_window_size.y != settings.Size_Y)
@@ -415,7 +415,7 @@ namespace RC::GUI
         auto& debugging_gui = UE4SSProgram::get_program().get_debugging_ui();
         
         // Read settings for backend window size/position
-        window_settings& settings = debugging_gui.backend_window_settings;
+        WindowSettings& settings = debugging_gui.backend_window_settings;
         if (std::string((const char*)entry) == "Backend_Window")
         {
             int x, y;
@@ -458,7 +458,8 @@ namespace RC::GUI
         IMGUI_CHECKVERSION();
         ImGui::CreateContext();
         ImGuiIO& io = ImGui::GetIO();
-        io.IniFilename = to_string(StringType{UE4SSProgram::get_program().get_working_directory()} + STR("\\imgui.ini")).c_str();
+        m_imgui_ini_file = to_string(StringType{UE4SSProgram::get_program().get_working_directory()} + STR("\\imgui.ini"));
+        io.IniFilename = m_imgui_ini_file.c_str();
 
         // Add .ini handle for UserData type
         ImGuiSettingsHandler ini_handler;
@@ -469,10 +470,10 @@ namespace RC::GUI
         ini_handler.WriteAllFn = ImGuiUE4SSData_WriteAll;
         ImGui::AddSettingsHandler(&ini_handler);
         
-        ImGui::LoadIniSettingsFromDisk(to_string(StringType{UE4SSProgram::get_program().get_working_directory()} + STR("\\imgui.ini")).c_str());
+        ImGui::LoadIniSettingsFromDisk(m_imgui_ini_file.c_str());
 
         auto& debugging_gui = UE4SSProgram::get_program().get_debugging_ui();
-        window_settings& settings = debugging_gui.backend_window_settings;
+        WindowSettings& settings = debugging_gui.backend_window_settings;
 
         m_os_backend->create_window(settings.Pos_X, settings.Pos_Y, settings.Size_X, settings.Size_Y);
 

--- a/UE4SS/src/GUI/GUI.cpp
+++ b/UE4SS/src/GUI/GUI.cpp
@@ -375,29 +375,29 @@ namespace RC::GUI
         auto& debugging_gui = UE4SSProgram::get_program().get_debugging_ui();
 
         auto now = std::chrono::steady_clock::now();
-        auto duration = std::chrono::duration_cast<std::chrono::seconds>(now - debugging_gui.ImGui_Last_Save).count();
+        auto duration = std::chrono::duration_cast<std::chrono::seconds>(now - debugging_gui.m_imgui_last_save).count();
         if (duration <= 5)
         {
             return false;
         }
         
-        WindowSettings& settings = debugging_gui.backend_window_settings;
+        auto& settings = debugging_gui.m_backend_window_settings;
         
         auto const current_window_size = debugging_gui.m_os_backend->is_valid() ? debugging_gui.m_os_backend->get_window_size() : debugging_gui.m_gfx_backend->get_window_size();
-        if (current_window_size.x != settings.Size_X || current_window_size.y != settings.Size_Y)
+        if (current_window_size.x != settings.size_x || current_window_size.y != settings.size_y)
         {
-            settings.Size_X = current_window_size.x;
-            settings.Size_Y = current_window_size.y;
-            debugging_gui.ImGui_Last_Save = now;
+            settings.size_x = current_window_size.x;
+            settings.size_y = current_window_size.y;
+            debugging_gui.m_imgui_last_save = now;
             return true;
         }
 
         auto const current_window_position = debugging_gui.m_os_backend->is_valid() ? debugging_gui.m_os_backend->get_window_position() : debugging_gui.m_gfx_backend->get_window_position();
-        if (current_window_position.x != settings.Pos_X || current_window_position.y != settings.Pos_Y)
+        if (current_window_position.x != settings.pos_x || current_window_position.y != settings.pos_y)
         {
-            settings.Pos_X = current_window_position.x;
-            settings.Pos_Y = current_window_position.y;
-            debugging_gui.ImGui_Last_Save = now;
+            settings.pos_x = current_window_position.x;
+            settings.pos_y = current_window_position.y;
+            debugging_gui.m_imgui_last_save = now;
             return true;
         }
         
@@ -415,12 +415,12 @@ namespace RC::GUI
         auto& debugging_gui = UE4SSProgram::get_program().get_debugging_ui();
         
         // Read settings for backend window size/position
-        WindowSettings& settings = debugging_gui.backend_window_settings;
+        WindowSettings& settings = debugging_gui.m_backend_window_settings;
         if (std::string((const char*)entry) == "Backend_Window")
         {
             int x, y;
-            if (sscanf_s(line, "Pos=%i,%i", &x, &y) == 2)         { settings.Pos_X = x; settings.Pos_Y = y; }
-            else if (sscanf_s(line, "Size=%i,%i", &x, &y) == 2)   { settings.Size_X = x; settings.Size_Y = y; }
+            if (sscanf_s(line, "Pos=%i,%i", &x, &y) == 2)         { settings.pos_x = x; settings.pos_y = y; }
+            else if (sscanf_s(line, "Size=%i,%i", &x, &y) == 2)   { settings.size_x = x; settings.size_y = y; }
         }
         
     }
@@ -473,9 +473,9 @@ namespace RC::GUI
         ImGui::LoadIniSettingsFromDisk(m_imgui_ini_file.c_str());
 
         auto& debugging_gui = UE4SSProgram::get_program().get_debugging_ui();
-        WindowSettings& settings = debugging_gui.backend_window_settings;
+        WindowSettings& settings = debugging_gui.m_backend_window_settings;
 
-        m_os_backend->create_window(settings.Pos_X, settings.Pos_Y, settings.Size_X, settings.Size_Y);
+        m_os_backend->create_window(settings.pos_x, settings.pos_y, settings.size_x, settings.size_y);
 
         gui_setup_style();
         io.Fonts->Clear();

--- a/UE4SS/src/GUI/GUI.cpp
+++ b/UE4SS/src/GUI/GUI.cpp
@@ -61,7 +61,7 @@ namespace RC::GUI
 
         if (show_window)
         {
-            if (ImGuiUE4SSData_ShouldSave())
+            if (imgui_ue4ss_data_should_save())
             {
                 ImGui::SaveIniSettingsToDisk(m_imgui_ini_file.c_str());
             }
@@ -370,7 +370,7 @@ namespace RC::GUI
         s_end_of_frame_callbacks.emplace_back(callback);
     }
 
-    auto DebuggingGUI::ImGuiUE4SSData_ShouldSave() -> bool
+    auto DebuggingGUI::imgui_ue4ss_data_should_save() -> bool
     {
         auto& debugging_gui = UE4SSProgram::get_program().get_debugging_ui();
 
@@ -404,13 +404,13 @@ namespace RC::GUI
         return false;
     }
 
-    auto DebuggingGUI::ImGuiUE4SSData_ReadOpen(ImGuiContext*, ImGuiSettingsHandler*, const char* name) -> void*
+    auto DebuggingGUI::imgui_ue4ss_data_read_open(ImGuiContext*, ImGuiSettingsHandler*, const char* name) -> void*
     {
         // UE4SS ImGui Settings
         return (void*)name;
     }
 
-    auto DebuggingGUI::ImGuiUE4SSData_ReadLine(ImGuiContext*, ImGuiSettingsHandler*, void* entry, const char* line) -> void
+    auto DebuggingGUI::imgui_ue4ss_data_read_line(ImGuiContext*, ImGuiSettingsHandler*, void* entry, const char* line) -> void
     {
         auto& debugging_gui = UE4SSProgram::get_program().get_debugging_ui();
         
@@ -425,7 +425,7 @@ namespace RC::GUI
         
     }
 
-    auto DebuggingGUI::ImGuiUE4SSData_WriteAll(ImGuiContext* ctx, ImGuiSettingsHandler* handler, ImGuiTextBuffer* buf) -> void
+    auto DebuggingGUI::imgui_ue4ss_data_write_all(ImGuiContext* ctx, ImGuiSettingsHandler* handler, ImGuiTextBuffer* buf) -> void
     {
         /*ImGuiContext& g = *ctx;*/
         auto& debugging_gui = UE4SSProgram::get_program().get_debugging_ui();
@@ -465,9 +465,9 @@ namespace RC::GUI
         ImGuiSettingsHandler ini_handler;
         ini_handler.TypeName = "UE4SSData";
         ini_handler.TypeHash = ImHashStr("UE4SSData");
-        ini_handler.ReadOpenFn = ImGuiUE4SSData_ReadOpen;
-        ini_handler.ReadLineFn = ImGuiUE4SSData_ReadLine;
-        ini_handler.WriteAllFn = ImGuiUE4SSData_WriteAll;
+        ini_handler.ReadOpenFn = imgui_ue4ss_data_read_open;
+        ini_handler.ReadLineFn = imgui_ue4ss_data_read_line;
+        ini_handler.WriteAllFn = imgui_ue4ss_data_write_all;
         ImGui::AddSettingsHandler(&ini_handler);
         
         ImGui::LoadIniSettingsFromDisk(m_imgui_ini_file.c_str());

--- a/UE4SS/src/GUI/GUI.cpp
+++ b/UE4SS/src/GUI/GUI.cpp
@@ -438,8 +438,8 @@ namespace RC::GUI
         buf->reserve(buf->size() + 15 * 6); // ballpark reserve
         const char* backend_window_settings_name = "Backend_Window";
         buf->appendf("[%s][%s]\n", handler->TypeName, backend_window_settings_name);
-        buf->appendf("Pos=%d,%d\n", (int)current_window_position.x, (int)current_window_position.y);
-        buf->appendf("Size=%d,%d\n", (int)current_window_size.x, (int)current_window_size.y);
+        buf->appendf("Pos=%d,%d\n", static_cast<int>(current_window_position.x), static_cast<int>(current_window_position.y));
+        buf->appendf("Size=%d,%d\n", static_cast<int>(current_window_size.x), static_cast<int>(current_window_size.y));
         buf->append("\n");
 
         // Add any additional ImGui UE4SS settings here

--- a/UE4SS/src/GUI/Windows.cpp
+++ b/UE4SS/src/GUI/Windows.cpp
@@ -34,7 +34,7 @@ namespace RC::GUI
         ImGui_ImplWin32_NewFrame();
     }
 
-    auto Backend_Windows::create_window() -> void
+    auto Backend_Windows::create_window(int Loc_X, int Loc_Y, int Size_X, int Size_Y) -> void
     {
         StringType title_bar_text{STR("UE4SS Debugging Tools")};
         if (dynamic_cast<Backend_DX11*>(m_gfx_backend))
@@ -58,7 +58,7 @@ namespace RC::GUI
         s_wc.lpszClassName = title_bar_text.c_str();
         s_wc.hIconSm = NULL;
         ::RegisterClassEx(&s_wc);
-        s_hwnd = ::CreateWindow(s_wc.lpszClassName, title_bar_text.c_str(), WS_OVERLAPPEDWINDOW, 100, 100, 1280, 800, NULL, NULL, s_wc.hInstance, NULL);
+        s_hwnd = ::CreateWindow(s_wc.lpszClassName, title_bar_text.c_str(), WS_OVERLAPPEDWINDOW, Loc_X, Loc_Y, Size_X, Size_Y, NULL, NULL, s_wc.hInstance, NULL);
 
         if (!m_gfx_backend->create_device())
         {
@@ -106,6 +106,13 @@ namespace RC::GUI
         RECT current_window_rect{};
         GetWindowRect(s_hwnd, &current_window_rect);
         return {current_window_rect.right - current_window_rect.left, current_window_rect.bottom - current_window_rect.top};
+    }
+
+    auto Backend_Windows::get_window_position() -> WindowPosition
+    {
+        RECT current_window_rect{};
+        GetWindowRect(s_hwnd, &current_window_rect);
+        return {current_window_rect.left, current_window_rect.top};
     }
 
     auto Backend_Windows::on_gfx_backend_set() -> void

--- a/UE4SS/src/GUI/Windows.cpp
+++ b/UE4SS/src/GUI/Windows.cpp
@@ -34,7 +34,7 @@ namespace RC::GUI
         ImGui_ImplWin32_NewFrame();
     }
 
-    auto Backend_Windows::create_window(int Loc_X, int Loc_Y, int Size_X, int Size_Y) -> void
+    auto Backend_Windows::create_window(int loc_x, int loc_y, int size_x, int size_y) -> void
     {
         StringType title_bar_text{STR("UE4SS Debugging Tools")};
         if (dynamic_cast<Backend_DX11*>(m_gfx_backend))
@@ -58,7 +58,7 @@ namespace RC::GUI
         s_wc.lpszClassName = title_bar_text.c_str();
         s_wc.hIconSm = NULL;
         ::RegisterClassEx(&s_wc);
-        s_hwnd = ::CreateWindow(s_wc.lpszClassName, title_bar_text.c_str(), WS_OVERLAPPEDWINDOW, Loc_X, Loc_Y, Size_X, Size_Y, NULL, NULL, s_wc.hInstance, NULL);
+        s_hwnd = ::CreateWindow(s_wc.lpszClassName, title_bar_text.c_str(), WS_OVERLAPPEDWINDOW, loc_x, loc_y, size_x, size_y, NULL, NULL, s_wc.hInstance, NULL);
 
         if (!m_gfx_backend->create_device())
         {
@@ -105,14 +105,14 @@ namespace RC::GUI
     {
         RECT current_window_rect{};
         GetWindowRect(s_hwnd, &current_window_rect);
-        return {current_window_rect.right - current_window_rect.left, current_window_rect.bottom - current_window_rect.top};
+        return {static_cast<int32_t>(current_window_rect.right - current_window_rect.left), static_cast<int32_t>(current_window_rect.bottom - current_window_rect.top)};
     }
 
     auto Backend_Windows::get_window_position() -> WindowPosition
     {
         RECT current_window_rect{};
         GetWindowRect(s_hwnd, &current_window_rect);
-        return {current_window_rect.left, current_window_rect.top};
+        return {static_cast<int32_t>(current_window_rect.left), static_cast<int32_t>(current_window_rect.top)};
     }
 
     auto Backend_Windows::on_gfx_backend_set() -> void


### PR DESCRIPTION
Add imgui userdata for backend window intended to scale into use for injected window as well

Needs to be changed to save less often. Either on exit or if moved and every 5 seconds or similar prior to merging.