### PR TITLE
fix(WinFile): File invalidation didn't take into account memory maps

### DIFF
--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -109,6 +109,8 @@ Fixed a crash caused by a race condition enabled by C++ mods using `UE4SS_ENABLE
 
 Fixed the `std::span` returned by `FileHandle::memory_map` being improperly sized. ([UE4SS #507](https://github.com/UE4SS-RE/RE-UE4SS/pull/507))
 
+Fixed 'File::Handle' unable to be moved if used in conjunction with memory_map. ([UE4SS #544](https://github.com/UE4SS-RE/RE-UE4SS/pull/544))
+
 ### BPModLoader
 Fixed "bad conversion" errors ([UE4SS #398](https://github.com/UE4SS-RE/RE-UE4SS/pull/398))
 

--- a/deps/first/File/src/FileType/WinFile.cpp
+++ b/deps/first/File/src/FileType/WinFile.cpp
@@ -20,6 +20,8 @@ namespace RC::File
     auto WinFile::invalidate_file() noexcept -> void
     {
         m_file = nullptr;
+        m_map_handle = nullptr;
+        m_memory_map = nullptr;
     }
 
     auto WinFile::delete_file(const std::filesystem::path& file_path_and_name) -> void


### PR DESCRIPTION
**Description**

This made the move constructor useless if you memory mapped something because the destructor would always try to unmap which meant the map is no longer valid which meant it was impossible to pass around a memory map.

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Checklist**

Please delete options that are not relevant. Update the list as the PR progresses.

- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
