### PR TITLE
chore: remove Windows.h from CrashDumper

### DIFF
--- a/UE4SS/include/CrashDumper.hpp
+++ b/UE4SS/include/CrashDumper.hpp
@@ -2,7 +2,10 @@
 
 #include <memory>
 
-#include <polyhook2/PE/IatHook.hpp>
+namespace PLH
+{
+    class IatHook;
+}
 
 namespace RC
 {

--- a/UE4SS/src/CrashDumper.cpp
+++ b/UE4SS/src/CrashDumper.cpp
@@ -6,9 +6,9 @@
 #include <bit>
 
 #include <UE4SSProgram.hpp>
+#include <Unreal/Core/Windows/WindowsHWrapper.hpp>
 
-#define NOMINMAX
-#include <Windows.h>
+#include <polyhook2/PE/IatHook.hpp>
 #include <dbghelp.h>
 
 namespace fs = std::filesystem;
@@ -19,7 +19,8 @@ using std::chrono::time_point_cast;
 
 namespace RC
 {
-    const int DumpType = MiniDumpNormal | MiniDumpWithThreadInfo | MiniDumpWithIndirectlyReferencedMemory | MiniDumpWithModuleHeaders | MiniDumpWithAvxXStateContext;
+    const int DumpType =
+            MiniDumpNormal | MiniDumpWithThreadInfo | MiniDumpWithIndirectlyReferencedMemory | MiniDumpWithModuleHeaders | MiniDumpWithAvxXStateContext;
 
     static bool FullMemoryDump = false;
 

--- a/UE4SS/src/UE4SSProgram.cpp
+++ b/UE4SS/src/UE4SSProgram.cpp
@@ -55,6 +55,8 @@
 #include <Unreal/World.hpp>
 #include <UnrealDef.hpp>
 
+#include <polyhook2/PE/IatHook.hpp>
+
 namespace RC
 {
     // Commented out because this system (turn off hotkeys when in-game console is open) it doesn't work properly.
@@ -382,7 +384,7 @@ namespace RC
         std::filesystem::path game_exe_path = exe_path_buffer;
         std::filesystem::path game_directory_path = game_exe_path.parent_path();
         m_legacy_root_directory = game_directory_path;
-        
+
         m_working_directory = m_root_directory;
         m_mods_directory = m_working_directory / "Mods";
         m_game_executable_directory = game_directory_path;


### PR DESCRIPTION
**Description**

Cleanup CrashDumper to not include Windows.h and not use polyhook in headers.

**Type of change**

- [x] Other... Please describe: header cleanup

**How Has This Been Tested?**

Compiling the project after the change.
