### PR TITLE
fix: crash dumps are sent to working directory

### DIFF
--- a/UE4SS/src/CrashDumper.cpp
+++ b/UE4SS/src/CrashDumper.cpp
@@ -3,8 +3,9 @@
 #include <chrono>
 #include <string>
 #include <format>
-#include <filesystem>
 #include <bit>
+
+#include <UE4SSProgram.hpp>
 
 #define NOMINMAX
 #include <Windows.h>
@@ -25,7 +26,7 @@ namespace RC
     LONG WINAPI ExceptionHandler(_EXCEPTION_POINTERS* exception_pointers)
     {
         const auto now = time_point_cast<seconds>(system_clock::now());
-        const std::wstring dump_path = (fs::current_path() / std::format("crash_{:%Y_%m_%d_%H_%M_%S}.dmp", now)).wstring();
+        const std::wstring dump_path = std::format(L"{}\\crash_{:%Y_%m_%d_%H_%M_%S}.dmp", StringType{UE4SSProgram::get_program().get_working_directory()}, now);
 
         const HANDLE file = CreateFileW(dump_path.c_str(), GENERIC_WRITE, FILE_SHARE_WRITE, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
 


### PR DESCRIPTION
**Description**

Fixes yet another missed case with #506 

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

It hasn't, I need someone to test it by forcecrashing the game to make it generate a dump report. Idk how to crash it to generate dmp report, I thought maybe something like dereferencing a null pointer might work but that just crashes with no report.