### PR TITLE
Add xmake ci --dump command

### DIFF
--- a/tools/xmakescripts/plugins/ci/dump/modes.lua
+++ b/tools/xmakescripts/plugins/ci/dump/modes.lua
@@ -1,0 +1,11 @@
+import("core.project.project")
+import("core.base.json")
+
+function main()
+    local modes = {}
+    for _, mode in pairs(project.modes()) do
+        table.append(modes, mode)
+    end
+    local jsonString = json.encode(modes)
+    io.write(jsonString)
+end

--- a/tools/xmakescripts/plugins/ci/dump/targets.lua
+++ b/tools/xmakescripts/plugins/ci/dump/targets.lua
@@ -1,0 +1,20 @@
+import("core.project.config")
+import("core.project.project")
+import("core.base.json")
+import("core.base.task")
+
+function main()
+    project.lock()
+    -- Check to ensure that config has been run. This will not trample the existing config if it exists.
+    task.run("config", {yes=true}, {disable_dump = true})
+    project.load_targets()
+    project.unlock()
+
+    local targets = {}
+    for targetname, target in pairs(project.targets()) do
+        targets[targetname] = {target = target:targetfile(), symbol = target:symbolfile()}
+    end
+
+    local jsonString = json.encode(targets)
+    io.write(jsonString)
+end

--- a/tools/xmakescripts/plugins/ci/main.lua
+++ b/tools/xmakescripts/plugins/ci/main.lua
@@ -1,0 +1,10 @@
+import("core.base.option")
+
+function main()
+    if option.get("dump") then
+        local module_name = string.format("dump.%s", string.lower(option.get("dump")))
+        assert(import(module_name, {try = true, anonymous = true}))()
+    else
+        raise("No options provided to the xmake ci command.")
+    end
+end

--- a/tools/xmakescripts/plugins/ci/xmake.lua
+++ b/tools/xmakescripts/plugins/ci/xmake.lua
@@ -1,0 +1,13 @@
+task("ci")
+    set_category("plugins")
+    on_run("main")
+
+    set_menu {
+            usage = "xmake ci [options]",
+            description = "Pass build information to external tools.",
+            options =
+            {
+                {'d', "dump", "kv", nil, "Dump the specified information in JSON format.",
+                    values =  {"modes", "targets"} }
+            }
+        }

--- a/tools/xmakescripts/plugins/ci/xmake.lua
+++ b/tools/xmakescripts/plugins/ci/xmake.lua
@@ -1,5 +1,5 @@
 task("ci")
-    set_category("plugins")
+    set_category("plugin")
     on_run("main")
 
     set_menu {

--- a/xmake.lua
+++ b/xmake.lua
@@ -12,6 +12,9 @@ set_config("buildir", "Intermediates")
 -- /modules/rules/my_module.lua     import("rules.my_module")
 add_moduledirs("tools/xmakescripts/modules")
 
+-- Add the plugins dir to support custom xmake <command>.
+add_plugindirs("tools/xmakescripts/plugins")
+
 -- Load our rule files into the global scope.
 includes("tools/xmakescripts/rules/**.lua")
 


### PR DESCRIPTION
# Proposed new xmake commands

`xmake ci --dump=targets`
<details><summary>Expand to show result</summary>

```json
{"File":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\File\\File.pdb","target":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\File\\File.lib"},"DynamicOutput":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\DynamicOutput\\DynamicOutput.pdb","target":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\DynamicOutput\\DynamicOutput.lib"},"LuaRaw":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\LuaRaw\\LuaRaw.pdb","target":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\LuaRaw\\LuaRaw.lib"},"KismetDebuggerMod":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\KismetDebuggerMod\\KismetDebuggerMod.pdb","target":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\KismetDebuggerMod\\KismetDebuggerMod.dll"},"Unreal":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\Unreal\\Unreal.pdb","target":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\Unreal\\Unreal.lib"},"JSON":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\JSON\\JSON.pdb","target":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\JSON\\JSON.lib"},"ParserBase":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\ParserBase\\ParserBase.pdb","target":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\ParserBase\\ParserBase.lib"},"Helpers":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\Helpers\\Helpers.pdb"},"proxy":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\proxy\\dwmapi.pdb","target":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\proxy\\dwmapi.dll"},"ArgsParser":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\ArgsParser\\ArgsParser.pdb","target":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\ArgsParser\\ArgsParser.exe"},"proxy_generator":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\proxy_generator\\proxy_generator.pdb","target":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\proxy_generator\\proxy_generator.exe"},"ScopedTimer":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\ScopedTimer\\ScopedTimer.pdb"},"Function":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\Function\\Function.pdb"},"Constructs":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\Constructs\\Constructs.pdb"},"MProgram":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\MProgram\\MProgram.pdb"},"ASMHelper":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\ASMHelper\\ASMHelper.pdb","target":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\ASMHelper\\ASMHelper.lib"},"IniParser":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\IniParser\\IniParser.pdb","target":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\IniParser\\IniParser.lib"},"SinglePassSigScanner":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\SinglePassSigScanner\\SinglePassSigScanner.pdb","target":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\SinglePassSigScanner\\SinglePassSigScanner.lib"},"patternsleuth_bind":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\patternsleuth_bind\\patternsleuth_bind.pdb","target":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\patternsleuth_bind\\patternsleuth_bind.lib"},"Profiler":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\Profiler\\Profiler.pdb"},"UE4SS":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\UE4SS\\UE4SS.pdb","target":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\UE4SS\\UE4SS.dll"},"LuaMadeSimple":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\LuaMadeSimple\\LuaMadeSimple.pdb","target":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\LuaMadeSimple\\LuaMadeSimple.lib"},"glad":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\glad\\glad.pdb","target":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\glad\\glad.lib"},"Input":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\Input\\Input.pdb","target":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\Input\\Input.lib"},"UVTD":{"symbol":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\UVTD\\UVTD.pdb","target":"H:\\bito_ue4ss_staged\\Binaries\\Game__Dev__Win64\\UVTD\\UVTD.exe"}}
```
</details>

---

`xmake ci --dump=modes`

```json
["Game__Dev__Win64","Game__Debug__Win64","CasePreserving__Dev__Win64","CasePreserving__Test__Win64","CasePreserving__Debug__Win64","CasePreserving__Shipping__Win64","Game__Shipping__Win64","Game__Test__Win64"]
```

---

These are foundational commands that allow us to safely query xmake for information about the build. This will be used by CI to determine expected files and can also be used in future scripting since the output is in JSON format and easily parseable. The dump subcommand is easily extensible and future functionality can be added to the `xmake ci` command as needs change in the future.
