### PR TITLE
Bump CI xmake version to dev branch

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup xmake
         uses: xmake-io/github-action-setup-xmake@v1
         with:
-          xmake-version: latest
+          xmake-version: branch@dev
 
       - name: Cache
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup xmake
         uses: xmake-io/github-action-setup-xmake@v1
         with:
-          xmake-version: latest
+          xmake-version: branch@dev
 
       - name: Release Commit
         id: release_commit


### PR DESCRIPTION
https://github.com/xmake-io/xmake/pull/4800

Need to bump xmake to the dev branch because that's where the fix landed. GitHub runners were updated to new toolsets and this is a result of that.
