### PR TITLE
Port/strings Typedef

### DIFF
--- a/deps/first/File/include/File/Macros.hpp
+++ b/deps/first/File/include/File/Macros.hpp
@@ -1,16 +1,5 @@
 #pragma once
 
-// Set this to 1 to use ANSI (char*) instead of wide strings (wchar_t*)
-#ifndef RC_IS_ANSI
-#define RC_IS_ANSI 0
-#endif
-
-#if RC_IS_ANSI == 1
-#define STR(str) u##str
-#else
-#define STR(str) L##str
-#endif
-
 #define THROW_INTERNAL_FILE_ERROR(msg)                                                                                                                         \
     RC::File::Internal::StaticStorage::internal_error = true;                                                                                                  \
     throw std::runtime_error{msg};
@@ -23,39 +12,3 @@
 construct a Targets object and supply your own devices.") \
                 }
 //*/
-
-#include <string>
-
-namespace RC::File
-{
-#if RC_IS_ANSI == 1
-    using StringType = std::string;
-    using StringViewType = std::string_view;
-    using CharType = char;
-    using StreamType = std::ifstream;
-    using ToString = std::tostring;
-
-    constexpr auto ToString = [](auto&& numeric_value) constexpr -> decltype(auto) {
-        return std::to_string(std::forward<decltype(numeric_value)>(numeric_value));
-    };
-#else
-    using StringType = std::wstring;
-    using StringViewType = std::wstring_view;
-    using CharType = wchar_t;
-    using StreamType = std::wifstream;
-
-    constexpr auto ToString = [](auto&& numeric_value) constexpr -> decltype(auto) {
-        return std::to_wstring(std::forward<decltype(numeric_value)>(numeric_value));
-    };
-#endif
-} // namespace RC::File
-
-namespace RC
-{
-    using StringType = File::StringType;
-    using StringViewType = File::StringViewType;
-    using CharType = File::CharType;
-    using StreamType = File::StreamType;
-
-    constexpr auto ToString = File::ToString;
-} // namespace RC

--- a/deps/first/File/include/File/Macros.hpp
+++ b/deps/first/File/include/File/Macros.hpp
@@ -20,5 +20,7 @@ namespace RC::File
     using StringType = RC::StringType;
     using StringViewType = RC::StringViewType;
     using CharType = RC::CharType;
-    using StreamType = RC::StreamType;
+    using StreamIType = RC::StreamIType;
+    using StreamOType = RC::StreamOType;
+    using StreamType = StreamIType;
 } // namespace RC::File

--- a/deps/first/File/include/File/Macros.hpp
+++ b/deps/first/File/include/File/Macros.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <String/StringType.hpp>
+
 #define THROW_INTERNAL_FILE_ERROR(msg)                                                                                                                         \
     RC::File::Internal::StaticStorage::internal_error = true;                                                                                                  \
     throw std::runtime_error{msg};
@@ -12,3 +14,11 @@
 construct a Targets object and supply your own devices.") \
                 }
 //*/
+
+namespace RC::File
+{
+    using StringType = RC::StringType;
+    using StringViewType = RC::StringViewType;
+    using CharType = RC::CharType;
+    using StreamType = RC::StreamType;
+} // namespace RC::File

--- a/deps/first/File/src/FileType/WinFile.cpp
+++ b/deps/first/File/src/FileType/WinFile.cpp
@@ -455,7 +455,7 @@ namespace RC::File
 
     auto WinFile::read_all() const -> StringType
     {
-        StreamType stream{get_file_path(), std::ios::in | std::ios::binary};
+        StreamIType stream{get_file_path(), std::ios::in | std::ios::binary};
         if (!stream)
         {
             THROW_INTERNAL_FILE_ERROR(fmt::format("[WinFile::read_all] Tried to read entire file but returned error {}", errno))
@@ -463,7 +463,7 @@ namespace RC::File
         else
         {
             // Strip the BOM if it exists
-            File::StreamType::off_type start{};
+            File::StreamIType::off_type start{};
             File::CharType bom[3]{};
             stream.read(bom, 3);
             if (bom[0] == 0xEF && bom[1] == 0xBB && bom[2] == 0xBF)

--- a/deps/first/File/xmake.lua
+++ b/deps/first/File/xmake.lua
@@ -5,6 +5,8 @@ target(projectName)
     set_languages("cxx20")
     set_exceptions("cxx")
     add_rules("ue4ss.dependency")
+    
+    add_deps("String")
 
     add_includedirs("include", { public = true }) 
     add_headerfiles("include/**.hpp")

--- a/deps/first/JSON/src/Number.cpp
+++ b/deps/first/JSON/src/Number.cpp
@@ -1,5 +1,8 @@
 #include <JSON/Number.hpp>
 
+#include <fmt/core.h>
+#include <fmt/xchar.h>
+
 namespace RC::JSON
 {
     Number::Number(uint32_t value)
@@ -46,6 +49,8 @@ namespace RC::JSON
     {
         (void)should_format;
         (void)indent_level;
+
+        #define ToString(numeric_value) fmt::format(STR("{}"), numeric_value)
 
         switch (m_stored_type)
         {

--- a/deps/first/String/include/String/StringType.hpp
+++ b/deps/first/String/include/String/StringType.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <string>
+
+// We will use this once we solve the circular dependency issue
+//#include <Unreal/Core/HAL/Platform.hpp>
+
+// This is a debug flag to force the use of u16string for testing purposes
+// char16_t and wchar_t are two different types, so we need to force the use of one of them
+// to ensure we have covered all the cases. 
+// #define FORCE_U16
+
+namespace RC {
+
+#ifdef FORCE_U16
+    using CharType = char16_t;
+    #define STR(str) u ## str
+#else
+    using CharType = wchar_t;
+    #define STR(str) L ## str
+#endif
+
+    using StringType = std::basic_string<CharType>;
+    using StringViewType = std::basic_string_view<CharType>;
+    using StreamIType = std::basic_ifstream<CharType>;
+    using StreamOType = std::basic_ofstream<CharType>;
+} // namespace RC

--- a/deps/first/String/xmake.lua
+++ b/deps/first/String/xmake.lua
@@ -1,0 +1,10 @@
+local projectName = "String"
+
+target(projectName)
+    set_kind("headeronly")
+    set_languages("cxx20")
+    set_exceptions("cxx")
+    add_rules("ue4ss.dependency")
+
+    add_includedirs("include", { public = true })
+    add_headerfiles("include/**.hpp")

--- a/deps/first/xmake.lua
+++ b/deps/first/xmake.lua
@@ -17,6 +17,7 @@ includes("Profiler")
 includes("ScopedTimer")
 includes("SinglePassSigScanner")
 includes("Unreal")
+includes("String")
 
 if is_config("patternsleuth", "local") then 
     -- The patternsleuth target is managed by the cargo.build rule.


### PR DESCRIPTION
This PR just moves `StringType` from File to String.

Right now, CharType is set to `whcar_t`, for a verification build for Linux, one can try to build when it is set to `char16_t`.

It is not intended to solve the circlular dependency in this PR but we may someday as suggested by @localcc seperate Unreal module into Unreal and UnrealDef.

Once this is sovled, CharType should be set to `TCHAR` for normal build.

I think it's safe to say TCHAR will be UTF-16 at this point, if we want to support cases that TCHAR can be say... utf8/utf32.. then might need to wrap it with `to_string` or `to_wstring` based on platform/env.. or pull back the `to_system` macro for those cases..



I have not tested this change but cherrypick it from my current working branch as suggest by @narknon to allow this part to be easily reviewed and merged. I think this should be mostly okay but please check if it compiles.. 
In theory, it should not break anything because I re-exported everything under the `RC::File::` namespace.

It is based on the `fmt` PR although it may not actaully related. It is also possible to merge this before the fmt change.

These is nothing to document at this point, although future code should avoid use `File::*` for string/char type I think.

Also, please try to avoid the use of wstring unless needed.