### PR TITLE
STL updates Mutex Fix

### DIFF
--- a/deps/third-repo/packages/p/polyhook_2/CMakeLists.txt
+++ b/deps/third-repo/packages/p/polyhook_2/CMakeLists.txt
@@ -4,6 +4,9 @@ include(FetchContent)
 
 set(FETCHCONTENT_QUIET OFF)
 
+# Add the preprocessor definition to fix mutex
+add_definitions(-D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+
 FetchContent_Declare(PolyHook2
     GIT_REPOSITORY https://github.com/stevemk14ebr/PolyHook_2_0.git
     GIT_TAG fd2a88f09c8ae89440858fc52573656141013c7f

--- a/tools/xmakescripts/rules/build_rules.lua
+++ b/tools/xmakescripts/rules/build_rules.lua
@@ -109,6 +109,9 @@ local MSVC_COMPILE_OPTIONS = {
     },
     ["shflags"] = {
         "/DEBUG:FULL"
+    },
+    ["defines"] = {
+        "_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR=1"
     }
 }
 


### PR DESCRIPTION
microsoft/STL#3824
microsoft/STL#4000
microsoft/STL#4339

Add escape hatch due to STL change resulting in issues with binary compatibility.

https://github.com/microsoft/STL/wiki/Changelog
"Fixed bugs:

    Fixed mutex's constructor to be constexpr. #3824 #4000 #4339
        Note: Programs that aren't following the documented restrictions on binary compatibility may encounter null dereferences in mutex machinery. You must follow this rule:

            When you mix binaries built by different supported versions of the toolset, the Redistributable version must be at least as new as the latest toolset used by any app component.

        You can define _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR as an escape hatch."**Description**



**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Tested on Wine where this issue originally caused hangs.

**Checklist**

- [x] I have commented my code, particularly in hard-to-understand areas.

