### PR TITLE
Lock fmt package version to 10.2.1

### DIFF
--- a/UE4SS/xmake.lua
+++ b/UE4SS/xmake.lua
@@ -6,7 +6,7 @@ add_requires("IconFontCppHeaders v1.0", { debug = is_mode_debug(), configs = {ru
 add_requires("glfw 3.3.9", { debug = is_mode_debug() , configs = {runtimes = get_mode_runtimes()}})
 add_requires("opengl", { debug = is_mode_debug(), configs = {runtimes = get_mode_runtimes()} })
 add_requires("glaze", { debug = is_mode_debug(), configs = {runtimes = get_mode_runtimes()} })
-add_requires("fmt", { debug = is_mode_debug(), configs = {runtimes = get_mode_runtimes()} })
+add_requires("fmt 10.2.1", { debug = is_mode_debug(), configs = {runtimes = get_mode_runtimes()} })
 
 option("ue4ssBetaIsStarted")
     set_default(true)


### PR DESCRIPTION
Fmt had a change that enabled unicode by default
https://github.com/fmtlib/fmt/commit/b7809f91e2cc42d3bb693e742a28815832c6cb89

xrepo followed up this change by adding v11.0 of the package to the xmake repository
https://github.com/xmake-io/xmake-repo/pull/4533

Proposing to lock the version prior to this unicode change since it causes build failures
```text
 error: TokenParser.cpp
C:\hostedtoolcache\windows\xmake-global\.xmake\packages\f\fmt\11.0.0\ef30b2773db346bbb83a54df6d28dc26\include\fmt\base.h(457): error C2338: static_assert failed: 'Unicode support requires compiling with /utf-8'
```