### PR TITLE
UHT - Fix SetupAttachment implementations randomly changing order

### DIFF
--- a/UE4SS/src/SDKGenerator/UEHeaderGenerator.cpp
+++ b/UE4SS/src/SDKGenerator/UEHeaderGenerator.cpp
@@ -814,8 +814,14 @@ namespace RC::UEGenerator
         }
         m_class_subobjects.clear();
 
+        // Sort the attachments alphabetically by the property name
+        std::vector<std::pair<FProperty*, std::tuple<std::wstring, std::wstring, bool>>> sorted_attachments(implementation_file.attachments.begin(), implementation_file.attachments.end());
+        std::sort(sorted_attachments.begin(), sorted_attachments.end(), [](const auto& a, const auto& b) {
+            return a.first->GetName() < b.first->GetName();
+        });
+        
         // Generate component attachments
-        for (auto attachment : implementation_file.attachments)
+        for (auto attachment : sorted_attachments)
         {
             if (get<2>(attachment.second) == false)
             {

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -94,6 +94,7 @@ Reduced the likelihood of a crash happening on shutdown when at least one watch 
 Fixed constantly searching even if the search field is empty, and even if not on the tab ([UE4SS #475](https://github.com/UE4SS-RE/RE-UE4SS/pull/475))
 
 ### UHT Dumper
+Fix SetupAttachment implementations randomly changing order ([UE4SS #606](https://github.com/UE4SS-RE/RE-UE4SS/pull/606)) - Buckminsterfullerene
 
 ### Lua API
 Fixed FString use after free ([UE4SS #425](https://github.com/UE4SS-RE/RE-UE4SS/pull/425)) - localcc


### PR DESCRIPTION
**Description**

`this->someproperty->SetupAttachment(someparent)` implementations in constructors randomly change order between sessions, and as a consequence, makes diffs more difficult to read (or manually fix them to not mess up the diffs). 

This PR simply sorts them by someproperty. There is no observed performance impact.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

1. Run game
2. Make dump (rename folder to not be overwritten)
3. Restart game
4. Make another dump
5. Check in winmerge that all files are identical

**Checklist**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
