### PR TITLE
fix: Mod directory being used before it's setup

### DIFF
--- a/UE4SS/src/UE4SSProgram.cpp
+++ b/UE4SS/src/UE4SSProgram.cpp
@@ -446,7 +446,14 @@ namespace RC
         }
         else
         {
-            m_mods_directory = settings_manager.Overrides.ModsFolderPath;
+            if (std::filesystem::path{settings_manager.Overrides.ModsFolderPath}.is_relative())
+            {
+                m_mods_directory = m_working_directory / settings_manager.Overrides.ModsFolderPath;
+            }
+            else
+            {
+                m_mods_directory = settings_manager.Overrides.ModsFolderPath;
+            }
         }
     }
 

--- a/UE4SS/src/UE4SSProgram.cpp
+++ b/UE4SS/src/UE4SSProgram.cpp
@@ -264,11 +264,11 @@ namespace RC
 
             Unreal::UnrealInitializer::SetupUnrealModules();
 
+            setup_mod_directory_path();
+
             setup_mods();
             install_cpp_mods();
             start_cpp_mods(IsInitialStartup::Yes);
-
-            setup_mod_directory_path();
 
             if (m_has_game_specific_config)
             {

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -86,6 +86,8 @@ Fixed a crash that would occur randomly due to accidental execution of Live View
 
 Fixed freeze related to the error "Tried to execute UFunction::FuncPtr hook but there was no function map entry" ([UE4SS #468](https://github.com/UE4SS-RE/RE-UE4SS/pull/468))
 
+Fixed `ModsFolderPath` in `UE4SS-settings.ini` not working ([UE4SS #609](https://github.com/UE4SS-RE/RE-UE4SS/pull/609))
+
 ### Live View
 Fixed the "Write to file" checkbox not working for functions in the `Watches` tab ([UE4SS #419](https://github.com/UE4SS-RE/RE-UE4SS/pull/419))
 


### PR DESCRIPTION
**Description**

This fixes `ModsFolderPath` in `UE4SS-settings.ini` being broken.

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Move `Binaries/Win64/Mods` to ~~`Binaries/Mods`~~`Content/Paks/Mods`, and set `ModsFolderPath` to `../../Content/Paks/Mods`.

**Checklist**

Please delete options that are not relevant. Update the list as the PR progresses.

- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
