### PR TITLE
fix: override.txt docs incorrectly showing example paths

### DIFF
--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -60,9 +60,9 @@ This method allows you to override the location of the `root directory` while pr
 
 In your `game executable directory` alongside the `dwmapi.dll`, create a file called `override.txt` and inside it you can write either an absolute path or a relative path to your new `UE4SS.dll`. 
 
-For an example, possible paths could be:
-- `C:\ue4ss\UE4SS.dll`
-- `..\..\..\..\..\..\UE4SS.dll`
+For example, possible paths could be:
+- `C:/ue4ss/`
+- `../../Content/Paks`
 
 ## Manual Injection
 

--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -85,7 +85,7 @@ D:\Games\Epic Games\SatisfactoryEarlyAccess\FactoryGame\Binaries\Win64\FactoryGa
 Then the name of your `working directory` should be `SatisfactoryEarlyAccess`.  
 This directory will be automatically found and used by UE4SS if it exists.
 
-As of UE4SS 3.0 (basic install), the following files & folders exist inside the `working directory`:
+The following files & folders exist inside the `working directory`:
 
 - Mods
     - Mod folders
@@ -93,7 +93,9 @@ As of UE4SS 3.0 (basic install), the following files & folders exist inside the 
 - UE4SS-settings.ini
 - UE4SS.log
 - UE4SS.dll
-- dwmapi.dll (Can have a name of any DLL that is loaded by the game engine or by its dependencies)
+- ...and some other auxiliary, optional files that are not required for UE4SS to function.
+
+While `dwmapi.dll` (can have a name of any DLL that is loaded by the game engine or by its dependencies) is in the `game executable directory`.
 
 Now all you need to do is start your game and point your injector of choice to `<root directory>/UE4SS.dll`.
 


### PR DESCRIPTION
**Description**

Docs were showing UE4SS.dll appended on example paths which is incorrect. 

**Type of change**

Please delete options that are not relevant.

- [x] Is documentation update

**How Has This Been Tested?**

Loaded relative & absolute paths in override.txt.

**Checklist**

- [x] I have made corresponding changes to the documentation.
