### PR TITLE
Add github alerts pre-processor to mdbook

### DIFF
--- a/.github/workflows/pushdocs.yml
+++ b/.github/workflows/pushdocs.yml
@@ -20,11 +20,20 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Setup mdBook Preprocessors
+        uses: cargo-bins/cargo-binstall@v1.6.8
+
       - name: Setup mdBook
         run: |
           mkdir mdbook
           curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.14/mdbook-v0.4.14-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
           echo `pwd`/mdbook >> $GITHUB_PATH
+
+      - name: Install mdBook Preprocessors
+        run: |
+          cargo binstall --no-confirm mdbook-mermaid
+          mdbook-mermaid install docs-export/
+          cargo binstall --no-confirm mdbook-alerts
 
       - name: Build
         run: |

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -15,6 +15,8 @@ UE Platform support, which allows for much easier internal implementation of new
 
 Added new installation method by allowing overriding of the location of the `UE4SS.dll`, [documentation](https://docs.ue4ss.com/installation-guide.html#overriding-install-location). - ([UE4SS #506](https://github.com/UE4SS-RE/RE-UE4SS/pull/506)) - Buckminsterfullerene 
 
+Add Github alerts pre-processor support to the documentation system ([UE4SS #611](https://github.com/UE4SS-RE/RE-UE4SS/pull/611)) - Buckminsterfullerene
+
 ### Live View 
 Added search filter: `IncludeClassNames`. ([UE4SS #472](https://github.com/UE4SS-RE/RE-UE4SS/pull/472)) - Buckminsterfullerene
 

--- a/docs-export/book.toml
+++ b/docs-export/book.toml
@@ -10,3 +10,5 @@ additional-css = ["css/custom.css"]
 [output.html.fold]
 enable = true
 level = 1
+
+[preprocessor.alerts]

--- a/docs-export/export.py
+++ b/docs-export/export.py
@@ -63,6 +63,13 @@ def export_version(ref, name):
     shutil.copy(os.path.join('docs-export', 'book.toml'), version_out_dir)
     shutil.copytree(os.path.join('docs-export', 'css'), os.path.join(version_out_dir, 'css'))
 
+    # github alerts pre-processor template files, if they are not found for whatever reason, just ignore
+    try:
+        shutil.copy(os.path.join('docs-export', 'mermaid.min.js'), version_out_dir)
+        shutil.copy(os.path.join('docs-export', 'mermaid-init.js'), version_out_dir)
+    except FileNotFoundError:
+        pass
+
     return True
 
 export_version('main', 'dev')


### PR DESCRIPTION
**Description**

Add github alerts pre-processor which allows markdown such as [!IMPORTANT] and [!WARNING] to work in mdbook. 

README in docs currently not supporting this so is a bit difficult to read.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)
- [x] Is documentation update

**How Has This Been Tested?**

Tested changes on own fork of repo.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
