### PR TITLE
PR CI: Ignore more paths that do not affect build

### DIFF
--- a/.github/workflows/ue4ss-ci.yml
+++ b/.github/workflows/ue4ss-ci.yml
@@ -11,8 +11,13 @@ on:
         - 'main'
     paths-ignore:
         - 'README.md'
+        - '.github/workflows/pushdocs.yml'
+        - '.github/pull_request_template.md'
+        - '.github/ISSUE_TEMPLATE/**'
+        - 'assets/**'
         - 'docs/**'
         - 'docs-export/**'
+        - 'docs-repo-template/**'
 
 # Ensure that rapid pushes to the pull request branch don't trigger this workflow multiple times.
 # We only care about executing this workflow for that 'latest' commit on a PR.


### PR DESCRIPTION
**Description**

We don't want to have to wait the 20 ish minutes for the PR CI to do its checks when some files that do not affect the build changes.

For example, currently, if someone were to change the `assets/Changelog.md` in a PR, it would still run all of the build checks despite nothing that affects the build changing. The same goes with all other files in paths added. 

`assets/**` is included because the PR CI only builds `UE4SS.dll` and does not produce an experimental-like zip.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

We'll see when this is merged! (change is too trivial to spend an hour setting up PR CI to work on fork for test)
