### PR TITLE
Version checking for crash dumper

### DIFF
--- a/UE4SS/include/SettingsManager.hpp
+++ b/UE4SS/include/SettingsManager.hpp
@@ -25,6 +25,7 @@ namespace RC
             bool EnableDebugKeyBindings{false};
             int64_t SecondsToScanBeforeGivingUp{30};
             bool UseUObjectArrayCache{true};
+            bool LatestVersionCheck{true};
         } General;
 
         struct SectionEngineVersionOverride

--- a/UE4SS/include/UE4SSProgram.hpp
+++ b/UE4SS/include/UE4SSProgram.hpp
@@ -221,6 +221,9 @@ namespace RC
         RC_UE4SS_API auto generate_uht_compatible_headers() -> void;
         RC_UE4SS_API auto generate_cxx_headers(const std::filesystem::path& output_dir) -> void;
         RC_UE4SS_API auto generate_lua_types(const std::filesystem::path& output_dir) -> void;
+        RC_UE4SS_API auto get_latest_version_check_setting() -> bool;
+        RC_UE4SS_API auto get_latest_ue4ss_version() -> StringType;
+        RC_UE4SS_API auto is_latest_ue4ss_version(StringType latest_ver) -> bool;
         auto get_debugging_ui() -> GUI::DebuggingGUI&
         {
             return m_debugging_gui;

--- a/UE4SS/src/CrashDumper.cpp
+++ b/UE4SS/src/CrashDumper.cpp
@@ -60,8 +60,18 @@ namespace RC
             return EXCEPTION_CONTINUE_SEARCH;
         }
 
-        const StringType message = fmt::format(STR("Crashdump written to: {}"), dump_path);
-        MessageBoxW(NULL, FromCharTypePtr<wchar_t>(message.c_str()), L"Fatal Error!", MB_OK);
+        StringType version_message = L"";
+        if (UE4SSProgram::get_program().get_latest_version_check_setting())
+        {
+            StringType latest_version = UE4SSProgram::get_program().get_latest_ue4ss_version();
+            if (!UE4SSProgram::get_program().is_latest_ue4ss_version(latest_version))
+            {
+                version_message = fmt::format(L"\n\nA newer version ({}) is available. Updating may solve your issue.", latest_version);
+            }
+        }
+
+        const StringType message = fmt::format(L"Crashdump written to: {}{}", dump_path, version_message);
+        MessageBoxW(NULL, message.c_str(), L"Fatal Error!", MB_OK);
 
         return EXCEPTION_EXECUTE_HANDLER;
     }

--- a/UE4SS/src/SettingsManager.cpp
+++ b/UE4SS/src/SettingsManager.cpp
@@ -57,6 +57,7 @@ namespace RC
         REGISTER_BOOL_SETTING(General.EnableDebugKeyBindings, section_general, EnableDebugKeyBindings)
         REGISTER_INT64_SETTING(General.SecondsToScanBeforeGivingUp, section_general, SecondsToScanBeforeGivingUp)
         REGISTER_BOOL_SETTING(General.UseUObjectArrayCache, section_general, bUseUObjectArrayCache)
+        REGISTER_BOOL_SETTING(General.LatestVersionCheck, section_general, bLatestVersionCheck)
 
         constexpr static File::CharType section_engine_version_override[] = STR("EngineVersionOverride");
         REGISTER_INT64_SETTING(EngineVersionOverride.MajorVersion, section_engine_version_override, MajorVersion)

--- a/UE4SS/xmake.lua
+++ b/UE4SS/xmake.lua
@@ -7,6 +7,7 @@ add_requires("glfw 3.3.9", { debug = is_mode_debug() , configs = {runtimes = get
 add_requires("opengl", { debug = is_mode_debug(), configs = {runtimes = get_mode_runtimes()} })
 add_requires("glaze v2.9.5", { debug = is_mode_debug(), configs = {runtimes = get_mode_runtimes()} })
 add_requires("fmt 10.2.1", { debug = is_mode_debug(), configs = {runtimes = get_mode_runtimes()} })
+add_requires("libcurl 8.7.1", { debug = is_mode_debug(), configs = {runtimes = get_mode_runtimes()} })
 
 option("ue4ssBetaIsStarted")
     set_default(true)
@@ -74,6 +75,8 @@ target(projectName)
     )
     
     add_packages("fmt", { public = true })
+
+    add_packages("libcurl", { public = true })
 
     add_packages("imgui", "ImGuiTextEdit", "IconFontCppHeaders", "glfw", "opengl", { public = true })
 

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -24,6 +24,8 @@ Added new installation method by allowing overriding of the location of the `UE4
 
 Add Github alerts pre-processor support to the documentation system ([UE4SS #611](https://github.com/UE4SS-RE/RE-UE4SS/pull/611)) - Buckminsterfullerene
 
+Add opt-out checking for the latest version of UE4SS during load or when a crash dump is created. ([UE4SS #617](https://github.com/UE4SS-RE/RE-UE4SS/pull/617)) - Buckminsterfullerene
+
 ### Live View 
 Added search filter: `IncludeClassNames`. ([UE4SS #472](https://github.com/UE4SS-RE/RE-UE4SS/pull/472)) - Buckminsterfullerene
 
@@ -179,6 +181,9 @@ Fixes mods not loading when UE4SS initializes too late ([UE4SS #454](https://git
 ; True if the game is built as Debug, Development, or Test.
 ; Default: false
 DebugBuild = 
+
+[General]
+bLatestVersionCheck = 1
 
 [Hooks]
 HookLoadMap = 1

--- a/assets/UE4SS-settings.ini
+++ b/assets/UE4SS-settings.ini
@@ -23,6 +23,11 @@ SecondsToScanBeforeGivingUp = 30
 ; Default: true
 bUseUObjectArrayCache = true
 
+; Whether to check if the user is running the latest stable version of UE4SS
+; If enabled, and user is not running latest stable version, a warning will be displayed in console and crash popup box
+; Default: 1
+bLatestVersionCheck = 1
+
 [EngineVersionOverride]
 MajorVersion = 
 MinorVersion = 


### PR DESCRIPTION
**Description**

We keep getting issues posted where the user is using an old version of UE4SS that does not work for their game. 

Yangff suggested adding information that checks for new versions when crash. 

Currently this change is adding the information in the message box that opens when it makes a crash dump, however the code is exposed in UE4SSProgram.hpp so could be used in other places such as in the logs or somewhere more obvious to the user, and it seems useful enough to add in the mod APIs in the future. 

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

Tested output of warning by temporarily flipping `if (!is_latest_ue4ss_version(latest_version))` condition. 

Checked that config works as intended.

Need to force crash dump to happen to test crash dumper part.

**Checklist**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.