### PR TITLE
Raise error or warning depending on installed rust/msvc versions

### DIFF
--- a/.github/workflows/msvc_build_ue4ss.yml
+++ b/.github/workflows/msvc_build_ue4ss.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Install VS2022 BuildTools 17.9.7
         run: choco install -y visualstudio2022buildtools --version=117.9.7.0 --params "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --installChannelUri https://aka.ms/vs/17/release/180911598_-255012421/channel"
 
+      - name: Install JQ
+        run: choco install -y jq
+
       - name: Setup xmake
         uses: xmake-io/github-action-setup-xmake@v1
         with:
@@ -85,7 +88,7 @@ jobs:
           Import-Module 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\Microsoft.VisualStudio.DevShell.dll'
           Enter-VsDevShell -VsInstallPath 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools' -DevCmdArguments '-arch=x64 -host_arch=x64'
 
-          xmake config -vD -m "${{inputs.build-mode}}" -y
+          xmake config -p windows -a x64 -vD -m "${{inputs.build-mode}}" -y
 
       - name: Save cached xmake dependencies
         if: ${{ !steps.restore-depcache.outputs.cache-hit }}
@@ -103,7 +106,7 @@ jobs:
       - name: Calculate Files For Artifact Inclusion
         id: calc-files-artifact
         run: |
-          $files_to_upload = (xmake ci --dump=targets) | jq --raw-output --argjson config '${{inputs.artifact-list}}' '. as $in | $config[] | $in[.] | .[]' 
+          $files_to_upload = (xmake ci --dump=targets) | jq --raw-input --raw-output --argjson config '${{inputs.artifact-list}}' 'fromjson? | . as $in | $config[] | $in[.] | .[]'
 
           $artifact_dir = New-Item -Path '${{runner.temp}}/ue4ss_artifacts/' -ItemType Directory -Force
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,12 @@ If you are planning on doing mod development using UE4SS, you can do the same as
 
 - A computer running Windows.
   - Linux support might happen at some point but not soon.
-- A version of MSVC that supports C++20, including std::format.
-  - Visual Studio 2019 (recent versions), and Visual Studio 2022 will work.
+- A version of MSVC that supports C++23:
+  - MSVC toolset version >= 14.39.0
+  - MSVC version >= 19.39.0
+  - Visual Studio version >= 17.9
   - More compilers will hopefully be supported in the future.
-- Rust toolchain 1.73.0 or greater
+- [Rust toolchain >= 1.73.0](https://www.rust-lang.org/tools/install)
 - [xmake >= 2.9.3](https://xmake.io/#/)
 
 ## Build instructions
@@ -112,6 +114,14 @@ By default, UE4SS generates a proxy based on `C:\Windows\System32\dwmapi.dll`. I
 
 By default, UE4SS uses Tracy for profiling. You can pass `--profilerFlavor=<profiler>` to the `xmake config` command to set the profiler flavor. The currently supported flavors are `Tracy`, `Superluminal`, and `None`.
 
+#### Version Check
+
+By default, xmake will check if you have the minimum required version of Rust or MSVC installed (if you are using the MSVC toolchain). If you do not, it will throw an error on the configure step. If you want to ignore this check, you can pass `--versionCheck=n` to the `xmake config` command.
+
+Once you set the flag, the option value be set until you specify otherwise.
+
+Therefore, to not check versions when running `xmake project -k vsxmake2022`, you must first run the `xmake config --versionCheck=n` command, then run the `xmake project -k vsxmake2022` command.
+
 ### Helpful `xmake` commands
 
 You may encounter use for the some of the more advanced `xmake` commands. A non-comprehensive list of some useful commands is included below.
@@ -147,8 +157,10 @@ Note that you should also commit & push the submodules that you've updated if th
 
 > [!WARNING]
 > The vs. build plugin performs the compile operation by directly calling the xmake command under vs, and also supports intellisense and definition jumps, as well as breakpoint debugging.
-> This means that modifying the project properties within Visual Studio will not affect which flags are passed to the build when VS executes `xmake`. XMake provides some configurable project settings
-which can be found in VS under the `Project Properties -> Configuration Properties -> Xmake` menu.
+> This means that modifying the project properties within Visual Studio will not affect which flags are passed to the build when VS executes `xmake`. XMake provides some configurable project settings which can be found in VS under the `Project Properties -> Configuration Properties -> Xmake` menu.
+
+> [!CAUTION]
+> If you have multiple Visual Studio versions installed, run `xmake f --vs=2022`, otherwise you may encounter issues with the project generation.
 
 ##### Configuring additional modes
 

--- a/UE4SS/xmake.lua
+++ b/UE4SS/xmake.lua
@@ -24,6 +24,14 @@ option("ue4ssIsBeta")
 
     set_description("Is this a beta release")
 
+option("versionCheck")
+    set_default(true)
+    set_showmenu(true)
+    -- Sets the possible options to only be true or false.
+    set_values(true, false)
+
+    set_description("Will xmake check the installed MSVC and Rust versions on configuration step")
+
 local projectName = "UE4SS"
 
 local function parse_version_string(str)
@@ -47,7 +55,8 @@ target(projectName)
     set_exceptions("cxx")
     set_default(true)
     add_rules("ue4ss.defines.exports")
-    add_options("ue4ssBetaIsStarted", "ue4ssIsBeta")
+    add_rules("ue4ss.check.minimum.version")
+    add_options("ue4ssBetaIsStarted", "ue4ssIsBeta", "allowAllVersions")
     add_includedirs("include", { public = true })
     add_includedirs("generated_include", { public = true })
     add_headerfiles("include/**.hpp")

--- a/tools/xmakescripts/rules/build_rules.lua
+++ b/tools/xmakescripts/rules/build_rules.lua
@@ -102,7 +102,7 @@ local MSVC_COMPILE_OPTIONS = {
         "/wd4068",
         "/Zc:inline",
         "/Zc:strictStrings",
-        "/Zc:preprocessor"
+        "/Zc:preprocessor"  
     },
     ["ldflags"] = {
         "/DEBUG:FULL"
@@ -274,4 +274,3 @@ rule("ue4ss.dependency")
     on_config(function(target)
         target:set("group", "deps")
     end)
-

--- a/tools/xmakescripts/rules/rust_rules.lua
+++ b/tools/xmakescripts/rules/rust_rules.lua
@@ -147,9 +147,9 @@ rule("cargo.build")
                 values = argv,
                 files = dependent_files,
                 dryrun = dryrun})  
-   end)
+    end)
 
-   before_clean(function(target)
+    before_clean(function(target)
         local is_debug = target:extraconf("rules", "cargo.build", "is_debug")
         local cargo_dir, _, cargo_mode = cargo_helpers.get_cargo_context(target, is_debug)
         local project_name = target:extraconf("rules", "cargo.build", "project_name")

--- a/tools/xmakescripts/rules/version_rules.lua
+++ b/tools/xmakescripts/rules/version_rules.lua
@@ -1,0 +1,91 @@
+local MINIMUM_MSVC_TOOLSET_VERSION = "14.39"
+local MINIMUM_RUST_VERSION = "1.73.0"
+
+local function compare_versions(ver1, ver2)
+    for i = 1, math.max(#ver1, #ver2) do
+        local num1 = ver1[i] or 0
+        local num2 = ver2[i] or 0
+        if num1 < num2 then
+            return false
+        elseif num1 > num2 then
+            return true
+        end
+    end
+    return true  -- Versions are equal
+end
+
+local function parse_version(ver)
+    local version_nums = {}
+    for num in ver:gmatch("(%d+)") do
+        table.insert(version_nums, tonumber(num))
+    end
+    return version_nums
+end
+
+rule("ue4ss.check.minimum.version")
+    add_deps("check.msvc.ver", "check.rust.ver")
+
+-- This rule checks the MSVC version number and raises an error if it is below the minimum.
+rule("check.msvc.ver")
+    on_config(function (target)
+        local msvc = target:toolchain("msvc")
+        if msvc then
+            local vctools_ver = msvc:config("vcvars").VCToolsVersion
+            local parsed_vcvars_ver = parse_version(vctools_ver)
+
+            -- Still print the version number even if we are allowing all versions
+            local version_check = get_config("versionCheck")
+            if not version_check then
+                cprint("checking for Microsoft C/C++ Compiler Toolset version ... ${color.success}%s", vctools_ver)
+                return
+            end
+            
+            local minimum_version = parse_version(MINIMUM_MSVC_TOOLSET_VERSION)
+            
+            if not compare_versions(parsed_vcvars_ver, minimum_version) then
+                cprint("checking for Microsoft C/C++ Compiler Toolset version ... ${color.failure}%s", vctools_ver)
+                raise("${color.failure}your MSVC toolset version is too low, please update to this version or higher: (%s)", MINIMUM_MSVC_TOOLSET_VERSION)
+            else
+                cprint("checking for Microsoft C/C++ Compiler Toolset version ... ${color.success}%s", vctools_ver)
+            end
+
+            -- TEMPORARY, remove before next release
+            -- if the msvc is in preview, we should warn the user, but not block build
+            if compare_versions(parsed_vcvars_ver, parse_version("14.41.0")) then
+                cprint("${color.warning}your MSVC version may cause error on compile, please consider downgrading to this version or similar: (%s)", MINIMUM_MSVC_TOOLSET_VERSION)
+            end
+
+            -- could also do this
+            -- local vs_version = msvc:config("vcvars").VSCMD_VER
+            -- if vs_version:find("pre") then
+            --     cprint("${color.warning}you are using a preview version of Visual Studio, which may cause an error on build... consider downgrading to a stable version.")
+            -- end
+        end
+    end)
+
+rule("check.rust.ver")
+    on_config(function(target)
+        import("lib.detect.find_tool")
+        local rustc = find_tool("rustc")
+        if not rustc then
+            raise("${color.failure}rustc not found! Please install Rust from https://www.rust-lang.org/tools/install")
+        end
+
+        local version = os.iorunv(rustc.program, {"--version"})
+        local version_num = version:match("rustc (%d+.%d+.%d+)")
+        if version_num then
+            -- Still print the version number even if we are allowing all versions
+            local version_check = get_config("versionCheck")
+            if not version_check then
+                cprint("checking for Rust version ... ${color.success}%s", version_num)
+                return
+            end
+
+            if not compare_versions(parse_version(version_num), parse_version(MINIMUM_RUST_VERSION)) then
+                cprint("checking for Rust version ... ${color.failure}%s", version_num)
+                raise("${color.failure}your Rust version is too low, please update to this version or higher: (%s)", MINIMUM_RUST_VERSION)
+            else
+                cprint("checking for Rust version ... ${color.success}%s", version_num)
+            end
+        end
+    end)


### PR DESCRIPTION
**Description**

Some build issues have been caused in the past and recently when the user does not meet the minimum build requirements. 

This PR aims to solve this by checking the Rust and MSVC minimum requirements, and, if they are not met, error out on config, not allowing build to begin in the first place. xmake already uses `set_xmakever` which works fine for minimum version.

In the case of #615, the user is using the current preview version which has a higher MSVC version, and causes the build to fail. This PR additionally prints a warning (and continues build) if they are using this current MSVC version. We should keep an eye on this version and fix the issue at the root or see if this is just a compiler bug, but in either case, eventually remove this temporary measure.

The PR also prints the additional versions info in console without verbose mode needing to be enabled.

Currently hardcoding the minimum versions at the top of the file, but perhaps we could change this to something less terrible in the future.

**Type of change**

- [x] New feature (non-breaking change which adds functionality): xmake rules
- [x] Requires documentation update

**How Has This Been Tested?**

Ran `xmake l detect.sdks.find_vstudio` to get the msvc version strings.

Changed minimum versions for rust and msvc to test edge cases on version numbers, such as equal, or equal majors but different minors/patches, lower and higher than installed version etc. 

**Checklist**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.

**Screenshots (if appropriate)**

Tests with changed minimums above my installed versions:

![image](https://github.com/user-attachments/assets/4e1e689d-d6b9-48c1-beff-e40f43f1df7a)

![image](https://github.com/user-attachments/assets/0cf43e7f-ad84-4f81-8ad8-644bb435f25f)

![image](https://github.com/user-attachments/assets/fb6ab041-e4b8-48bf-957c-453462aa1400)

Works on any part touching UE4SS configurations:
![image](https://github.com/user-attachments/assets/1b56e700-51e6-4fa3-a4cb-bd1e886fe7c9)
