### PR TITLE
fix: RegisterProcessConsoleExecPostHook not passing the correct number of params to call_function

### DIFF
--- a/UE4SS/src/Mod/LuaMod.cpp
+++ b/UE4SS/src/Mod/LuaMod.cpp
@@ -4179,7 +4179,7 @@ Overloads:
                                 LuaType::FOutputDevice::construct(callback_data.lua, &ar);
                                 LuaType::RemoteUnrealParam::construct(callback_data.lua, &executor, s_object_property_name);
 
-                                callback_data.lua.call_function(4, 1);
+                                callback_data.lua.call_function(5, 1);
 
                                 if (callback_data.lua.is_nil())
                                 {

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -107,6 +107,8 @@ Fixed `FText` not working as a parameter (in `RegisterHook`, etc.) ([UE4SS #422]
 
 Fixed crash when calling UFunctions that take one or more 'out' params of type TArray<T>. ([UE4SS #477](https://github.com/UE4SS-RE/RE-UE4SS/pull/477))
 
+Fixed `RegisterProcessConsoleExecPostHook`. ([UE4SS #631](https://github.com/UE4SS-RE/RE-UE4SS/pull/631))
+
 ### C++ API
 Fixed a crash caused by a race condition enabled by C++ mods using `UE4SS_ENABLE_IMGUI` in their constructor ([UE4SS #481](https://github.com/UE4SS-RE/RE-UE4SS/pull/481))
 


### PR DESCRIPTION
**Description**

The `RegisterProcessConsoleExecPostHook` function was broken and unusable.
This was because we were passing the wrong number of params to `call_function` causing it to attempt to call a value that wasn't a function.

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Use `RegisterProcessConsoleExecPostHook` in a Lua script, enable the console enabler mod and type anything in the console and there's no longer an error outputted to the UE4SS console.

**Checklist**

- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
