### PR TITLE
Fix for not finding BP mods and lua mods if there are unicode characer in game path

### DIFF
--- a/UE4SS/src/Mod/LuaMod.cpp
+++ b/UE4SS/src/Mod/LuaMod.cpp
@@ -816,20 +816,20 @@ namespace RC
         lua_getglobal(lua_state, "package");
 
         lua_getfield(lua_state, -1, "path");
-        std::string current_paths = lua_tostring(lua_state, -1);
-        current_paths.append(fmt::format(";{}\\{}\\Scripts\\?.lua", to_string(m_program.get_mods_directory()).c_str(), to_string(get_name())));
-        current_paths.append(fmt::format(";{}\\shared\\?.lua", to_string(m_program.get_mods_directory()).c_str()));
-        current_paths.append(fmt::format(";{}\\shared\\?\\?.lua", to_string(m_program.get_mods_directory()).c_str()));
+        std::wstring current_paths = to_wstring(lua_tostring(lua_state, -1));
+        current_paths.append(fmt::format(STR(";{}\\{}\\Scripts\\?.lua"), m_program.get_mods_directory(), get_name()));
+        current_paths.append(fmt::format(STR(";{}\\shared\\?.lua"), m_program.get_mods_directory()));
+        current_paths.append(fmt::format(STR(";{}\\shared\\?\\?.lua"), m_program.get_mods_directory()));
         lua_pop(lua_state, 1);
-        lua_pushstring(lua_state, current_paths.c_str());
+        lua_pushstring(lua_state, to_string(current_paths).c_str());
         lua_setfield(lua_state, -2, "path");
 
         lua_getfield(lua_state, -1, "cpath");
-        std::string current_cpaths = lua_tostring(lua_state, -1);
-        current_cpaths.append(fmt::format(";{}\\{}\\Scripts\\?.dll", to_string(m_program.get_mods_directory()).c_str(), to_string(get_name())));
-        current_cpaths.append(fmt::format(";{}\\{}\\?.dll", to_string(m_program.get_mods_directory()).c_str(), to_string(get_name())));
+        std::wstring current_cpaths = to_wstring(lua_tostring(lua_state, -1));
+        current_cpaths.append(fmt::format(STR(";{}\\{}\\Scripts\\?.dll"), m_program.get_mods_directory(), get_name()));
+        current_cpaths.append(fmt::format(STR(";{}\\{}\\?.dll"), m_program.get_mods_directory(), get_name()));
         lua_pop(lua_state, 1);
-        lua_pushstring(lua_state, current_cpaths.c_str());
+        lua_pushstring(lua_state, to_string(current_cpaths).c_str());
         lua_setfield(lua_state, -2, "cpath");
 
         lua_pop(lua_state, 1);
@@ -2198,7 +2198,7 @@ Overloads:
                                     {
                                         throw std::runtime_error{"Couldn't find '__absolute_path' for directory entry."};
                                     }
-                                    const auto current_path = std::string{lua.get_string()};
+                                    const auto current_path = to_wstring(lua.get_string());
                                     auto files_table = lua.prepare_new_table();
                                     auto index = 1;
                                     for (const auto& item : std::filesystem::directory_iterator(current_path))
@@ -3364,7 +3364,7 @@ Overloads:
         // Don't crash on syntax errors.
         try
         {
-            main_lua()->execute_file((m_scripts_path / STR("main.lua")).string());
+            main_lua()->execute_file((m_scripts_path / STR("main.lua")).wstring());
         }
         catch (std::runtime_error& e)
         {

--- a/UE4SS/src/UE4SSProgram.cpp
+++ b/UE4SS/src/UE4SSProgram.cpp
@@ -1359,27 +1359,27 @@ namespace RC
 
     auto UE4SSProgram::get_module_directory() -> File::StringType
     {
-        return ensure_str(m_module_file_path);
+        return ensure_str(m_module_file_path.wstring());
     }
 
     auto UE4SSProgram::get_game_executable_directory() -> File::StringType
     {
-        return ensure_str(m_game_executable_directory);
+        return ensure_str(m_game_executable_directory.wstring());
     }
 
     auto UE4SSProgram::get_working_directory() -> File::StringType
     {
-        return ensure_str(m_working_directory);
+        return ensure_str(m_working_directory.wstring());
     }
 
     auto UE4SSProgram::get_mods_directory() -> File::StringType
     {
-        return ensure_str(m_mods_directory);
+        return ensure_str(m_mods_directory.wstring());
     }
 
     auto UE4SSProgram::get_legacy_root_directory() -> File::StringType
     {
-        return ensure_str(m_legacy_root_directory);
+        return ensure_str(m_legacy_root_directory.wstring());
     }
 
     auto UE4SSProgram::generate_uht_compatible_headers() -> void

--- a/deps/first/LuaRaw/include/lauxlib.h
+++ b/deps/first/LuaRaw/include/lauxlib.h
@@ -296,6 +296,7 @@ typedef struct luaL_Stream {
 
 
 
+FILE* wfopen(const char *filename, const char *mode);
 #endif
 
 

--- a/deps/first/LuaRaw/src/lauxlib.c
+++ b/deps/first/LuaRaw/src/lauxlib.c
@@ -9,6 +9,8 @@
 
 #include "lprefix.h"
 
+#define WIN32_LEAN_AND_MEAN      // Exclude rarely-used stuff from Windows headers
+#include <windows.h>
 
 #include <errno.h>
 #include <stdarg.h>
@@ -785,7 +787,7 @@ LUALIB_API int luaL_loadfilex (lua_State *L, const char *filename,
   }
   else {
     lua_pushfstring(L, "@%s", filename);
-    lf.f = fopen(filename, "r");
+    lf.f = wfopen(filename, "r");
     if (lf.f == NULL) return errfile(L, "open", fnameindex);
   }
   if (skipcomment(&lf, &c))  /* read initial portion */
@@ -1104,3 +1106,12 @@ LUALIB_API void luaL_checkversion_ (lua_State *L, lua_Number ver, size_t sz) {
                   (LUAI_UACNUMBER)ver, (LUAI_UACNUMBER)v);
 }
 
+FILE* wfopen(const char *filename, const char *mode)
+{
+  wchar_t buff[MAX_PATH+1];
+  wchar_t modeBuff[MAX_PATH+1];
+  if (MultiByteToWideChar(CP_UTF8, 0, filename, -1, buff, MAX_PATH) == 0 || MultiByteToWideChar(CP_UTF8, 0, mode, -1, modeBuff, MAX_PATH) == 0)
+    return fopen(filename, mode);
+
+  return _wfopen(buff, modeBuff);
+}

--- a/deps/first/LuaRaw/src/liolib.c
+++ b/deps/first/LuaRaw/src/liolib.c
@@ -260,7 +260,7 @@ static LStream *newfile (lua_State *L) {
 
 static void opencheck (lua_State *L, const char *fname, const char *mode) {
   LStream *p = newfile(L);
-  p->f = fopen(fname, mode);
+  p->f = wfopen(fname, mode);
   if (l_unlikely(p->f == NULL))
     luaL_error(L, "cannot open file '%s' (%s)", fname, strerror(errno));
 }
@@ -272,7 +272,7 @@ static int io_open (lua_State *L) {
   LStream *p = newfile(L);
   const char *md = mode;  /* to traverse/check mode */
   luaL_argcheck(L, l_checkmode(md), 2, "invalid mode");
-  p->f = fopen(filename, mode);
+  p->f = wfopen(filename, mode);
   return (p->f == NULL) ? luaL_fileresult(L, 0, filename) : 1;
 }
 

--- a/deps/first/LuaRaw/src/luac.c
+++ b/deps/first/LuaRaw/src/luac.c
@@ -184,7 +184,7 @@ static int pmain(lua_State* L)
  if (listing) luaU_print(f,listing>1);
  if (dumping)
  {
-  FILE* D= (output==NULL) ? stdout : fopen(output,"wb");
+  FILE* D= (output==NULL) ? stdout : wfopen(output,"wb");
   if (D==NULL) cannot("open");
   lua_lock(L);
   luaU_dump(L,f,writer,D,stripping);


### PR DESCRIPTION
**Description**

Fixes #495, #335

While it is possible to workaround those issues, by setting **ModsFolderPath** to directory without unicode characters, this doesn't solve a problem with loading BP mods from Content\Paks\LogicMods folder, which is still inside path with unicode character and does not have relevant settings to bypass this issue.
Also forcing users to make additional configuration makes using mods more diffucult.

**Type of change**

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Problem occured, while working on mod for "The Lord of the Rings Return to Moria™" game (note that unicode symbol at the end). After applying a fix - all mods load correctly, lua and BP.

**Checklist**

All changes are small and pretty self-explanatory. There are mostly on-liners and no additional code.
The only real additions are:
1. wrapper function for fopen (wfopen) to make number of changes to LuaRaw as small as possible.
2. conversion of GetModuleFileNameW to utf-8 in setprogdir (LuaRaw, loadlib.c)

Please delete options that are not relevant. Update the list as the PR progresses.

**Screenshots (if appropriate)**

**Additional context**

Add any other context about the pull request here.
