### PR TITLE
Implement global Lua function GenerateLuaTypes (#625)

### DIFF
--- a/UE4SS/src/Mod/LuaMod.cpp
+++ b/UE4SS/src/Mod/LuaMod.cpp
@@ -1435,7 +1435,7 @@ Overloads:
                 const Mod* mod = get_mod_ref(lua);
                 if (!mod)
                 {
-                    lua.throw_error("Could not dump objects and properties because the pointer to 'Mod' was nullptr");
+                    lua.throw_error("Couldn't dump objects and properties because the pointer to 'Mod' was nullptr");
                 }
                 UE4SSProgram::dump_all_objects_and_properties(mod->m_program.get_object_dumper_output_directory() + STR("\\") +
                                                               UE4SSProgram::m_object_dumper_file_name);
@@ -1444,8 +1444,23 @@ Overloads:
 
             lua.register_function("GenerateSDK", []([[maybe_unused]] const LuaMadeSimple::Lua& lua) -> int {
                 const Mod* mod = get_mod_ref(lua);
+                if (!mod)
+                {
+                    lua.throw_error("Couldn't generate SDK because the pointer to 'Mod' was nullptr");
+                }
                 File::StringType working_dir{mod->m_program.get_working_directory()};
                 mod->m_program.generate_cxx_headers(working_dir + STR("\\CXXHeaderDump"));
+                return 0;
+            });
+
+            lua.register_function("GenerateLuaTypes", []([[maybe_unused]] const LuaMadeSimple::Lua& lua) -> int {
+                const Mod* mod = get_mod_ref(lua);
+                if (!mod)
+                {
+                    lua.throw_error("Couldn't generate lua types because the pointer to 'Mod' was nullptr");
+                }
+                File::StringType working_dir{mod->m_program.get_working_directory()};
+                UE4SSProgram::get_program().generate_lua_types(working_dir + STR("\\Mods\\shared\\types"));
                 return 0;
             });
 

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -22,7 +22,8 @@ Added search filter: `IncludeClassNames`. ([UE4SS #472](https://github.com/UE4SS
 
 ### Lua API
 
-Added global function `CreateInvalidObject`, which returns an invalid UObject. ([UE4SS #652](https://github.com/UE4SS-RE/RE-UE4SS/issues/652))  Added GenerateLuaTypes function. ([UE4SS #664](https://github.com/UE4SS-RE/RE-UE4SS/pull/664))  
+Added global function `CreateInvalidObject`, which returns an invalid UObject. ([UE4SS #652](https://github.com/UE4SS-RE/RE-UE4SS/issues/652))  
+Added GenerateLuaTypes function. ([UE4SS #664](https://github.com/UE4SS-RE/RE-UE4SS/pull/664))  
 Added global Dumpers functions to Types.lua. ([UE4SS #664](https://github.com/UE4SS-RE/RE-UE4SS/pull/664))  
 
 ### C++ API

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -21,6 +21,8 @@ Added search filter: `IncludeClassNames`. ([UE4SS #472](https://github.com/UE4SS
 ### UHT Dumper
 
 ### Lua API
+Added GenerateLuaTypes function. ([UE4SS #664](https://github.com/UE4SS-RE/RE-UE4SS/pull/664))  
+Added global Dumpers functions to Types.lua. ([UE4SS #664](https://github.com/UE4SS-RE/RE-UE4SS/pull/664))
 
 ### C++ API
 Key binds created with `UE4SSProgram::register_keydown_event` end up being duplicated upon mod hot-reload.  

--- a/assets/Mods/shared/Types.lua
+++ b/assets/Mods/shared/Types.lua
@@ -280,6 +280,28 @@ EInternalObjectFlags = {
 
 -- # Global Functions
 
+---Dumps all objects and properties to UE4SS_ObjectDump.txt file
+function DumpAllObjects() end
+
+---Generates CXX Headers / CXXHeaderDump
+function GenerateSDK() end
+
+---Generates lua types in /Mods/shared/types
+function GenerateLuaTypes() end
+
+---Generates UHT Compatible Headers
+function GenerateUHTCompatibleHeaders() end
+
+---Dumps Static Meshes to *-ue4ss_static_mesh_data.csv file
+function DumpStaticMeshes() end
+
+---Dumps all current existing actors to *-ue4ss_actor_data.csv file
+function DumpAllActors() end
+
+--- Generates .usmap file
+function DumpUSMAP() end
+
+
 ---@param ObjectName string
 ---@return UObject
 function StaticFindObject(ObjectName) end

--- a/assets/Mods/shared/Types.lua
+++ b/assets/Mods/shared/Types.lua
@@ -283,6 +283,7 @@ EInternalObjectFlags = {
 ---Creates an blank UObject whose IsValid function always returns false
 ---@return UObject
 function CreateInvalidObject() end
+
 ---Dumps all objects and properties to UE4SS_ObjectDump.txt file
 function DumpAllObjects() end
 


### PR DESCRIPTION
Added  GenerateLuaTypes like described in #625.
Additionally added dumpers functions to Types.lua.


Built UE4SS and tested in Abiotic Factor. The function works and does exactly the same as the button in the GUI.

resolve #625
