### PR TITLE
ops: Trigger the Experimental release action for every Lua mod or ini change

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -11,6 +11,8 @@ on:
       - "UE4SS/generated_include/**"
       - "deps/**"
       - "UE4SS/proxy_generator/**"
+      - "assets/Mods/**"
+      - "assets/**.ini"
 
 permissions:
   contents: read


### PR DESCRIPTION
Currently no changes in "assets" directory trigger an experimental release.  
I think it should happen since changes on Lua mods or in the `UE4SS-settings.ini` can be important. 