### PR TITLE
Update warning message for FAssetData when loading all assets

### DIFF
--- a/UE4SS/src/UE4SSProgram.cpp
+++ b/UE4SS/src/UE4SSProgram.cpp
@@ -864,6 +864,11 @@ namespace RC
                 Output::send<LogLevel::Warning>(
                         STR("FAssetData not available in <4.17, ignoring 'LoadAllAssetsBeforeDumpingObjects' & 'LoadAllAssetsBeforeGeneratingCXXHeaders'."));
             }
+            else if (!bFAssetDataAvailable)
+            {
+                Output::send<LogLevel::Warning>(
+                        STR("FAssetData not available, ignoring 'LoadAllAssetsBeforeDumpingObjects' & 'LoadAllAssetsBeforeGeneratingCXXHeaders'."));
+            }
 
             install_lua_mods();
             LuaMod::on_program_start();


### PR DESCRIPTION
FAssetData isn't used for core functionality and crashing here makes it harder to debug the root cause.  Requires Re-UE4SS/UEPseudo#102