### PR TITLE
ConsoleEnablerMod overhaul

### DIFF
--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -100,6 +100,10 @@ The callback of `NotifyOnNewObject` can now optionally return `true` to unregist
 ### BPModLoader
 BPModLoader now supports loading mods from subdirectories within the `LogicMods` folder ([UE4SS #412](https://github.com/UE4SS-RE/RE-UE4SS/pull/412)) - Ethan Green
 
+### ConsoleEnablerMod
+Added additional console key **~** (Tilde) ([UE4SS #687](https://github.com/UE4SS-RE/RE-UE4SS/pull/687))  
+The console keys **F10** and **~** are now added by the mod in addition to the existing keys instead of replacing them ([UE4SS #687](https://github.com/UE4SS-RE/RE-UE4SS/pull/687))
+
 ### Repo & Build Process
 Switch to xmake from cmake which makes building much more streamlined ([UE4SS #377](https://github.com/UE4SS-RE/RE-UE4SS/pull/377), [UEPseudo #81](https://github.com/Re-UE4SS/UEPseudo/pull/81)) - localcc
 

--- a/assets/Mods/ConsoleEnablerMod/Scripts/main.lua
+++ b/assets/Mods/ConsoleEnablerMod/Scripts/main.lua
@@ -10,21 +10,21 @@ local function RemapConsoleKeys()
 
     local ConsoleKeys = InputSettings.ConsoleKeys
 
-    local keysToAdd = {
+    local KeysToAdd = {
         UEHelpers.FindFName("Tilde"),
         UEHelpers.FindFName("F10")
     }
 
-    for _, keyName in ipairs(keysToAdd) do
-        if keyName ~= NAME_None then
-            local alreadySet = false
+    for _, KeyName in ipairs(KeysToAdd) do
+        if KeyName ~= NAME_None then
+            local KeyIsAlreadySet = false
             for i = 1, #ConsoleKeys do
-                if ConsoleKeys[i].KeyName == keyName then
-                    alreadySet = true
+                if ConsoleKeys[i].KeyName == KeyName then
+                    KeyIsAlreadySet = true
                 end
             end
-            if not alreadySet then
-                ConsoleKeys[#ConsoleKeys + 1].KeyName = keyName
+            if not KeyIsAlreadySet then
+                ConsoleKeys[#ConsoleKeys + 1].KeyName = KeyName
             end
         end
     end

--- a/assets/Mods/ConsoleEnablerMod/Scripts/main.lua
+++ b/assets/Mods/ConsoleEnablerMod/Scripts/main.lua
@@ -1,42 +1,52 @@
-local Engine = FindFirstOf("Engine")
+local UEHelpers = require("UEHelpers")
+
 local PlayerControllerHookActive = false
 local WasFirstConsoleCreated = false
 
 local function RemapConsoleKeys()
     -- Change console key
-    local InputSettings = StaticFindObject("/Script/Engine.Default__InputSettings")
+    local InputSettings = StaticFindObject("/Script/Engine.Default__InputSettings") ---@cast InputSettings UInputSettings
     if not InputSettings:IsValid() then print("[ConsoleEnabler] InputSettings not found, could not change console key\n") return end
-    
+
     local ConsoleKeys = InputSettings.ConsoleKeys
-    
-    -- This sets the first console key to F10
-    ConsoleKeys[1].KeyName = FName("F10", EFindName.FNAME_Find)
-    
-    ConsoleKeys:ForEach(function(index, elem_wrapper)
-        local KeyStruct = elem_wrapper:get()
-        local KeyFName = KeyStruct.KeyName
-        -- The ToString() call here will go bad if the FName is not ansi
-        print(string.format("[ConsoleEnabler] ConsoleKey[%d]: %s\n", index, KeyFName:ToString()))
-    end)
+
+    local f10Name = UEHelpers.FindFName("F10")
+    if f10Name == NAME_None then
+        print("[RemapConsoleKeys] Was unable to find F10 FName\n")
+        return
+    end
+
+    local f10AlreadySet = false
+    for i = 1, #ConsoleKeys do
+        local consoleKey = ConsoleKeys[i]
+        local keyName = consoleKey.KeyName
+        if keyName == f10Name then
+            f10AlreadySet = true
+        end
+        print(string.format("[ConsoleEnabler] ConsoleKey[%d]: %s\n", i, keyName:ToString()))
+    end
+    if not f10AlreadySet then
+        local newKeyIndex = #ConsoleKeys + 1
+        ConsoleKeys[newKeyIndex].KeyName = f10Name
+        print(string.format("[ConsoleEnabler] ConsoleKey[%d]: %s\n", newKeyIndex, f10Name:ToString()))
+    end
 end
 
 local function CreateConsole()
-    if not Engine:IsValid() then
-        Engine = FindFirstOf("Engine")
-    end
-    
+    local Engine = UEHelpers.GetEngine()
     if not Engine:IsValid() then print("[ConsoleEnabler] Was unable to find an instance of UEngine\n") return end
-    
-    local ConsoleClass = Engine.ConsoleClass
+
+    local ConsoleClass = Engine.ConsoleClass ---@type UClass
     local GameViewport = Engine.GameViewport
-    
-    if GameViewport.ViewportConsole:IsValid() then
+
+    if GameViewport:IsValid() and GameViewport.ViewportConsole:IsValid() then
         -- Console already exists, let's just remap the keys
         RemapConsoleKeys()
     elseif ConsoleClass:IsValid() and GameViewport:IsValid() then
-        local CreatedConsole = StaticConstructObject(ConsoleClass, GameViewport, 0, 0, 0, nil, false, false, nil)
+        local CreatedConsole = StaticConstructObject(ConsoleClass, GameViewport) ---@cast CreatedConsole UConsole
+        if not CreatedConsole:IsValid() then print("[CreateConsole] Was unable to construct an UConsole object\n") return end
+
         GameViewport.ViewportConsole = CreatedConsole
-        
         PlayerControllerHookActive = true
         WasFirstConsoleCreated = true
 
@@ -48,7 +58,7 @@ end
 
 CreateConsole()
 
-NotifyOnNewObject("/Script/Engine.PlayerController", function(CreatedObject)
+NotifyOnNewObject("/Script/Engine.PlayerController", function()
     if PlayerControllerHookActive or not WasFirstConsoleCreated then
         CreateConsole()
     end

--- a/assets/Mods/ConsoleEnablerMod/Scripts/main.lua
+++ b/assets/Mods/ConsoleEnablerMod/Scripts/main.lua
@@ -10,25 +10,27 @@ local function RemapConsoleKeys()
 
     local ConsoleKeys = InputSettings.ConsoleKeys
 
-    local f10Name = UEHelpers.FindFName("F10")
-    if f10Name == NAME_None then
-        print("[RemapConsoleKeys] Was unable to find F10 FName\n")
-        return
+    local keysToAdd = {
+        UEHelpers.FindFName("Tilde"),
+        UEHelpers.FindFName("F10")
+    }
+
+    for _, keyName in ipairs(keysToAdd) do
+        if keyName ~= NAME_None then
+            local alreadySet = false
+            for i = 1, #ConsoleKeys do
+                if ConsoleKeys[i].KeyName == keyName then
+                    alreadySet = true
+                end
+            end
+            if not alreadySet then
+                ConsoleKeys[#ConsoleKeys + 1].KeyName = keyName
+            end
+        end
     end
 
-    local f10AlreadySet = false
     for i = 1, #ConsoleKeys do
-        local consoleKey = ConsoleKeys[i]
-        local keyName = consoleKey.KeyName
-        if keyName == f10Name then
-            f10AlreadySet = true
-        end
-        print(string.format("[ConsoleEnabler] ConsoleKey[%d]: %s\n", i, keyName:ToString()))
-    end
-    if not f10AlreadySet then
-        local newKeyIndex = #ConsoleKeys + 1
-        ConsoleKeys[newKeyIndex].KeyName = f10Name
-        print(string.format("[ConsoleEnabler] ConsoleKey[%d]: %s\n", newKeyIndex, f10Name:ToString()))
+        print(string.format("[ConsoleEnabler] ConsoleKey[%d]: %s\n", i, ConsoleKeys[i].KeyName:ToString()))
     end
 end
 


### PR DESCRIPTION
### Changes
- Check if ~ (Tilde) and F10 already exist as ConsoleKeys, if not add them at the end of the array
- Add some missing IsValid checks
- Removed obsolete parameters from callbacks and function calls
### Description
I don't know the reasons for the structure of the mod, but I couldn't find any harm in my improvements.  
Originally the mod overwrites the first hotkey for the console with **F10**, if the game has default settings that allows you to open the console, it would overwrite the default key.  
Also the most universal key to open a console on English keyboard layouts is **~** (tilde).  
My changes add **~** in addition to **F10**, check if hotkeys are already set, if not the mod expands the ConsoleKeys array and adds **~** and **F10** as additional options to open the console. Not only does it allow you to respect the game's settings, but it also allows other mods to add their own hotkeys to open the console.
### Testing
I've tested the changes and I use it basically daily with my [Cheat Console Commands Mod for Abiotic Factor](https://github.com/igromanru/CheatConsoleCommands-UE4SS-AF).  
For test purposes I've **locally** changed key mappings to **F11** in my mod [here](https://github.com/igromanru/CheatConsoleCommands-UE4SS-AF/blob/549342f520db8dded96189faadab7b513a68b78c/scripts/main.lua#L33) and it worked. I could open the console with any of assigned keys.  

### Changelog changes
~~Like usually I'll write down the changes in the Changelog.md a bit later, maybe after an initial review, so I know which changes will remain.~~
Added