### PR TITLE
Fix(Types.lua): Fix GetFName function return definition

### DIFF
--- a/assets/Mods/shared/Types.lua
+++ b/assets/Mods/shared/Types.lua
@@ -838,7 +838,7 @@ function UObject:GetFullName() end
 
 ---Returns the FName of this object by copy
 ---All FNames returned by `__index` are returned by reference
----@retur FName
+---@return FName
 function UObject:GetFName() end
 
 ---Returns the memory address of this object


### PR DESCRIPTION
The return definition of the GetFName function was nil instead of FName.