### PR TITLE
Fix FindObject not working when specifying UClass outer

### DIFF
--- a/UE4SS/src/Mod/LuaMod.cpp
+++ b/UE4SS/src/Mod/LuaMod.cpp
@@ -2624,7 +2624,7 @@ Overloads:
             std::string error_overload_not_found{R"(
 No overload found for function 'FindObject'.
 Overloads:
-#1: FindObject(UClass InClass, UObject InOuter, string Name, bool ExactClass)
+#1: FindObject(UClass InClass, UObject|UClass InOuter, string Name, bool ExactClass)
 #2: FindObject(string|FName|nil ClassName, string|FName|nil ObjectShortName, EObjectFlags RequiredFlags, EObjectFlags BannedFlags)
 #3: FindObject(UClass|nil Class, string|FName|nil ObjectShortName, EObjectFlags RequiredFlags, EObjectFlags BannedFlags))"};
 
@@ -2691,9 +2691,14 @@ Overloads:
                 auto& userdata = lua.get_userdata<LuaType::UE4SSBaseObject>(1, true);
                 std::string_view lua_object_name = userdata.get_object_name();
                 // TODO: Redo when there's a bette way of checking whether a lua object is derived from UObject
-                if (lua_object_name == "UObject" || lua_object_name == "UWorld" || lua_object_name == "AActor")
+                if (lua_object_name == "UObject" || lua_object_name == "UWorld" || lua_object_name == "AActor" || lua_object_name == "UClass")
                 {
-                    in_outer = lua.get_userdata<LuaType::UObject>().get_remote_cpp_object();
+                    if (lua_object_name == "UClass") {
+                        in_outer = lua.get_userdata<LuaType::UClass>().get_remote_cpp_object();
+                    }
+                    else {
+                        in_outer = lua.get_userdata<LuaType::UObject>().get_remote_cpp_object();
+                    }
                     could_be_in_outer = true;
                 }
                 else if (lua_object_name == "FName")

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -162,7 +162,7 @@ Fixed `RegisterProcessConsoleExecPostHook`. ([UE4SS #631](https://github.com/UE4
 
 Fixed `FindFirstOf` return type annotation in `Types.lua` to signal that the return value will never be nil. ([UE4SS #652](https://github.com/UE4SS-RE/RE-UE4SS/issues/652))
 
-Fixed `FindObject` not accepting UClass as a valid outer parameter.
+Fixed `FindObject` not accepting UClass as a valid outer parameter. ([UE4SS #732](https://github.com/UE4SS-RE/RE-UE4SS/issues/732)) - GhostyPool
 
 ### C++ API
 Fixed a crash caused by a race condition enabled by C++ mods using `UE4SS_ENABLE_IMGUI` in their constructor ([UE4SS #481](https://github.com/UE4SS-RE/RE-UE4SS/pull/481))

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -162,6 +162,8 @@ Fixed `RegisterProcessConsoleExecPostHook`. ([UE4SS #631](https://github.com/UE4
 
 Fixed `FindFirstOf` return type annotation in `Types.lua` to signal that the return value will never be nil. ([UE4SS #652](https://github.com/UE4SS-RE/RE-UE4SS/issues/652))
 
+Fixed `FindObject` not accepting UClass as a valid outer parameter.
+
 ### C++ API
 Fixed a crash caused by a race condition enabled by C++ mods using `UE4SS_ENABLE_IMGUI` in their constructor ([UE4SS #481](https://github.com/UE4SS-RE/RE-UE4SS/pull/481))
 

--- a/docs/lua-api/global-functions/findobject.md
+++ b/docs/lua-api/global-functions/findobject.md
@@ -10,7 +10,7 @@ Overload #2 works the same way as `FindObject` in the [UE source](https://docs.u
 
 | # | Type | Information |
 |---|------|-------------|
-| 1 | string\|FName\|nil | The short name of the class of the object |
+| 1 | string\|FName\|UClass\|nil | The short name of the object's class or the UClass itself |
 | 2 | string\|FName\|nil | The short name of the object itself |
 | 3 | EObjectFlags | Any flags that the object cannot have. Uses \| as a seperator |
 | 4 | EObjectFlags | Any flags that the object must have. Uses \| as a seperator |
@@ -22,7 +22,7 @@ Overload #2 works the same way as `FindObject` in the [UE source](https://docs.u
 | # | Type | Information |
 |---|------|-------------|
 | 1 | UClass | The class to find |
-| 2 | UObject | The outer to look inside. If this is null then param 3 should start with a package name |
+| 2 | UObject\|UClass | The outer to look inside. If this is null then param 3 should start with a package name |
 | 3 | string | The object path to search for an object, relative to param 2 |
 | 4 | bool | Whether to require an exact match with the UClass parameter |
 
@@ -36,12 +36,18 @@ Overload #2 works the same way as `FindObject` in the [UE source](https://docs.u
 
 ```lua
 -- SceneComponent instance called TransformComponent0
-local Object = FindObject("SceneComponent", "TransformComponent0") 
+local Object = FindObject("SceneComponent", "TransformComponent0")
 ```
 
 ```lua
 -- FirstPersonCharacter_C instance called FirstPersonCharacter_C_0
 local Object = FindObject("FirstPersonCharacter_C", "FirstPersonCharacter_C_0", EObjectFlags.RF_NoFlags, EObjectFlags.RF_ClassDefaultObject)
+```
+
+Alternatively, you can use a UClass object:
+
+```lua
+local Object = FindObject(SceneComponentClass, "TransformComponent0")
 ```
 
 ## Example (overload #2)


### PR DESCRIPTION
**Description**

Fixes FindObject not working with a UClass as the provided outer, previously failed with "No overload found for function 'FindObject'.".

Slightly improves documentation for FindObject and provides more examples.

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Tested and works just fine to find objects which have a UClass as their outer.
