### PR TITLE
Fixed indexing nil in BPModLoaderMod

### DIFF
--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -196,6 +196,8 @@ Fixed `RegisterProcessConsoleExecPostHook`. ([UE4SS #631](https://github.com/UE4
 
 Fixed `FindFirstOf` return type annotation in `Types.lua` to signal that the return value will never be nil. ([UE4SS #652](https://github.com/UE4SS-RE/RE-UE4SS/issues/652)) 
 
+Fixed indexing nil in BPModLoaderMod ([UE4SS #751](https://github.com/UE4SS-RE/RE-UE4SS/issues/751))
+
 ### C++ API 
 Fixed a crash caused by a race condition enabled by C++ mods using `UE4SS_ENABLE_IMGUI` in their constructor ([UE4SS #481](https://github.com/UE4SS-RE/RE-UE4SS/pull/481)) 
 

--- a/assets/Mods/BPModLoaderMod/Scripts/main.lua
+++ b/assets/Mods/BPModLoaderMod/Scripts/main.lua
@@ -215,7 +215,7 @@ local function LoadMod(ModName, ModInfo, World)
 			return
 		end
 
-        if not World:IsValid() then Log(string.format("World is not valid for '%s' to spawn in\n", ModName)) return end
+        if not World or not World:IsValid() then Log(string.format("World is not valid for '%s' to spawn in\n", ModName)) return end
 
         local Actor = World:SpawnActor(ModClass, {}, {})
         if not Actor:IsValid() then


### PR DESCRIPTION
**Description**

Sometimes, for some unknown reason, the `World` argument to `LoadMod` can be nil.
This must be checked for or Lua will throw an error.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

It has not beyond making sure the syntax is valid.

**Checklist**

- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.