### PR TITLE
Reuse exports for proxy dll generation

### DIFF
--- a/UE4SS/proxy_generator/exports/_dummy.exports
+++ b/UE4SS/proxy_generator/exports/_dummy.exports
@@ -1,2 +1,0 @@
-Path: C:\Windows\system32\_dummy.dll
-1 DllMain

--- a/UE4SS/proxy_generator/exports/_dummy.exports
+++ b/UE4SS/proxy_generator/exports/_dummy.exports
@@ -1,0 +1,2 @@
+Path: C:\Windows\system32\_dummy.dll
+1 DllMain

--- a/UE4SS/proxy_generator/exports/dwmapi.exports
+++ b/UE4SS/proxy_generator/exports/dwmapi.exports
@@ -1,0 +1,145 @@
+Path: C:\Windows\System32\dwmapi.dll
+
+12 DllCanUnloadNow
+16 DllGetClassObject
+17 DwmAttachMilContent
+18 DwmDefWindowProc
+19 DwmDetachMilContent
+20 DwmEnableBlurBehindWindow
+3 DwmEnableComposition
+21 DwmEnableMMCSS
+22 DwmExtendFrameIntoClientArea
+23 DwmFlush
+24 DwmGetColorizationColor
+26 DwmGetCompositionTimingInfo
+27 DwmGetGraphicsStreamClient
+30 DwmGetGraphicsStreamTransformHint
+31 DwmGetTransportAttributes
+34 DwmGetUnmetTabRequirements
+35 DwmGetWindowAttribute
+50 DwmInvalidateIconicBitmaps
+85 DwmIsCompositionEnabled
+86 DwmModifyPreviousDxFrameDuration
+87 DwmQueryThumbnailSourceSize
+88 DwmRegisterThumbnail
+89 DwmRenderGesture
+90 DwmSetDxFrameDuration
+91 DwmSetIconicLivePreviewBitmap
+92 DwmSetIconicThumbnail
+93 DwmSetPresentParameters
+94 DwmSetWindowAttribute
+95 DwmShowContact
+96 DwmTetherContact
+57 DwmTetherTextContact
+97 DwmTransitionOwnedWindow
+98 DwmUnregisterThumbnail
+99 DwmUpdateThumbnailProperties
+37 DwmpAllocateSecurityDescriptor
+1 DwmpDxGetWindowSharedSurface
+2 DwmpDxUpdateWindowSharedSurface
+29 DwmpDxgiIsThreadDesktopComposited
+44 DwmpEnableDDASupport
+38 DwmpFreeSecurityDescriptor
+28 DwmpGetColorizationParameters
+36 DwmpRenderFlick
+32 DwmpSetColorizationParameters
+84 DwmpUpdateProxyWindowForCapture
+100 
+101 
+102 
+103 
+104 
+105 
+106 
+107 
+108 
+109 
+110 
+111 
+112 
+113 
+114 
+115 
+116 
+117 
+118 
+119 
+120 
+121 
+122 
+123 
+124 
+125 
+126 
+127 
+128 
+129 
+130 
+131 
+132 
+133 
+134 
+135 
+136 
+137 
+138 
+139 
+140 
+141 
+142 
+143 
+144 
+145 
+146 
+147 
+148 
+149 
+150 
+151 
+152 
+153 
+154 
+155 
+156 
+157 
+158 
+159 
+160 
+161 
+162 
+163 
+164 
+165 
+166 
+167 
+168 
+169 
+170 
+171 
+172 
+173 
+174 
+175 
+176 
+177 
+178 
+179 
+180 
+181 
+182 
+183 
+184 
+185 
+186 
+187 
+188 
+189 
+190 
+191 
+192 
+193 
+194 
+195 
+196 
+197 
+198 

--- a/UE4SS/proxy_generator/exports/xinput1_3.exports
+++ b/UE4SS/proxy_generator/exports/xinput1_3.exports
@@ -1,0 +1,14 @@
+Path: C:\Windows\System32\xinput1_3.dll
+
+1 DllMain
+5 XInputEnable
+7 XInputGetBatteryInformation
+4 XInputGetCapabilities
+6 XInputGetDSoundAudioDeviceGuids
+8 XInputGetKeystroke
+2 XInputGetState
+3 XInputSetState
+100 
+101 
+102 
+103 

--- a/UE4SS/proxy_generator/xmake.lua
+++ b/UE4SS/proxy_generator/xmake.lua
@@ -1,5 +1,8 @@
 local projectName = "proxy_generator"
 
+rule("dllexports")
+    set_extensions(".exports")
+
 target(projectName)
     set_kind("binary")
     set_languages("cxx23")
@@ -10,19 +13,38 @@ target(projectName)
     add_deps("File", "Constructs")
     add_links("imagehlp")
 
+    add_files("exports/*.exports", { rule = "dllexports" })
+
     after_build(function(target)
         local proxy_exe =  target:targetfile()
         local output_path = target:autogendir()
         import("core.base.task")
+
+        local input = get_config("ue4ssProxyPath")
+
+        local dll_name = path.basename(input):lower()
+        for k, sourcebatch in pairs(target:sourcebatches()) do
+            if k == "dllexports" then
+                for _, expfile in ipairs(sourcebatch.sourcefiles) do
+                    if path.basename(expfile):lower() == dll_name then
+                        input = path.absolute(expfile)
+                        goto found
+                    end
+                end
+            end
+        end
+        ::found::
+
         -- The second arg of task.run is used if we plan on calling `xmake proxy_files`.
         -- The proxy_files task is not exposed to the CLI, so we pass an empty second arg.
-        task.run("proxy_files", {}, proxy_exe, output_path)
+        task.run("proxy_files", {}, proxy_exe, input, output_path)
     end)
 
 -- Define a task that executes the proxy_generator exe with the provided arguments
 task("proxy_files")
-    on_run(function (proxy_gen_exe, output_path)
+    on_run(function (proxy_gen_exe, input, output_path)
         os.mkdir(output_path)
-        os.execv(proxy_gen_exe, {get_config("ue4ssProxyPath"), output_path})
+        os.execv(proxy_gen_exe, {input, output_path})
     end)
+
 includes("proxy")


### PR DESCRIPTION
## Description

proxy_generator now generates an .exports file that it can reuse later, in place of dumping exports from system provided DLL. This avoids using the export arrangement from the GitHub runner's dwmapi DLL (from Windows Server 20xx) that reportedly breaks OpenGL graphics mode for the GUI console, and maybe breaks more things than that.

The .exports files are initially generated under the `Intermediate` directory (build log will print out the output path during proxy_generator run). These files are then pushed into the repository under `UE4SS/proxy_generator/exports`, so that for the next build, proxy_generator can use those exports. The .exports files can also be hand-made from `dumpbin.exe /EXPORTS` output, keeping in mind that the first line being in the form `Path: <path/to/orig.dll>` and subsequent lines in the form `<ordinal> <functionname?>` for each export.

I'm not sure which GitHub issues were directly related to the OpenGL white window issue *only*, so I don't know which ones should be linked here for closing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Built proxy DLL both locally and on GitHub runners (see below). In both cases, dwmapi.dll and xinput1_3.dll proxies are built (`xmake f -m "Game__Shipping__Win64" -y --ue4ssProxyPath=C:\Windows\System32\xinput1_3.dll` to configure a separate proxy).

In all cases, OpenGL graphics mode for the GUI does not show a white window anymore.

- [UE4SS xinput1_3 zip](https://github.com/Lyrth/RE-UE4SS/releases/download/experimental-latest/UE4SS_v2.5.2-915-gbff6a1b.zip) - [corresponding workflow run](https://github.com/Lyrth/RE-UE4SS/actions/runs/12809854109/job/35715565585)
- [UE4SS dwmapi zip](https://github.com/Lyrth/RE-UE4SS/releases/download/experimental-latest/UE4SS_v2.5.2-914-gcea18a1.zip) - [corresponding workflow run](https://github.com/Lyrth/RE-UE4SS/actions/runs/12809553550/job/35714622553)

(I think PR actions builds will also work.)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
