### PR TITLE
Added hook for UGameViewportClient::Tick

### DIFF
--- a/UE4SS/include/SettingsManager.hpp
+++ b/UE4SS/include/SettingsManager.hpp
@@ -92,6 +92,7 @@ namespace RC
             bool HookBeginPlay{true};
             bool HookLocalPlayerExec{true};
             bool HookAActorTick{true};
+            bool HookGameViewportClientTick{true};
             int64_t FExecVTableOffsetInLocalPlayer{0x28};
         } Hooks;
 

--- a/UE4SS/src/SettingsManager.cpp
+++ b/UE4SS/src/SettingsManager.cpp
@@ -115,6 +115,7 @@ namespace RC
         REGISTER_BOOL_SETTING(Hooks.HookBeginPlay, section_hooks, HookBeginPlay)
         REGISTER_BOOL_SETTING(Hooks.HookLocalPlayerExec, section_hooks, HookLocalPlayerExec)
         REGISTER_BOOL_SETTING(Hooks.HookAActorTick, section_hooks, HookAActorTick)
+        REGISTER_BOOL_SETTING(Hooks.HookGameViewportClientTick, section_hooks, HookGameViewportClientTick)
         REGISTER_INT64_SETTING(Hooks.FExecVTableOffsetInLocalPlayer, section_hooks, FExecVTableOffsetInLocalPlayer)
 
         constexpr static File::CharType section_experimental_features[] = STR("ExperimentalFeatures");

--- a/UE4SS/src/UE4SSProgram.cpp
+++ b/UE4SS/src/UE4SSProgram.cpp
@@ -768,6 +768,7 @@ namespace RC
         config.bHookBeginPlay = settings_manager.Hooks.HookBeginPlay;
         config.bHookLocalPlayerExec = settings_manager.Hooks.HookLocalPlayerExec;
         config.bHookAActorTick = settings_manager.Hooks.HookAActorTick;
+        config.bHookGameViewportClientTick = settings_manager.Hooks.HookGameViewportClientTick;
         config.FExecVTableOffsetInLocalPlayer = settings_manager.Hooks.FExecVTableOffsetInLocalPlayer;
         // Apply Debug Build setting from settings file only for now.
         Unreal::Version::DebugBuild = settings_manager.EngineVersionOverride.DebugBuild;

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -90,6 +90,8 @@ Added `OpenFor::ReadWrite`, to be used when calling `File::open`.
 
 This can be used when calling `FileHandle::memory_map`, unlike `OpenFor::Writing`.  ([UE4SS #507](https://github.com/UE4SS-RE/RE-UE4SS/pull/507)) 
 
+Added hook for `UGameViewportClient::Tick`. ([UE4SS #767](https://github.com/UE4SS-RE/RE-UE4SS/pull/767))
+
 ### BPModLoader 
 
 ### Experimental 
@@ -229,6 +231,7 @@ DebugBuild =
 [Hooks]
 HookLoadMap = 1
 HookAActorTick = 1
+HookGameViewportClientTick = 1
 ```
 
 ### Removed


### PR DESCRIPTION
**Description**

This PR adds a UGameViewportClient::Tick hook.
It currently doesn't register any hooks for this function, it just brings the ability to do so in the future.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**Checklist**

- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
- [x] Any dependent changes have been merged and published in downstream modules.
