### PR TITLE
Option for rendering GUI in the game thread

### DIFF
--- a/UE4SS/include/GUI/GUI.hpp
+++ b/UE4SS/include/GUI/GUI.hpp
@@ -28,6 +28,18 @@ namespace RC::GUI
         GameViewportClientTick,
     };
 
+    inline auto render_mode_to_string(RenderMode mode) -> std::string
+    {
+        switch (mode)
+        {
+        case RenderMode::ExternalThread:
+            return "ExternalThread";
+        case RenderMode::GameViewportClientTick:
+            return "GameViewportClientTick";
+        }
+        return "UnknownRenderMode";
+    }
+
     enum class OSBackend
     {
         Windows,

--- a/UE4SS/include/SettingsManager.hpp
+++ b/UE4SS/include/SettingsManager.hpp
@@ -63,6 +63,7 @@ namespace RC
             bool DebugConsoleVisible{true};
             float DebugGUIFontScaling{1.0};
             GUI::GfxBackend GraphicsAPI{GUI::GfxBackend::GLFW3_OpenGL3};
+            GUI::RenderMode RenderMode{GUI::RenderMode::ExternalThread};
         } Debug;
 
         struct SectionCrashDump

--- a/UE4SS/include/UE4SSProgram.hpp
+++ b/UE4SS/include/UE4SSProgram.hpp
@@ -48,6 +48,7 @@ namespace RC
         class UObjectBase;
         class UObjectBaseUtility;
         class UWorld;
+        class UGameViewportClient;
     } // namespace Unreal
 
     namespace Output
@@ -131,6 +132,7 @@ namespace RC
         };
         std::vector<Event> m_queued_events{};
         std::mutex m_event_queue_mutex{};
+        std::mutex m_render_thread_mutex{};
 
       private:
         std::unique_ptr<PLH::IatHook> m_load_library_a_hook;
@@ -320,5 +322,6 @@ namespace RC
         friend void* HookedLoadLibraryExA(const char* dll_name, void* file, int32_t flags);
         friend void* HookedLoadLibraryW(const wchar_t* dll_name);
         friend void* HookedLoadLibraryExW(const wchar_t* dll_name, void* file, int32_t flags);
+        friend auto gui_render_thread_GameViewportClientTick(Unreal::UGameViewportClient*, float) -> void;
     };
 } // namespace RC

--- a/UE4SS/src/GUI/GLFW3_OpenGL3.cpp
+++ b/UE4SS/src/GUI/GLFW3_OpenGL3.cpp
@@ -9,6 +9,7 @@
 #include <backends/imgui_impl_glfw.h>
 #include <backends/imgui_impl_opengl3.h>
 #include <imgui.h>
+#include <UE4SSProgram.hpp>
 
 namespace RC::GUI
 {
@@ -33,7 +34,8 @@ namespace RC::GUI
         glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE); // 3.2+ only
 
         // Create window with graphics context
-        m_window = glfwCreateWindow(1280, 800, "UE4SS Debugging Tools (OpenGL 3)", NULL, NULL);
+        auto window_title = fmt::format("UE4SS Debugging Tools (OpenGL 3) - {}", render_mode_to_string(UE4SSProgram::settings_manager.Debug.RenderMode));
+        m_window = glfwCreateWindow(1280, 800, window_title.c_str(), NULL, NULL);
         if (m_window == NULL)
         {
             throw std::runtime_error{"Was unable to create glfw window"};

--- a/UE4SS/src/GUI/Windows.cpp
+++ b/UE4SS/src/GUI/Windows.cpp
@@ -1,6 +1,7 @@
 #include <GUI/Windows.hpp>
 
 #include <GUI/DX11.hpp>
+#include <UE4SSProgram.hpp>
 #include <backends/imgui_impl_win32.h>
 #include <imgui.h>
 #include <tchar.h>
@@ -41,6 +42,7 @@ namespace RC::GUI
         {
             title_bar_text.append(STR(" (DX11)"));
         }
+        title_bar_text.append(fmt::format(STR(" - {}"), ensure_str(render_mode_to_string(UE4SSProgram::settings_manager.Debug.RenderMode))));
 
         // ImGui_ImplWin32_EnableDpiAwareness()
         s_wc.cbSize = sizeof(WNDCLASSEX);

--- a/UE4SS/src/SettingsManager.cpp
+++ b/UE4SS/src/SettingsManager.cpp
@@ -94,6 +94,16 @@ namespace RC
         {
             Debug.GraphicsAPI = GUI::GfxBackend::GLFW3_OpenGL3;
         }
+        StringType render_mode_string{};
+        REGISTER_STRING_SETTING(render_mode_string, section_debug, RenderMode)
+        if (String::iequal(render_mode_string, STR("ExternalThread")))
+        {
+            Debug.RenderMode = GUI::RenderMode::ExternalThread;
+        }
+        else if (String::iequal(render_mode_string, STR("GameViewportClientTick")))
+        {
+            Debug.RenderMode = GUI::RenderMode::GameViewportClientTick;
+        }
 
         constexpr static File::CharType section_crash_dump[] = STR("CrashDump");
         REGISTER_BOOL_SETTING(CrashDump.EnableDumping, section_crash_dump, EnableDumping);

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -36,6 +36,9 @@ Added custom game configurations for Abiotic Factor ([UE4SS #709](https://github
 
 Added custom game configurations for Psychonauts 2 ([UE4SS #731](https://github.com/UE4SS-RE/RE-UE4SS/pull/731)) 
 
+The GUI can now be rendered in the game thread if `RenderMode` in UE4SS-settings.ini is set to
+`GameViewportClientTick` ([UE4SS #768](https://github.com/UE4SS-RE/RE-UE4SS/pull/768)).
+
 ### Live View 
 Added search filter: `IncludeClassNames`. ([UE4SS #472](https://github.com/UE4SS-RE/RE-UE4SS/pull/472)) - Buckminsterfullerene 
 
@@ -230,7 +233,10 @@ Fixed `LoadMod` function issue that variables would go out-of-scope in the `Exec
 [EngineVersionOverride]
 ; True if the game is built as Debug, Development, or Test.
 ; Default: false
-DebugBuild = 
+DebugBuild =
+
+[Debug]
+RenderMode = ExternalThread
 
 [Hooks]
 HookLoadMap = 1

--- a/assets/UE4SS-settings.ini
+++ b/assets/UE4SS-settings.ini
@@ -100,6 +100,13 @@ GuiConsoleFontScaling = 1
 ; Default: opengl
 GraphicsAPI = opengl
 
+; The method with which the GUI will be rendered.
+; Valid values (case-insensitive):
+; ExternalThread: A separate thread will be used.
+; GameViewportClientTick: The UGameViewportClient::Tick function will be used.
+; Default: ExternalThread
+RenderMode = ExternalThread
+
 [Threads]
 ; The number of threads that the sig scanner will use (not real cpu threads, can be over your physical & hyperthreading max)
 ; If the game is modular then multi-threading will always be off regardless of the settings in this file
@@ -130,6 +137,7 @@ HookCallFunctionByNameWithArguments = 1
 HookBeginPlay  = 1
 HookLocalPlayerExec = 1
 HookAActorTick = 1
+HookGameViewportClientTick = 1
 FExecVTableOffsetInLocalPlayer = 0x28
 
 [CrashDump]


### PR DESCRIPTION
**Description**

This PR adds an option to render the GUI in the game thread.
The default is still to render in its own GUI thread.
To turn on game thread rendering, set `RenderMode` in UE4SS-settings.ini to `GameViewportClientTick` in the `[Debug]` section.

Fixes #764 

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

With RenderMode set to `GameViewportClientTick`, start the game, make sure the GUI opens, and use CTRL + O to close it and again to open it.
Repeat with `RenderMode` set to `ExternalThread`.

**Checklist**

- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.

**Additional context**

This needs to be tested for a bunch of games, and ideally by more than one person.
