### PR TITLE
Added C++/Lua hooks for AActor::Endplay

### DIFF
--- a/UE4SS/include/Mod/LuaMod.hpp
+++ b/UE4SS/include/Mod/LuaMod.hpp
@@ -112,6 +112,8 @@ namespace RC
         static inline std::vector<LuaCallbackData> m_init_game_state_post_callbacks{};
         static inline std::vector<LuaCallbackData> m_begin_play_pre_callbacks{};
         static inline std::vector<LuaCallbackData> m_begin_play_post_callbacks{};
+        static inline std::vector<LuaCallbackData> m_end_play_pre_callbacks{};
+        static inline std::vector<LuaCallbackData> m_end_play_post_callbacks{};
         static inline std::unordered_map<StringType, LuaCallbackData> m_script_hook_callbacks{};
         static inline std::unordered_map<int32_t, int32_t> m_generic_hook_id_to_native_hook_id{};
         // Generic hook ids are generated incrementally so the first one is 0 and the next one is always +1 from the last id.

--- a/UE4SS/include/SettingsManager.hpp
+++ b/UE4SS/include/SettingsManager.hpp
@@ -91,6 +91,7 @@ namespace RC
             bool HookLoadMap{true};
             bool HookCallFunctionByNameWithArguments{true};
             bool HookBeginPlay{true};
+            bool HookEndPlay{true};
             bool HookLocalPlayerExec{true};
             bool HookAActorTick{true};
             bool HookGameViewportClientTick{true};

--- a/UE4SS/src/SettingsManager.cpp
+++ b/UE4SS/src/SettingsManager.cpp
@@ -123,6 +123,7 @@ namespace RC
         REGISTER_BOOL_SETTING(Hooks.HookInitGameState, section_hooks, HookInitGameState)
         REGISTER_BOOL_SETTING(Hooks.HookCallFunctionByNameWithArguments, section_hooks, HookCallFunctionByNameWithArguments)
         REGISTER_BOOL_SETTING(Hooks.HookBeginPlay, section_hooks, HookBeginPlay)
+        REGISTER_BOOL_SETTING(Hooks.HookEndPlay, section_hooks, HookEndPlay)
         REGISTER_BOOL_SETTING(Hooks.HookLocalPlayerExec, section_hooks, HookLocalPlayerExec)
         REGISTER_BOOL_SETTING(Hooks.HookAActorTick, section_hooks, HookAActorTick)
         REGISTER_BOOL_SETTING(Hooks.HookGameViewportClientTick, section_hooks, HookGameViewportClientTick)

--- a/UE4SS/src/UE4SSProgram.cpp
+++ b/UE4SS/src/UE4SSProgram.cpp
@@ -775,6 +775,7 @@ namespace RC
         config.bHookInitGameState = settings_manager.Hooks.HookInitGameState;
         config.bHookCallFunctionByNameWithArguments = settings_manager.Hooks.HookCallFunctionByNameWithArguments;
         config.bHookBeginPlay = settings_manager.Hooks.HookBeginPlay;
+        config.bHookEndPlay = settings_manager.Hooks.HookEndPlay;
         config.bHookLocalPlayerExec = settings_manager.Hooks.HookLocalPlayerExec;
         config.bHookAActorTick = settings_manager.Hooks.HookAActorTick;
         config.bHookGameViewportClientTick = settings_manager.Hooks.HookGameViewportClientTick;

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -50,7 +50,10 @@ Added global function `CreateInvalidObject`, which returns an invalid UObject. (
 
 Added GenerateLuaTypes function. ([UE4SS #664](https://github.com/UE4SS-RE/RE-UE4SS/pull/664))  
 
-Added global Dumpers functions to Types.lua. ([UE4SS #664](https://github.com/UE4SS-RE/RE-UE4SS/pull/664))  
+Added global Dumpers functions to Types.lua. ([UE4SS #664](https://github.com/UE4SS-RE/RE-UE4SS/pull/664))
+
+Added global functions `RegisterEndPlayPreHook` and
+`RegisterEndPlayPostHook`. ([UE4SS #769](https://github.com/UE4SS-RE/RE-UE4SS/pull/769))
 
 #### Types.lua [PR #650](https://github.com/UE4SS-RE/RE-UE4SS/pull/650) 
 - Added `NAME_None` definition 
@@ -94,6 +97,8 @@ Added `OpenFor::ReadWrite`, to be used when calling `File::open`.
 This can be used when calling `FileHandle::memory_map`, unlike `OpenFor::Writing`.  ([UE4SS #507](https://github.com/UE4SS-RE/RE-UE4SS/pull/507)) 
 
 Added hook for `UGameViewportClient::Tick`. ([UE4SS #767](https://github.com/UE4SS-RE/RE-UE4SS/pull/767))
+
+Added hook for `AActor::EndPlay`. ([UE4SS #769](https://github.com/UE4SS-RE/RE-UE4SS/pull/769))
 
 ### BPModLoader 
 


### PR DESCRIPTION
**Description**

This PR adds hooks accessible via both Lua and C++ for `AActor::EndPlay`, in the same way that we have `AActor::BeginPlay`.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

Make a Lua mod, register an EndPlay hook that prints the object name.
Start a game, load some save files, and quit.
Open UE4SS.log and make sure the output is correct.

**Checklist**

- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
- [ ] Any dependent changes have been merged and published in downstream modules.

**Additional context**

This may not be merged until #768 is merged.
If #768 doesn't get merged, this PR must be rebased onto main.
