### PR TITLE
Fixed crash when using RegisterLoadMapPreHook from Lua

### DIFF
--- a/UE4SS/src/Mod/LuaMod.cpp
+++ b/UE4SS/src/Mod/LuaMod.cpp
@@ -3699,11 +3699,11 @@ Overloads:
                             lua.registry().get_function_ref(registry_index.lua_index);
                             static auto s_object_property_name = Unreal::FName(STR("ObjectProperty"));
                             LuaType::RemoteUnrealParam::construct(lua, &Engine, s_object_property_name);
-                            LuaType::RemoteUnrealParam::construct(lua, WorldContext.GetThisCurrentWorld().UnderlyingObjectPointer, s_object_property_name);
+                            LuaType::RemoteUnrealParam::construct(lua, &WorldContext.GetThisCurrentWorld().UnderlyingObjectPointer, s_object_property_name);
                             LuaType::FURL::construct(lua, URL);
-                            LuaType::RemoteUnrealParam::construct(lua, PendingGame, s_object_property_name);
+                            LuaType::RemoteUnrealParam::construct(lua, &PendingGame, s_object_property_name);
                             callback_data.lua.set_string(to_string(Error.GetCharArray()));
-                            lua.call_function(4, 1);
+                            lua.call_function(5, 1);
 
                             if (callback_data.lua.is_nil())
                             {

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -210,6 +210,8 @@ Fixed `FindFirstOf` return type annotation in `Types.lua` to signal that the ret
 
 Fixed non-const TArray outparams being skipped in UFunction property pushers. ([UE4SS #754](https://github.com/UE4SS-RE/RE-UE4SS/pull/754))
 
+Fixed `RegisterLoadMapPreHook` not working at all. ([UE4SS #776](https://github.com/UE4SS-RE/RE-UE4SS/pull/776))
+
 Fixed `Key::NUM_ZERO` being incorrectly mapped to
 `Key::NUM_NINE`. ([UE4SS #762](https://github.com/UE4SS-RE/RE-UE4SS/pull/762))
 


### PR DESCRIPTION
**Description**

There were mistakes in the code processing Lua pre-hooks for LoadMap, this PR fixes those mistakes.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

By using `RegisterLoadMapPreHook` and verifying that it works.

**Checklist**

- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
- [ ] Any dependent changes have been merged and published in downstream modules.

**Additional context**

Wait for #768, #769, and #771, or rebase/cherry-pick before merging.
