### PR TITLE
GuiConsoleEnabled is now set to 0 by default in non-dev releases

### DIFF
--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -114,6 +114,9 @@ Updated PatternSleuth submodule ([UE4SS #638](https://github.com/UE4SS-RE/RE-UE4
 
 The `bUseUObjectArrayCache` option in UE4SS-settings.ini is now set to false by default in the non-zDev release ([UE4SS #747](https://github.com/UE4SS-RE/RE-UE4SS/pull/747)) 
 
+The `GuiConsoleEnabled` option in UE4SS-settings.ini is now set to 0 by default in the non-zDev
+release ([UE4SS #779](https://github.com/UE4SS-RE/RE-UE4SS/pull/779))
+
 ### Live View 
 Fixed the majority of the lag ([UE4SS #512](https://github.com/UE4SS-RE/RE-UE4SS/pull/512)) 
 

--- a/tools/buildscripts/release.py
+++ b/tools/buildscripts/release.py
@@ -41,6 +41,7 @@ class ReleaseHandler:
         # Settings to change in the release. The default settings in assets/UE4SS-settings.ini are for dev
         self.settings_to_modify_in_release = {
             'GuiConsoleVisible': 0,
+            'GuiConsoleEnabled': 0,
             'ConsoleEnabled': 0,
             'EnableHotReloadSystem': 0,
             'MaxMemoryUsageDuringAssetLoading': 80,


### PR DESCRIPTION
**Description**

It being set to 1 wasn't providing any benefit, and could cause performance problems

**Type of change**

- [x] Other... Please describe: Packaging update

**Checklist**

- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.