### PR TITLE
Added missing glfw cleanup calls

### DIFF
--- a/UE4SS/src/GUI/GLFW3_OpenGL3.cpp
+++ b/UE4SS/src/GUI/GLFW3_OpenGL3.cpp
@@ -86,6 +86,8 @@ namespace RC::GUI
 
     auto Backend_GLFW3_OpenGL3::cleanup() -> void
     {
+        glfwDestroyWindow(m_window);
+        glfwTerminate();
     }
 
     auto Backend_GLFW3_OpenGL3::create_device() -> bool

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -184,6 +184,9 @@ Fixed `ModsFolderPath` in `UE4SS-settings.ini` not working ([UE4SS #609](https:/
 
 Fixed `attempt to index a nil value (global 'NewController')` error in `SplitScreenMod` ([UE4SS #729](https://github.com/UE4SS-RE/RE-UE4SS/pull/729)) 
 
+Fixed the GUI not closing properly with CTRL + O when OpenGL is enabled in
+`UE4SS-settings.ini`. ([UE4SS #780](https://github.com/UE4SS-RE/RE-UE4SS/pull/780))
+
 ### Live View 
 Fixed the "Write to file" checkbox not working for functions in the `Watches` tab ([UE4SS #419](https://github.com/UE4SS-RE/RE-UE4SS/pull/419)) 
 


### PR DESCRIPTION
**Description**

This fixes the GUI not closing when CTRL + O is hit.
Fixes # (issue) (if applicable)

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

Hit CTRL + O a bunch and verify that only one window ever exists.

**Checklist**

- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.