### PR TITLE
[lua-tmap] fix: mapproperty pusher lua stack usage

### DIFF
--- a/UE4SS/src/LuaType/LuaUObject.cpp
+++ b/UE4SS/src/LuaType/LuaUObject.cpp
@@ -922,8 +922,7 @@ namespace RC::LuaType
                                            .lua = params.lua,
                                            .base = static_cast<Unreal::UObject*>(map->GetData(0, info.layout)),
                                            .data = map->GetData(added_index, info.layout),
-                                           .property = nullptr,
-                                           .stored_at_index = 1};
+                                           .property = nullptr};
 
                 Unreal::FMemory::Memzero(pusher_params.data, info.layout.SetLayout.Size);
 
@@ -932,7 +931,6 @@ namespace RC::LuaType
 
                 pusher_params.data = static_cast<uint8_t*>(pusher_params.data) + info.layout.ValueOffset;
                 pusher_params.property = info.value;
-                pusher_params.stored_at_index = 2;
                 StaticState::m_property_value_pushers[static_cast<int32_t>(info.value_fname.GetComparisonIndex())](pusher_params);
 
                 return false;


### PR DESCRIPTION
## Description

[`lua-tmap`](https://github.com/UE4SS-RE/RE-UE4SS/tree/lua-tmap) branch.

Pusher params should use lua stack index 0.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<details>
<summary>Test code</summary>

```lua
-- int32 Map_Length(const TMap<int32, int32>& TargetMap);
RegisterHook("/Script/Engine.BlueprintMapLibrary:Map_Length", function (_, _map)
    print(">> Map_Length call")
    local map = _map:get()

    print("Len is ", #map)
    map:ForEach(function(k,v)
        print(" >>> ", k:get(), v:get())
    end)

    print("<< Map_Length")
    print()
end)

ExecuteInGameThread(function()
    local kml = StaticFindObject("/Script/Engine.Default__BlueprintMapLibrary")

    local map = { [7] = 77, [4] = 44, [9] = 99, [1] = 11 }
    kml:Map_Length(map)

--[[
struct FPoseData
{
    TArray<FTransform> LocalSpacePose;                                                // 0x0000 (size: 0x10)
    TMap<int32, int32> TrackToBufferIndex;                                            // 0x0010 (size: 0x50)
    TArray<float> CurveData;                                                          // 0x0060 (size: 0x10)

}; // Size: 0x70

struct FPoseDataContainer
{
    TArray<FSmartName> PoseNames;                                                     // 0x0000 (size: 0x10)
    TArray<FName> Tracks;                                                             // 0x0010 (size: 0x10)
    TMap<FName, int32> TrackMap;                                                      // 0x0020 (size: 0x50)
    TArray<FPoseData> Poses;                                                          // 0x0070 (size: 0x10)
    TArray<FAnimCurveBase> Curves;                                                    // 0x0080 (size: 0x10)

}; // Size: 0x90
]]

    local pacl = StaticFindObject("/Script/Engine.PoseAsset")
    local world = require "UEHelpers".GetWorld()

    local pa =  StaticConstructObject(pacl, world)

    pa.PoseContainer.TrackMap = {
        [FName("Key010")] = 1,
        [FName("Key040")] = 4,
        [FName("Key100")] = 10,
        [FName("Key400")] = 40,
    }

    print("Type of TrackMap: " .. tostring(pa.PoseContainer.TrackMap))
    pa.PoseContainer.TrackMap:ForEach(function(k,v)
        print(" >>> ", k:get():ToString(), v:get())
    end)

    pa.PoseContainer.Poses[1] = {}
    pa.PoseContainer.Poses[1].TrackToBufferIndex = map
    pa.PoseContainer.Poses[1].CurveData = {4, 5}

    print("Type of TrackToBufferIndex: " .. tostring(pa.PoseContainer.Poses[1].TrackToBufferIndex))
    pa.PoseContainer.Poses[1].TrackToBufferIndex:ForEach(function(k,v)
        print(" >>> ", k:get(), v:get())
    end)
end)
```

</details>

## Screenshots (if appropriate)

**Before:**
![lyrth_080225_WDP2Q0ujXN](https://github.com/user-attachments/assets/abdef776-0752-41ce-840c-daf7350a22ed)
![lyrth_080225_UuEh0hh6vy](https://github.com/user-attachments/assets/700a182b-4167-4bf0-adf6-24acac09a697)

**After:**
![lyrth_080225_fNGEqTvcFG](https://github.com/user-attachments/assets/97ef663c-7e98-4ce2-a723-b8355cc8c8fe)
![lyrth_080225_sSfhQks0Hc](https://github.com/user-attachments/assets/1add79df-4d27-4323-a671-8d2815b8ae04)
