### PR TITLE
Add UE method for handling key binds

### DIFF
--- a/UE4SS/include/SettingsManager.hpp
+++ b/UE4SS/include/SettingsManager.hpp
@@ -9,6 +9,13 @@
 
 namespace RC
 {
+    enum class KeyBindSystem
+    {
+        V1,
+        V2,
+        Count,
+    };
+
     class RC_UE4SS_API SettingsManager
     {
       public:
@@ -25,6 +32,7 @@ namespace RC
             bool EnableDebugKeyBindings{false};
             int64_t SecondsToScanBeforeGivingUp{30};
             bool UseUObjectArrayCache{true};
+            KeyBindSystem KeyBindSystem{};
         } General;
 
         struct SectionEngineVersionOverride

--- a/UE4SS/include/UE4SSProgram.hpp
+++ b/UE4SS/include/UE4SSProgram.hpp
@@ -192,6 +192,7 @@ namespace RC
         auto share_lua_functions() -> void;
         auto on_program_start() -> void;
         auto setup_unreal_properties() -> void;
+        auto handle_toggle_gui() -> void;
 
       protected:
         auto update() -> void;
@@ -323,5 +324,6 @@ namespace RC
         friend void* HookedLoadLibraryW(const wchar_t* dll_name);
         friend void* HookedLoadLibraryExW(const wchar_t* dll_name, void* file, int32_t flags);
         friend auto render_gui_from_game_thread() -> void;
+        friend auto process_keybinds_from_game_thread(Unreal::UGameViewportClient*) -> void;
     };
 } // namespace RC

--- a/UE4SS/include/UE4SSProgram.hpp
+++ b/UE4SS/include/UE4SSProgram.hpp
@@ -322,6 +322,6 @@ namespace RC
         friend void* HookedLoadLibraryExA(const char* dll_name, void* file, int32_t flags);
         friend void* HookedLoadLibraryW(const wchar_t* dll_name);
         friend void* HookedLoadLibraryExW(const wchar_t* dll_name, void* file, int32_t flags);
-        friend auto gui_render_thread_GameViewportClientTick(Unreal::UGameViewportClient*, float) -> void;
+        friend auto render_gui_from_game_thread() -> void;
     };
 } // namespace RC

--- a/UE4SS/src/SettingsManager.cpp
+++ b/UE4SS/src/SettingsManager.cpp
@@ -57,6 +57,16 @@ namespace RC
         REGISTER_BOOL_SETTING(General.EnableDebugKeyBindings, section_general, EnableDebugKeyBindings)
         REGISTER_INT64_SETTING(General.SecondsToScanBeforeGivingUp, section_general, SecondsToScanBeforeGivingUp)
         REGISTER_BOOL_SETTING(General.UseUObjectArrayCache, section_general, bUseUObjectArrayCache)
+        int64_t KeyBindSystem_as_int64{};
+        REGISTER_INT64_SETTING(KeyBindSystem_as_int64, section_general, KeyBindSystem)
+        if (KeyBindSystem_as_int64 < 0 || KeyBindSystem_as_int64 >= static_cast<std::underlying_type_t<KeyBindSystem>>(KeyBindSystem::Count))
+        {
+            General.KeyBindSystem = KeyBindSystem::V1;
+        }
+        else
+        {
+            General.KeyBindSystem = static_cast<KeyBindSystem>(KeyBindSystem_as_int64);
+        }
 
         constexpr static File::CharType section_engine_version_override[] = STR("EngineVersionOverride");
         REGISTER_INT64_SETTING(EngineVersionOverride.MajorVersion, section_engine_version_override, MajorVersion)

--- a/UE4SS/src/UE4SSProgram.cpp
+++ b/UE4SS/src/UE4SSProgram.cpp
@@ -868,14 +868,9 @@ namespace RC
         UE4SSProgram::get_program().get_debugging_ui().main_loop_internal();
     }
 
-    auto post_GameViewportClientTick(Unreal::UGameViewportClient* ViewportClient, float) -> void
+    auto process_keybinds_from_game_thread(Unreal::UGameViewportClient* ViewportClient) -> void
     {
         using namespace ::RC::Unreal;
-        if (UE4SSProgram::settings_manager.Debug.RenderMode == GUI::RenderMode::GameViewportClientTick)
-        {
-            render_gui_from_game_thread();
-        }
-
         // We're making an assumption here that the following is always valid: GameInstance->LocalPlayers[0]->PlayerController
         // TODO: Check if the 'LocalPlayers' array has players on servers.
         auto GameInstance = ViewportClient->GetValuePtrByPropertyNameInChain<UObject*>(STR("GameInstance"));
@@ -885,6 +880,19 @@ namespace RC
         if (PlayerController->WasInputKeyJustPressed(FKey{FName(STR("SpaceBar"))}))
         {
             Output::send(STR("Space hit\n"));
+        }
+    }
+
+    auto post_GameViewportClientTick(Unreal::UGameViewportClient* ViewportClient, float) -> void
+    {
+        if (UE4SSProgram::settings_manager.Debug.RenderMode == GUI::RenderMode::GameViewportClientTick)
+        {
+            render_gui_from_game_thread();
+        }
+
+        if (UE4SSProgram::settings_manager.General.KeyBindSystem == KeyBindSystem::V2)
+        {
+            process_keybinds_from_game_thread(ViewportClient);
         }
     }
 

--- a/assets/UE4SS-settings.ini
+++ b/assets/UE4SS-settings.ini
@@ -23,6 +23,12 @@ SecondsToScanBeforeGivingUp = 30
 ; Default: true
 bUseUObjectArrayCache = true
 
+; Which system should be used to process key binds.
+; 0 = In-house system (will eventually get deprecated)
+; 1 = UE built-in system
+; Default: 0
+KeyBindSystem = 0
+
 [EngineVersionOverride]
 MajorVersion = 
 MinorVersion = 


### PR DESCRIPTION
**Description**

Note: This is a very early draft! It will change a lot, and might not be merged in the end, we'll see how it goes.

This PR adds UEs own input handling as a method we can use for our own key binds.
The system uses two reflected functions: `APlayerController::IsInputKeyDown` and `APlayerController::WasInputKeyJustPressed`.

The reasons why it doesn't replace our own system entirely: I don't know if every game has the necessary functions.
If the new system is battle tested and works in all games, we can drop our own system.
Otherwise, we'll need to keep our own system still as a fallback.

Reasons for  replacing our current system:
1. Cross-platform support with no effort, and very low maintenance burden.
2. Culling of most of the `Input` dependency, which is an old homegrown solution that I wouldn't recommend to anyone.

Initial goals:
1. Implement the new system side-by-side with the old system.
2. To not break existing code, the new system should route through our existing `register_keydown_event` functions, and there may need to be some small wrappers in the `Input` namespace.

Performance impact has not been tested.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**Checklist**

- [ ] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.