### PR TITLE
Custom game configurations for Lies of P

### DIFF
--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -36,6 +36,8 @@ Added custom game configurations for Abiotic Factor ([UE4SS #709](https://github
 
 Added custom game configurations for Psychonauts 2 ([UE4SS #731](https://github.com/UE4SS-RE/RE-UE4SS/pull/731)) 
 
+Added custom game configurations for Lies of P ([UE4SS #787](https://github.com/UE4SS-RE/RE-UE4SS/pull/787))
+
 The GUI can now be rendered in the game thread if `RenderMode` in UE4SS-settings.ini is set to
 `GameViewportClientTick` ([UE4SS #768](https://github.com/UE4SS-RE/RE-UE4SS/pull/768)).
 

--- a/assets/CustomGameConfigs/Lies of P/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Lies of P/UE4SS-settings.ini
@@ -1,0 +1,142 @@
+﻿[Overrides]
+; Path to the 'Mods' folder
+; Default: <dll_directory>/Mods
+ModsFolderPath =
+
+[General]
+EnableHotReloadSystem = 0
+
+; Whether the cache system for AOBs will be used.
+; Default: 1
+UseCache = 1
+
+; Whether caches will be invalidated if ue4ss.dll has changed
+; Default: 1
+InvalidateCacheIfDLLDiffers = 1
+
+; The number of seconds the scanner will scan for before giving up
+; Default: 30
+SecondsToScanBeforeGivingUp = 30
+
+; Whether to create UObject listeners in GUObjectArray to create a fast cache for use instead of iterating GUObjectArray.
+; Setting this to false can help if you're experiencing a crash on startup.
+; Default: true
+bUseUObjectArrayCache = false
+
+[EngineVersionOverride]
+MajorVersion = 4
+MinorVersion = 27
+; True if the game is built as Debug, Development, or Test.
+; Default: false
+DebugBuild = 
+
+[ObjectDumper]
+; Whether to force all assets to be loaded before dumping objects
+; WARNING: Can require multiple gigabytes of extra memory
+; WARNING: Is not stable & will crash the game if you load past the main menu after dumping
+; Default: 0
+LoadAllAssetsBeforeDumpingObjects = 0
+
+[CXXHeaderGenerator]
+; Whether to property offsets and sizes
+; Default: 1
+DumpOffsetsAndSizes = 1
+
+; Whether memory layouts of classes and structs should be accurate
+; This must be set to 1, if you want to use the generated headers in an actual C++ project
+; When set to 0, padding member variables will not be generated
+; NOTE: A VALUE OF 1 HAS NO PURPOSE YET! MEMORY LAYOUT IS NOT ACCURATE EITHER WAY!
+; Default: 0
+KeepMemoryLayout = 0
+
+; Whether to force all assets to be loaded before generating headers
+; WARNING: Can require multiple gigabytes of extra memory
+; WARNING: Is not stable & will crash the game if you load past the main menu after dumping
+; Default: 0
+LoadAllAssetsBeforeGeneratingCXXHeaders = 0
+
+[UHTHeaderGenerator]
+; Whether to skip generating packages that belong to the engine
+; Some games make alterations to the engine and for those games you might want to set this to 0
+; Default: 0
+IgnoreAllCoreEngineModules = 0
+
+; Whether to skip generating the "Engine" and "CoreUObject" packages
+; Default: 0
+IgnoreEngineAndCoreUObject = 0
+
+; Whether to force all UFUNCTION macros to have "BlueprintCallable"
+; Note: This will cause some errors in the generated headers that you will need to manually fix
+; Default: 1
+MakeAllFunctionsBlueprintCallable = 1
+
+; Whether to force all UPROPERTY macros to have "BlueprintReadWrite"
+; Also forces all UPROPERTY macros to have "meta=(AllowPrivateAccess=true)"
+; Default: 1
+MakeAllPropertyBlueprintsReadWrite = 1
+
+; Whether to force UENUM macros on enums to have 'BlueprintType' if the underlying type was implicit or uint8
+; Note: This also forces the underlying type to be uint8 where the type would otherwise be implicit
+; Default: 1
+MakeEnumClassesBlueprintType = 1
+
+; Whether to force "Config = Engine" on all UCLASS macros that use either one of:
+; "DefaultConfig", "GlobalUserConfig" or "ProjectUserConfig"
+; Default: 1
+MakeAllConfigsEngineConfig = 1
+
+[Debug]
+; Whether to enable the external UE4SS debug console.
+ConsoleEnabled = 0
+GuiConsoleEnabled = 0
+GuiConsoleVisible = 0
+
+; Multiplier for Font Size within the Debug Gui
+; Default: 1
+GuiConsoleFontScaling = 1.2
+
+; The API that will be used to render the GUI debug window.
+; Valid values (case-insensitive): dx11, d3d11, opengl
+; Default: opengl
+GraphicsAPI = dx11
+
+[Threads]
+; The number of threads that the sig scanner will use (not real cpu threads, can be over your physical & hyperthreading max)
+; If the game is modular then multi-threading will always be off regardless of the settings in this file
+; Min: 1
+; Max: 4294967295
+; Default: 8
+SigScannerNumThreads = 8
+
+; The minimum size that a module has to be in order for multi-threading to be enabled
+; This should be large enough so that the cost of creating threads won't out-weigh the speed gained from scanning in multiple threads
+; Min: 0
+; Max: 4294967295
+; Default: 16777216
+SigScannerMultithreadingModuleSizeThreshold = 16777216
+
+[Memory]
+; The maximum memory usage (in percentage, see Task Manager %) allowed before asset loading (when LoadAllAssetsBefore* is 1) cannot happen.
+; Once this percentage is reached, the asset loader will stop loading and whatever operation was in progress (object dump, or cxx generator) will continue.
+; Default: 85
+MaxMemoryUsageDuringAssetLoading = 80
+
+[Hooks]
+HookProcessInternal = 1
+HookProcessLocalScriptFunction = 1
+HookInitGameState = 1
+HookLoadMap = 1
+HookCallFunctionByNameWithArguments = 1
+HookBeginPlay  = 1
+HookLocalPlayerExec = 1
+HookAActorTick = 1
+HookGameViewportClientTick = 1
+FExecVTableOffsetInLocalPlayer = 0x28
+
+[CrashDump]
+EnableDumping = 1
+FullMemoryDump = 0
+
+[ExperimentalFeatures]
+; Only enable these features if you know what you are doing.
+GUIUFunctionCaller = 0

--- a/assets/CustomGameConfigs/Lies of P/UE4SS_Signatures/FText_Constructor.lua
+++ b/assets/CustomGameConfigs/Lies of P/UE4SS_Signatures/FText_Constructor.lua
@@ -1,0 +1,7 @@
+function Register()
+    return "48 89 5C 24 ?? 48 89 6C 24 ?? 56 57 41 54 41 56 41 57 48 83 EC ?? 45 33 E4 48 8B F1 48 8B 0D"
+end
+
+function OnMatchFound(MatchAddress)
+    return MatchAddress
+end

--- a/assets/CustomGameConfigs/Lies of P/UE4SS_Signatures/StaticConstructObject.lua
+++ b/assets/CustomGameConfigs/Lies of P/UE4SS_Signatures/StaticConstructObject.lua
@@ -1,0 +1,10 @@
+function Register()
+    return "48 89 ?? 24 30 89 ?? 24 38 E8 ?? ?? ?? ?? 48 ?? ?? 24 70 48 ?? ?? 24 78"
+end
+
+function OnMatchFound(MatchAddress)
+    local NextInstr = MatchAddress + 14
+    local Offset = MatchAddress + 10
+    local AddressLoaded = NextInstr + DerefToInt32(Offset)
+    return AddressLoaded
+end


### PR DESCRIPTION
**Description**
Patternsleuth detects the game as UE 4.26 while it's actually 4.27.  
StaticConstructObject doesn't match and while FText constructor works, it finds multiple addresses in some versions of the game.  
These changes solve these problems.
