### PR TITLE
Add FText function description to Types.lua and rewrite description in Docs

### DIFF
--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -80,6 +80,8 @@ Added global functions `RegisterEndPlayPreHook` and
   
 - Added functions `GetAllPlayerStates` and `GetAllPlayers` [PR #688](https://github.com/UE4SS-RE/RE-UE4SS/pull/688) 
 
+- Added annotation for function `FText` to Types.lua. ([UE4SS #788](https://github.com/UE4SS-RE/RE-UE4SS/pull/788))
+
 ### C++ API 
 Key binds created with `UE4SSProgram::register_keydown_event` end up being duplicated upon mod hot-reload.  
 

--- a/assets/Mods/shared/Types.lua
+++ b/assets/Mods/shared/Types.lua
@@ -400,6 +400,11 @@ function FName(Name, FindType) end
 ---@return FName
 function FName(ComparisonIndex, FindType) end
 
+---Returns a new FText object with passed string as content
+---@param Text string
+---@return FText
+function FText(Text) end
+
 ---Attempts to construct a UObject of the passed UClass
 ---(>=4.26) Maps to https://docs.unrealengine.com/4.27/en-US/API/Runtime/CoreUObject/UObject/StaticConstructObject_Internal/1/
 ---(<4.25) Maps to https://docs.unrealengine.com/4.27/en-US/API/Runtime/CoreUObject/UObject/StaticConstructObject_Internal/2/

--- a/docs/lua-api/global-functions/ftext.md
+++ b/docs/lua-api/global-functions/ftext.md
@@ -1,27 +1,34 @@
 # FText
 
-The `FText` function is used to get an `FText` representation of a `string`.
+The `FText` function is used to create a `FText` object from a `string`.
 
 Useful when you have to interact with `UserWidget`-related classes for the UI of your mods, and call their `SetText(FText("My New Text"))` methods.
 
 ## Parameters (overload #1)
 
-This overload mimics [FText::FText( FString&& InSourceString )](https://docs.unrealengine.com/4.27/en-US/API/Runtime/Core/Internationalization/FText/__ctor/6/).
+This overload uses [FText::FText( FString&& InSourceString )](https://docs.unrealengine.com/4.27/en-US/API/Runtime/Core/Internationalization/FText/__ctor/6/) to create a new `FText` object.
 
-| # | Type     | Information |
-|---|----------|-------------|
-| 1 | string   | String that you'd like to get an FText representation of |
+ # | Type     | Information 
+---|----------|-------------
+ 1 | string   | Content with which FText will to be created
 
 ## Return Value
 
-| # | Type  | Information |
-|---|-------|-------------|
-| 1 | FText | FText representation of incoming `string`|
+ # | Type  | Information 
+---|-------|-------------
+ 1 | FText | FText object that contains the passed `string`|
 
 ## Example
-
+Code:
 ```lua
-local some_text = FText("MyText")
-
-print(some_text) -- MyText
+local my_text = FText("My Text")
+print(string.format("Lua type: %s\n", type(my_text)))
+print(string.format("Object type: %s\n", my_text:type()))
+print(string.format("Content: %s\n", my_text:ToString()))
+```
+Output:
+```
+[Lua] Lua type: userdata
+[Lua] Object type: FText
+[Lua] Content: My Text
 ```

--- a/docs/lua-api/global-functions/ftext.md
+++ b/docs/lua-api/global-functions/ftext.md
@@ -1,6 +1,6 @@
 # FText
 
-The `FText` function is used to create a `FText` object from a `string`.
+The `FText` function is used to create an `FText` object from a `string`.
 
 Useful when you have to interact with `UserWidget`-related classes for the UI of your mods, and call their `SetText(FText("My New Text"))` methods.
 

--- a/docs/lua-api/global-functions/ftext.md
+++ b/docs/lua-api/global-functions/ftext.md
@@ -16,7 +16,7 @@ This overload uses [FText::FText( FString&& InSourceString )](https://docs.unrea
 
  # | Type  | Information 
 ---|-------|-------------
- 1 | FText | FText object that contains the passed `string`|
+ 1 | FText | FText object that contains the passed `string`
 
 ## Example
 Code:


### PR DESCRIPTION
**Description**
I've noticed that the example of the use of `FText` object in `FText` function documentation was wrong, and the description overall is weirdly worded ("FText representation").  
I fixed the example code and improved the description to make it easier to understand what the function does.  
At the same time `FText` function was missing in the `Types.lua`.