### PR TITLE
Add HookEngineTick setting and EngineTick as GUI RenderMode

### DIFF
--- a/UE4SS/include/GUI/GUI.hpp
+++ b/UE4SS/include/GUI/GUI.hpp
@@ -25,7 +25,8 @@ namespace RC::GUI
     enum class RenderMode
     {
         ExternalThread,
-        GameViewportClientTick,
+        EngineTick,
+        GameViewportClientTick
     };
 
     inline auto render_mode_to_string(RenderMode mode) -> std::string
@@ -34,6 +35,8 @@ namespace RC::GUI
         {
         case RenderMode::ExternalThread:
             return "ExternalThread";
+        case RenderMode::EngineTick:
+            return "EngineTick";
         case RenderMode::GameViewportClientTick:
             return "GameViewportClientTick";
         }

--- a/UE4SS/include/SettingsManager.hpp
+++ b/UE4SS/include/SettingsManager.hpp
@@ -94,6 +94,7 @@ namespace RC
             bool HookEndPlay{true};
             bool HookLocalPlayerExec{true};
             bool HookAActorTick{true};
+            bool HookEngineTick{true};
             bool HookGameViewportClientTick{true};
             int64_t FExecVTableOffsetInLocalPlayer{0x28};
         } Hooks;

--- a/UE4SS/include/UE4SSProgram.hpp
+++ b/UE4SS/include/UE4SSProgram.hpp
@@ -322,6 +322,6 @@ namespace RC
         friend void* HookedLoadLibraryExA(const char* dll_name, void* file, int32_t flags);
         friend void* HookedLoadLibraryW(const wchar_t* dll_name);
         friend void* HookedLoadLibraryExW(const wchar_t* dll_name, void* file, int32_t flags);
-        friend auto gui_render_thread_GameViewportClientTick(Unreal::UGameViewportClient*, float) -> void;
+        friend auto gui_render_thread_tick(Unreal::UObject*, float) -> void;
     };
 } // namespace RC

--- a/UE4SS/src/SettingsManager.cpp
+++ b/UE4SS/src/SettingsManager.cpp
@@ -100,6 +100,10 @@ namespace RC
         {
             Debug.RenderMode = GUI::RenderMode::ExternalThread;
         }
+        else if (String::iequal(render_mode_string, STR("EngineTick")))
+        {
+            Debug.RenderMode = GUI::RenderMode::EngineTick;
+        }
         else if (String::iequal(render_mode_string, STR("GameViewportClientTick")))
         {
             Debug.RenderMode = GUI::RenderMode::GameViewportClientTick;
@@ -126,6 +130,7 @@ namespace RC
         REGISTER_BOOL_SETTING(Hooks.HookEndPlay, section_hooks, HookEndPlay)
         REGISTER_BOOL_SETTING(Hooks.HookLocalPlayerExec, section_hooks, HookLocalPlayerExec)
         REGISTER_BOOL_SETTING(Hooks.HookAActorTick, section_hooks, HookAActorTick)
+        REGISTER_BOOL_SETTING(Hooks.HookEngineTick, section_hooks, HookEngineTick)
         REGISTER_BOOL_SETTING(Hooks.HookGameViewportClientTick, section_hooks, HookGameViewportClientTick)
         REGISTER_INT64_SETTING(Hooks.FExecVTableOffsetInLocalPlayer, section_hooks, FExecVTableOffsetInLocalPlayer)
 

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -39,7 +39,6 @@ Added custom game configurations for Psychonauts 2 ([UE4SS #731](https://github.
 The GUI can now be rendered in the game thread if `RenderMode` in UE4SS-settings.ini is set to
 `EngineTick` or `GameViewportClientTick` ([UE4SS #768](https://github.com/UE4SS-RE/RE-UE4SS/pull/768), [UE4SS #794](https://github.com/UE4SS-RE/RE-UE4SS/pull/794)).
 
-Added new setting `HookEngineTick` ([UE4SS #794](https://github.com/UE4SS-RE/RE-UE4SS/pull/794)).
 
 ### Live View 
 Added search filter: `IncludeClassNames`. ([UE4SS #472](https://github.com/UE4SS-RE/RE-UE4SS/pull/472)) - Buckminsterfullerene 

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -37,9 +37,7 @@ Added custom game configurations for Abiotic Factor ([UE4SS #709](https://github
 Added custom game configurations for Psychonauts 2 ([UE4SS #731](https://github.com/UE4SS-RE/RE-UE4SS/pull/731)) 
 
 The GUI can now be rendered in the game thread if `RenderMode` in UE4SS-settings.ini is set to
-`GameViewportClientTick` ([UE4SS #768](https://github.com/UE4SS-RE/RE-UE4SS/pull/768)).
-
-Added `EngineTick` `RenderMode` for the GUI ([UE4SS #794](https://github.com/UE4SS-RE/RE-UE4SS/pull/794)).
+`EngineTick` or `GameViewportClientTick` ([UE4SS #768](https://github.com/UE4SS-RE/RE-UE4SS/pull/768), [UE4SS #794](https://github.com/UE4SS-RE/RE-UE4SS/pull/794)).
 
 Added new setting `HookEngineTick` ([UE4SS #794](https://github.com/UE4SS-RE/RE-UE4SS/pull/794)).
 

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -39,6 +39,10 @@ Added custom game configurations for Psychonauts 2 ([UE4SS #731](https://github.
 The GUI can now be rendered in the game thread if `RenderMode` in UE4SS-settings.ini is set to
 `GameViewportClientTick` ([UE4SS #768](https://github.com/UE4SS-RE/RE-UE4SS/pull/768)).
 
+Added `EngineTick` `RenderMode` for the GUI ([UE4SS #794](https://github.com/UE4SS-RE/RE-UE4SS/pull/794)).
+
+Added new setting `HookEngineTick` ([UE4SS #794](https://github.com/UE4SS-RE/RE-UE4SS/pull/794)).
+
 ### Live View 
 Added search filter: `IncludeClassNames`. ([UE4SS #472](https://github.com/UE4SS-RE/RE-UE4SS/pull/472)) - Buckminsterfullerene 
 
@@ -264,6 +268,7 @@ RenderMode = ExternalThread
 [Hooks]
 HookLoadMap = 1
 HookAActorTick = 1
+HookEngineTick = 1
 HookGameViewportClientTick = 1
 ```
 

--- a/assets/UE4SS-settings.ini
+++ b/assets/UE4SS-settings.ini
@@ -103,6 +103,7 @@ GraphicsAPI = opengl
 ; The method with which the GUI will be rendered.
 ; Valid values (case-insensitive):
 ; ExternalThread: A separate thread will be used.
+; EngineTick: The UEngine::Tick function will be used.
 ; GameViewportClientTick: The UGameViewportClient::Tick function will be used.
 ; Default: ExternalThread
 RenderMode = ExternalThread
@@ -137,6 +138,7 @@ HookCallFunctionByNameWithArguments = 1
 HookBeginPlay  = 1
 HookLocalPlayerExec = 1
 HookAActorTick = 1
+HookEngineTick = 1
 HookGameViewportClientTick = 1
 FExecVTableOffsetInLocalPlayer = 0x28
 


### PR DESCRIPTION
**Description**
Similar to #768 where `GameViewportClientTick` was added as a new `RenderMode` for the GUI Tool, I've added `EngineTick`.
Additionally, I had to add `HookEngineTick` setting, as it wasn't a thing yet.  
I put `EngineTick` everywhere in front of `GameViewportClientTick` because I think it's more important. GameViewportClient doesn't exist on servers and with Engine::Tick implementation the hook might be obsolete in the future.

**How it was tested**
After setting `RenderMode = EngineTick`, I attached the debugger to the game at the start and made sure that `Engine::Tick` is used instead of `GameViewportClient::Tick`.  
Then I played around in the Live View like before and it worked well. At least as good as it usually works.
Additionally, I tested it in Dedicated Server and unlike `GameViewportClientTick` it works there as well! 🥳
The game in question is Abiotic Factor.
![AbioticFactor-Win64-Shipping_AhZ5iE1ids](https://github.com/user-attachments/assets/a548c01d-bc00-4509-a7bd-f63fae986c29)
