### PR TITLE
Performance improvements for script hooks

### DIFF
--- a/UE4SS/src/Mod/LuaMod.cpp
+++ b/UE4SS/src/Mod/LuaMod.cpp
@@ -2845,10 +2845,12 @@ Overloads:
                 // TODO: Redo when there's a bette way of checking whether a lua object is derived from UObject
                 if (lua_object_name == "UObject" || lua_object_name == "UWorld" || lua_object_name == "AActor" || lua_object_name == "UClass")
                 {
-                    if (lua_object_name == "UClass") {
+                    if (lua_object_name == "UClass")
+                    {
                         in_outer = lua.get_userdata<LuaType::UClass>().get_remote_cpp_object();
                     }
-                    else {
+                    else
+                    {
                         in_outer = lua.get_userdata<LuaType::UObject>().get_remote_cpp_object();
                     }
                     could_be_in_outer = true;

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -143,6 +143,8 @@ The callback of `NotifyOnNewObject` can now optionally return `true` to unregist
 
 **BREAKING:** `RegisterProcessConsoleExecPreHook`,  `RegisterProcessConsoleExecPostHook` callback parameter `CommandParts` now includes the command name at the start of the array (lua array index **1**). ([UE4SS #669](https://github.com/UE4SS-RE/RE-UE4SS/pull/669)) 
 
+Improved performance of script hooks created with `RegisterHook`, and
+`RegisterCustomEvent`. ([UE4SS #801](https://github.com/UE4SS-RE/RE-UE4SS/pull/801))
 
 #### UEHelpers [UE4SS #650](https://github.com/UE4SS-RE/RE-UE4SS/pull/650) 
 - Increased version to 3


### PR DESCRIPTION
**Description**

This PR improved the performance of script hooks.
We were calling `GetFullName` every time `ProcessLocalScriptFunction` (4.22+) or `ProcessInternal` (<4.22) was called.
This is an expensive operation and should be avoided whenever possible.
This PR gets rid of this call in favor of comparing the FName of each outer of the function.

**Type of change**

- [ ] Other... Please describe: Performance improvement

**How Has This Been Tested?**

I did a very basic script hook with `RegisterHook` in Lua.
Please do some testing to make sure this PR doesn't break stuff.

**Checklist**

- [ ] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.