### PR TITLE
Change Lua `AActor` class functions `GetWorld()` and `GetLevel()` to return an invalid `UObject` instead of `nil`

### DIFF
--- a/UE4SS/src/LuaType/LuaAActor.cpp
+++ b/UE4SS/src/LuaType/LuaAActor.cpp
@@ -53,31 +53,13 @@ namespace RC::LuaType
     {
         table.add_pair("GetWorld", [](const LuaMadeSimple::Lua& lua) -> int {
             const auto& lua_object = lua.get_userdata<AActor>();
-
-            if (Unreal::UWorld* world = lua_object.get_remote_cpp_object()->GetWorld(); world)
-            {
-                auto_construct_object(lua, world);
-            }
-            else
-            {
-                lua.set_nil();
-            }
-
+            auto_construct_object(lua, lua_object.get_remote_cpp_object()->GetWorld());
             return 1;
         });
 
         table.add_pair("GetLevel", [](const LuaMadeSimple::Lua& lua) -> int {
             const auto& lua_object = lua.get_userdata<AActor>();
-
-            if (Unreal::UObject* level = lua_object.get_remote_cpp_object()->GetLevel(); level)
-            {
-                auto_construct_object(lua, level);
-            }
-            else
-            {
-                lua.set_nil();
-            }
-
+            auto_construct_object(lua, lua_object.get_remote_cpp_object()->GetLevel());
             return 1;
         });
 

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -148,6 +148,8 @@ The callback of `NotifyOnNewObject` can now optionally return `true` to unregist
 Improved performance of script hooks created with `RegisterHook`, and
 `RegisterCustomEvent`. ([UE4SS #801](https://github.com/UE4SS-RE/RE-UE4SS/pull/801))
 
+**BREAKING:** `AActor:GetWorld()` and `AActor:GetLevel()` functions are now returning an invalid `UObject` instead of `nil`. ([UE4SS #810](https://github.com/UE4SS-RE/RE-UE4SS/pull/810)) 
+
 #### UEHelpers [UE4SS #650](https://github.com/UE4SS-RE/RE-UE4SS/pull/650) 
 - Increased version to 3
   

--- a/docs/lua-api/classes/aactor.md
+++ b/docs/lua-api/classes/aactor.md
@@ -6,9 +6,9 @@
 ## Methods
 
 ### GetWorld()
-- **Return types:** `UObject` | `nil`
-- **Returns:** the `UWorld` that this actor belongs to
+- **Return types:** `UObject`
+- **Returns:** the `UWorld` that this actor belongs to or an invalid `UObject`
 
 ### GetLevel()
-- **Return type:** `UObject` | `nil`
-- **Returns:** the `ULevel` that this actor belongs to
+- **Return type:** `UObject`
+- **Returns:** the `ULevel` that this actor belongs to or an invalid `UObject`


### PR DESCRIPTION
**Description**
- Changed Lua functions `GetWorld()` and `GetLevel()` from `AActor` class to always return an `UObject`. (Previously they would return a `nil` instead.)
- Updated AActor documentation to match changes
- Added the changes to the `Changelog.md`


**Type of change**
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Is/requires documentation update

**How Has This Been Tested?**

Added few log outputs to the `BPModLoaderMod` mod, which runs at the start of the game and finds an AActor which doesn't belong to a World or Level.  
Tested in game: **Avowed**
Code:  
```lua
ExecuteInGameThread(function()
    local ExistingActor = FindFirstOf("Actor")
    if ExistingActor:IsValid() then
        local world = ExistingActor:GetWorld()
        Log(string.format("GetWorld: %s\n", type(world)))
        Log(string.format("GetWorld type: %s\n", world:type()))
        Log(string.format("GetWorld:IsValid: %s\n", tostring(world:IsValid())))
        local level = ExistingActor:GetLevel()
        Log(string.format("GetLevel: %s\n", type(level)))
        Log(string.format("GetLevel type: %s\n", level:type()))
        Log(string.format("GetLevel:IsValid: %s\n", tostring(level:IsValid())))
        LoadMods(ExistingActor:GetWorld())
    end
end)
```
Result:
```
[17:44:19.9180541] [Lua] [BPModLoaderMod] GetWorld: userdata
[17:44:19.9180689] [Lua] [BPModLoaderMod] GetWorld type: UObject
[17:44:19.9180775] [Lua] [BPModLoaderMod] GetWorld:IsValid: false
[17:44:19.9180855] [Lua] [BPModLoaderMod] GetLevel: userdata
[17:44:19.9180916] [Lua] [BPModLoaderMod] GetLevel type: UObject
[17:44:19.9180976] [Lua] [BPModLoaderMod] GetLevel:IsValid: false
```

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
