### PR TITLE
Fix proxy_generator proxy being unbuildable due to uninitialized variable

### DIFF
--- a/UE4SS/proxy_generator/main.cpp
+++ b/UE4SS/proxy_generator/main.cpp
@@ -112,7 +112,7 @@ std::vector<ExportFunction> ReadExportsFile(const fs::path& exp_path, fs::path& 
     {
         std::istringstream s(line);
 
-        uint16_t ordinal;
+        uint16_t ordinal{};
         string export_name;
         s >> ordinal >> export_name;
 


### PR DESCRIPTION
## Description

Fixes "fatal error LNK1121: duplicate ordinal number '1'" when building the proxy, due to undefined behavior of `ordinal` variable if not set nor initialized.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

A user that had above fatal error on build has reported that the proxy has succeeded building after adding the change.

