### PR TITLE
Add Lua type definitions for UStruct and UClass

### DIFF
--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -66,6 +66,11 @@ Added global functions `RegisterEndPlayPreHook` and
 - Added `FName` function overloads with FindType parameter 
 - Added `TMap` definitions
 
+#### Types.lua [PR #820](https://github.com/UE4SS-RE/RE-UE4SS/pull/820)
+
+- Added `UStruct` definition
+- Added `UClass` definition
+
 #### UEHelpers 
 - Added function `GetPlayer` which is just a fast way to get player controlled Pawn (the majority of the time it will be the player character) [PR #650](https://github.com/UE4SS-RE/RE-UE4SS/pull/650)
   

--- a/assets/Mods/shared/Types.lua
+++ b/assets/Mods/shared/Types.lua
@@ -947,7 +947,7 @@ function UObject:type() end
 
 
 ---@class UStruct : UObject
-UStruct = {}
+local UStruct = {}
 
 ---Returns the SuperStruct of this struct (can be invalid).
 ---@return UClass
@@ -967,7 +967,7 @@ function UStruct:ForEachProperty(Callback) end
 
 
 ---@class UClass : UStruct
-UClass = {}
+local UClass = {}
 
 ---Returns the ClassDefaultObject of a UClass.
 ---@return UClass

--- a/assets/Mods/shared/Types.lua
+++ b/assets/Mods/shared/Types.lua
@@ -945,6 +945,40 @@ function UObject:ProcessConsoleExec(Cmd, Reserved, Executor) end
 ---@return string
 function UObject:type() end
 
+
+---@class UStruct : UObject
+UStruct = {}
+
+---Returns the SuperStruct of this struct (can be invalid).
+---@return UClass
+function UStruct:GetSuperStruct() end
+
+---Iterates every UFunction that belongs to this struct.
+---The callback has one param: UFunction Function.
+---Return true in the callback to stop iterating.
+---@param Callback fun(Function: UFunction): boolean?
+function UStruct:ForEachFunction(Callback) end
+
+---Iterates every Property that belongs to this struct.
+---The callback has one param: Property Property.
+---Return true in the callback to stop iterating.
+---@param Callback fun(Property: Property): boolean?
+function UStruct:ForEachProperty(Callback) end
+
+
+---@class UClass : UStruct
+UClass = {}
+
+---Returns the ClassDefaultObject of a UClass.
+---@return UClass
+function UClass:GetCDO() end
+
+---Returns whether or not the class is a child of another class.
+---@param Class UClass
+---@return boolean
+function UClass:IsChildOf(Class) end
+
+
 ---@class TArray<T> : { [integer]: T }
 local TArray = {}
 


### PR DESCRIPTION
**Description**

Adds the missing, but documented, `UStruct` and `UClass` to Lua type definitions.