### PR TITLE
General improvements to Types.lua and generated Lua type definition files

### DIFF
--- a/UE4SS/src/SDKGenerator/Generator.cpp
+++ b/UE4SS/src/SDKGenerator/Generator.cpp
@@ -1092,7 +1092,7 @@ namespace RC::UEGenerator
         auto generate_enum_declaration(File::StringType& content_buffer, UEnum* uenum) -> void
         {
             auto enum_name = uenum->GetName();
-            content_buffer.append(fmt::format(STR("---@enum {}\n{} = {{\n"), enum_name, enum_name));
+            content_buffer.append(fmt::format(STR("---@enum {}\nlocal {} = {{\n"), enum_name, enum_name));
         }
         auto generate_enum_member(File::StringType& content_buffer, UEnum* uenum, const File::StringType& enum_value_name, const Unreal::FEnumNamePair& elem) -> void
         {
@@ -1218,7 +1218,7 @@ namespace RC::UEGenerator
                                        int32_t num_padding_elements,
                                        XProperty* last_property_in_this_class) -> void
         {
-            content_buffer.append(fmt::format(STR("{} = {{}}\n"), class_name));
+            content_buffer.append(fmt::format(STR("local {} = {{}}\n"), class_name));
         }
         auto generate_class_end(File::StringType& content_buffer, size_t class_size) -> void
         {
@@ -1278,7 +1278,8 @@ namespace RC::UEGenerator
             }
             else
             {
-                current_class_content.append(fmt::format(STR("{}[{}] = function("), class_name, quote_lua_symbol(function_name)));
+                // `function MyClass:MyMethod(p1, p2)` is syntactical sugar for `function MyClass.MyMethod(self, p1, p2)`
+                current_class_content.append(fmt::format(STR("{}[{}] = function(self, "), class_name, quote_lua_symbol(function_name)));
             }
 
             for (size_t i = 0; i < function_info.params.size(); ++i)

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -242,6 +242,8 @@ function. ([UE4SS #800](https://github.com/UE4SS-RE/RE-UE4SS/pull/800))
 Fixed race condition when using RegisterCustomEvent or
 UnregisterCustomEvent. ([UE4SS #805](https://github.com/UE4SS-RE/RE-UE4SS/pull/805))
 
+Fixed problems that caused issues for language servers. ([UE4SS #821](https://github.com/UE4SS-RE/RE-UE4SS/pull/821)
+
 ### C++ API 
 Fixed a crash caused by a race condition enabled by C++ mods using `UE4SS_ENABLE_IMGUI` in their constructor ([UE4SS #481](https://github.com/UE4SS-RE/RE-UE4SS/pull/481)) 
 

--- a/assets/Mods/shared/Types.lua
+++ b/assets/Mods/shared/Types.lua
@@ -796,34 +796,39 @@ local ObjectProperty = {}
 
 ---Returns the class that this property holds.
 ---@return UClass
-function GetPropertyClass() end
+function ObjectProperty:GetPropertyClass() end
 
 
 ---@class BoolProperty : Property
+local BoolProperty = {}
 
 ---@return integer
-function GetByteMask() end
+function BoolProperty:GetByteMask() end
 
 ---@return integer
-function GetByteOffset() end
+function BoolProperty:GetByteOffset() end
 
 ---@return integer
-function GetFieldMask() end
+function BoolProperty:GetFieldMask() end
 
 ---@return integer
-function GetFieldSize() end
+function BoolProperty:GetFieldSize() end
 
 
 ---@class StructProperty : Property
+local StructProperty = {}
+
 ---Returns the UScriptStruct that's mapped to this property.
 ---@return UScriptStruct
-function GetStruct() end
+function StructProperty:GetStruct() end
 
 
 ---@class ArrayProperty : Property
+local ArrayProperty = {}
+
 ---Returns the inner property of the array.
 ---@return Property
-function GetInner() end
+function ArrayProperty:GetInner() end
 
 
 ---@class UObjectReflection
@@ -1055,7 +1060,7 @@ function UEnum:ForEachName(Callback) end
 
 --- Returns the `FName` and `Integer` value that coresponds the given `Index`.
 ---@param Index integer
-function GetEnumNameByIndex(Index) end
+function UEnum:GetEnumNameByIndex(Index) end
 
 --- Inserts a `FName`/`Value` combination into a a `UEnum` at the given `Index`.
 --- If `ShiftValues = true`, will shift all enum values greater than inserted value by one.

--- a/assets/Mods/shared/Types.lua
+++ b/assets/Mods/shared/Types.lua
@@ -266,16 +266,17 @@ EInternalObjectFlags = {
     AllFlags                         = 0x7F800000,
 }
 
----@alias int8 number
----@alias int16 number
----@alias int32 number
----@alias int64 number
----@alias uint8 number
----@alias uint16 number
----@alias uint32 number
----@alias uint64 number
+---@alias int8 integer
+---@alias int16 integer
+---@alias int32 integer
+---@alias int64 integer
+---@alias uint8 integer
+---@alias uint16 integer
+---@alias uint32 integer
+---@alias uint64 integer
 ---@alias float number
 ---@alias double number
+
 
 -- # Global Functions
 
@@ -602,6 +603,7 @@ function LoopAsync(DelayInMilliseconds, Callback) end
 ---You also use `.__name` and `.__absolute_path` for files.
 function IterateGameDirectories() end
 
+
 -- # Classes
 
 ---Class for interacting with UE4SS metadata
@@ -695,6 +697,7 @@ function UnrealVersion:IsAbove(MajorVersion, MinorVersion) end
 ---@param MinorVersion integer
 ---@return boolean
 function UnrealVersion.IsAbove(MajorVersion, MinorVersion) end
+
 
 ---@class UFunction : UObject
 local UFunction = {}
@@ -1045,7 +1048,6 @@ function RemoteUnrealParam:type() end
 
 
 ---@class UEnum
-
 local UEnum = {}
 
 --- Returns the `FName` that corresponds to the specified value.

--- a/assets/Mods/shared/Types.lua
+++ b/assets/Mods/shared/Types.lua
@@ -697,7 +697,7 @@ function UnrealVersion:IsAbove(MajorVersion, MinorVersion) end
 function UnrealVersion.IsAbove(MajorVersion, MinorVersion) end
 
 ---@class UFunction : UObject
-UFunction = {}
+local UFunction = {}
 
 ---Attempts to call the UFunction
 ---@param ... UFunctionParams
@@ -714,7 +714,7 @@ function UFunction:SetFunctionFlags(Flags) end
 
 ---A TArray of characters
 ---@class FString
-FString = {}
+local FString = {}
 
 ---Returns a string that Lua can understand
 ---@return string
@@ -725,7 +725,7 @@ function FString:Clear() end
 
 
 ---@class FieldClass : LocalObject
-FieldClass = {}
+local FieldClass = {}
 
 ---Returns the FName of this class by copy.
 ---@return FName
@@ -751,7 +751,7 @@ FText = {}
 function FText:ToString() end
 
 ---@class RemoteObject
-RemoteObject = {}
+local RemoteObject = {}
 
 ---Returns whether this object is valid or not
 ---@return boolean
@@ -759,7 +759,7 @@ function RemoteObject:IsValid() end
 
 
 ---@class Property : RemoteObject
-Property = {}
+local Property = {}
 ---Returns the full name & path for this property.
 ---@return string
 function Property:GetFullName() end
@@ -792,7 +792,7 @@ function Property:ImportText(Buffer, Data, PortFlags, OwnerObject) end
 
 
 ---@class ObjectProperty : Property
-ObjectProperty = {}
+local ObjectProperty = {}
 
 ---Returns the class that this property holds.
 ---@return UClass
@@ -827,7 +827,7 @@ function GetInner() end
 
 
 ---@class UObjectReflection
-UObjectReflection = {}
+local UObjectReflection = {}
 
 ---Returns a property meta-data object
 ---@param PropertyName string
@@ -836,7 +836,7 @@ function UObjectReflection:GetProperty(PropertyName) end
 
 
 ---@class UObject : RemoteObject
-UObject = {}
+local UObject = {}
 
 ---Attempts to return either a member variable or a callable UFunction
 ---Can return any type, you can use the `type()` function on the returned value to figure out what Lua class it's using (if non-trivial type)
@@ -938,7 +938,7 @@ function UObject:ProcessConsoleExec(Cmd, Reserved, Executor) end
 function UObject:type() end
 
 ---@class TArray<T> : { [integer]: T }
-TArray = {}
+local TArray = {}
 
 ---Return the address in memory where the TArray struct is located
 ---@return integer
@@ -968,7 +968,7 @@ function TArray:ForEach(Callback) end
 ---@class TSet<K> : { [K]: nil }
 
 ---@class TMap<K, V> : { [K]: V }
-TMap = {}
+local TMap = {}
 
 ---Find the specified key in the map
 ---Throws an exception if the key is not found
@@ -1015,7 +1015,7 @@ function TMap:ForEach(callback) end
 ---Whether the Remote or Local variant is used depends on the requirements of the data but the usage is identical with either param types
 ---@generic T
 ---@class RemoteUnrealParam<T> : RemoteObject<T>
-RemoteUnrealParam = {}
+local RemoteUnrealParam = {}
 
 ---Returns the underlying value for this param
 ---@generic T
@@ -1041,7 +1041,7 @@ function RemoteUnrealParam:type() end
 
 ---@class UEnum
 
-UEnum = {}
+local UEnum = {}
 
 --- Returns the `FName` that corresponds to the specified value.
 ---@param Value integer


### PR DESCRIPTION
## Description

This PR ensures that types that do not actually exist in the Lua context as global variables are made local to the definition files only. This prevents cluttering of the autocomplete suggestions with numerous unusable variables.

Also did a few fixes and cleanup, refer to individual commit messages for more information.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<details>
<summary>Before</summary>

No warnings on inexistent global variables, suggestions are cluttered with types
![image](https://github.com/user-attachments/assets/80059ae3-4b6a-4b8a-ae3f-85c7db1ed8ed)

Types are generated as globals
![image](https://github.com/user-attachments/assets/f875f8c7-6590-4b93-aefd-b75aa1753afa)

</details>


<details>
<summary>After</summary>

Types that are not global variables are properly labeled as warnings now, and suggestions are decluttered and easier to use
![image](https://github.com/user-attachments/assets/70d133b8-7b5c-456f-9616-a5a3000680d2)

Generated types are now local-scoped
![image](https://github.com/user-attachments/assets/3ab7fc62-4e42-42ea-b6cb-0faa5ca9ec89)

</details>


## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries. (Does this need to?)

