### PR TITLE
Added ProcessLocalScriptFunction Override functionality

### DIFF
--- a/UE4SS/src/Signatures.cpp
+++ b/UE4SS/src/Signatures.cpp
@@ -324,7 +324,7 @@ namespace RC
                         lua_process_local_script_function_scan_script,
                         signature_containers,
                         [](void* address) {
-                            // Address logged in UEPseudo (UnrealInitializer.cpp) after final assignment
+                            Output::send(STR("ProcessLocalScriptFunction address: {} <- Lua Script\n"), address);
                             Unreal::UObject::ProcessLocalScriptFunctionInternal.assign_address(address);
                             return DidLuaScanSucceed::Yes;
                         },
@@ -346,7 +346,7 @@ namespace RC
                                 lua_process_internal_scan_script,
                                 signature_containers,
                                 [](void* address) {
-                                    // Address logged in UEPseudo (UnrealInitializer.cpp) after final assignment
+                                    Output::send(STR("ProcessInternal address: {} <- Lua Script\n"), address);
                                     Unreal::UObject::ProcessInternalInternal.assign_address(address);
                                     return DidLuaScanSucceed::Yes;
                                 },

--- a/UE4SS/src/Signatures.cpp
+++ b/UE4SS/src/Signatures.cpp
@@ -315,5 +315,26 @@ namespace RC
                         });
             };
         }
+        auto lua_process_local_script_function_scan_script = working_directory / "UE4SS_Signatures/ProcessLocalScriptFunction.lua";
+        if (std::filesystem::exists(lua_process_local_script_function_scan_script))
+        {
+            config.ScanOverrides.process_local_script_function = [lua_process_local_script_function_scan_script](std::vector<SignatureContainer>& signature_containers,
+                                                                                              Unreal::Signatures::ScanResult& scan_result) mutable {
+                scan_from_lua_script(
+                        lua_process_local_script_function_scan_script,
+                        signature_containers,
+                        [&scan_result](void* address) {
+                            Output::send(STR("ProcessLocalScriptFunction address: {} <- Lua Script\n"), address);
+                            Unreal::UObject::ProcessLocalScriptFunctionInternal.assign_address(address);
+                            return DidLuaScanSucceed::Yes;
+                        },
+                        [&](DidLuaScanSucceed did_lua_scan_succeed) {
+                            if (did_lua_scan_succeed == DidLuaScanSucceed::No)
+                            {
+                                scan_result.Errors.emplace_back("Was unable to find AOB for 'ProcessLocalScriptFunction' via Lua script");
+                            }
+                        });
+            };
+        }
     }
 } // namespace RC

--- a/UE4SS/src/Signatures.cpp
+++ b/UE4SS/src/Signatures.cpp
@@ -254,13 +254,13 @@ namespace RC
         if (std::filesystem::exists(lua_guhashtables_scan_script))
         {
             config.ScanOverrides.fuobject_hash_tables_get = [lua_guhashtables_scan_script](std::vector<SignatureContainer>& signature_containers,
-                                                                                 Unreal::Signatures::ScanResult& scan_result) mutable {
+                                                                                           Unreal::Signatures::ScanResult& scan_result) mutable {
                 scan_from_lua_script(
                         lua_guhashtables_scan_script,
                         signature_containers,
                         [](void* address) {
                             Output::send(STR("GUObjectHashTables_Get address: {} <- Lua Script\n"), address);
-                            
+
                             return DidLuaScanSucceed::Yes;
                         },
                         [&](DidLuaScanSucceed did_lua_scan_succeed) {
@@ -276,7 +276,7 @@ namespace RC
         if (std::filesystem::exists(lua_gnatives_scan_script))
         {
             config.ScanOverrides.gnatives = [lua_gnatives_scan_script](std::vector<SignatureContainer>& signature_containers,
-                                                                                 Unreal::Signatures::ScanResult& scan_result) mutable {
+                                                                       Unreal::Signatures::ScanResult& scan_result) mutable {
                 scan_from_lua_script(
                         lua_gnatives_scan_script,
                         signature_containers,
@@ -298,13 +298,13 @@ namespace RC
         if (std::filesystem::exists(lua_consolemanager_scan_script))
         {
             config.ScanOverrides.console_manager_singleton = [lua_consolemanager_scan_script](std::vector<SignatureContainer>& signature_containers,
-                                                                                 Unreal::Signatures::ScanResult& scan_result) mutable {
+                                                                                              Unreal::Signatures::ScanResult& scan_result) mutable {
                 scan_from_lua_script(
                         lua_consolemanager_scan_script,
                         signature_containers,
                         [](void* address) {
                             Output::send(STR("ConsoleManagerSingleton address: {} <- Lua Script\n"), address);
-                            
+
                             return DidLuaScanSucceed::Yes;
                         },
                         [&](DidLuaScanSucceed did_lua_scan_succeed) {
@@ -318,45 +318,45 @@ namespace RC
         auto lua_process_local_script_function_scan_script = working_directory / "UE4SS_Signatures/ProcessLocalScriptFunction.lua";
         if (std::filesystem::exists(lua_process_local_script_function_scan_script))
         {
-            config.ScanOverrides.process_local_script_function = [lua_process_local_script_function_scan_script](std::vector<SignatureContainer>& signature_containers,
-                                                                                              Unreal::Signatures::ScanResult& scan_result) mutable {
-                scan_from_lua_script(
-                        lua_process_local_script_function_scan_script,
-                        signature_containers,
-                        [](void* address) {
-                            Output::send(STR("ProcessLocalScriptFunction address: {} <- Lua Script\n"), address);
-                            Unreal::UObject::ProcessLocalScriptFunctionInternal.assign_address(address);
-                            return DidLuaScanSucceed::Yes;
-                        },
-                        [&](DidLuaScanSucceed did_lua_scan_succeed) {
-                            if (did_lua_scan_succeed == DidLuaScanSucceed::No)
-                            {
-                                scan_result.Errors.emplace_back("Was unable to find AOB for 'ProcessLocalScriptFunction' via Lua script");
-                            }
-                        });
-            };
-        }
-        auto lua_process_internal_scan_script = working_directory / "UE4SS_Signatures/ProcessInternal.lua";
-        if (std::filesystem::exists(lua_process_internal_scan_script))
-        {
-            config.ScanOverrides.process_internal =
-                    [lua_process_internal_scan_script](std::vector<SignatureContainer>& signature_containers,
+            config.ScanOverrides.process_local_script_function =
+                    [lua_process_local_script_function_scan_script](std::vector<SignatureContainer>& signature_containers,
                                                                     Unreal::Signatures::ScanResult& scan_result) mutable {
                         scan_from_lua_script(
-                                lua_process_internal_scan_script,
+                                lua_process_local_script_function_scan_script,
                                 signature_containers,
                                 [](void* address) {
-                                    Output::send(STR("ProcessInternal address: {} <- Lua Script\n"), address);
-                                    Unreal::UObject::ProcessInternalInternal.assign_address(address);
+                                    Output::send(STR("ProcessLocalScriptFunction address: {} <- Lua Script\n"), address);
+                                    Unreal::UObject::ProcessLocalScriptFunctionInternal.assign_address(address);
                                     return DidLuaScanSucceed::Yes;
                                 },
                                 [&](DidLuaScanSucceed did_lua_scan_succeed) {
                                     if (did_lua_scan_succeed == DidLuaScanSucceed::No)
                                     {
-                                        scan_result.Errors.emplace_back("Was unable to find AOB for 'ProcessInternal' via Lua script");
+                                        scan_result.Errors.emplace_back("Was unable to find AOB for 'ProcessLocalScriptFunction' via Lua script");
                                     }
                                 });
                     };
+        }
+        auto lua_process_internal_scan_script = working_directory / "UE4SS_Signatures/ProcessInternal.lua";
+        if (std::filesystem::exists(lua_process_internal_scan_script))
+        {
+            config.ScanOverrides.process_internal = [lua_process_internal_scan_script](std::vector<SignatureContainer>& signature_containers,
+                                                                                       Unreal::Signatures::ScanResult& scan_result) mutable {
+                scan_from_lua_script(
+                        lua_process_internal_scan_script,
+                        signature_containers,
+                        [](void* address) {
+                            Output::send(STR("ProcessInternal address: {} <- Lua Script\n"), address);
+                            Unreal::UObject::ProcessInternalInternal.assign_address(address);
+                            return DidLuaScanSucceed::Yes;
+                        },
+                        [&](DidLuaScanSucceed did_lua_scan_succeed) {
+                            if (did_lua_scan_succeed == DidLuaScanSucceed::No)
+                            {
+                                scan_result.Errors.emplace_back("Was unable to find AOB for 'ProcessInternal' via Lua script");
+                            }
+                        });
+            };
         }
     }
 } // namespace RC

--- a/UE4SS/src/Signatures.cpp
+++ b/UE4SS/src/Signatures.cpp
@@ -324,7 +324,7 @@ namespace RC
                         lua_process_local_script_function_scan_script,
                         signature_containers,
                         [](void* address) {
-                            Output::send(STR("ProcessLocalScriptFunction address: {} <- Lua Script\n"), address);
+                            // Address logged in UEPseudo (UnrealInitializer.cpp) after final assignment
                             Unreal::UObject::ProcessLocalScriptFunctionInternal.assign_address(address);
                             return DidLuaScanSucceed::Yes;
                         },
@@ -346,7 +346,7 @@ namespace RC
                                 lua_process_internal_scan_script,
                                 signature_containers,
                                 [](void* address) {
-                                    Output::send(STR("ProcessInternal address: {} <- Lua Script\n"), address);
+                                    // Address logged in UEPseudo (UnrealInitializer.cpp) after final assignment
                                     Unreal::UObject::ProcessInternalInternal.assign_address(address);
                                     return DidLuaScanSucceed::Yes;
                                 },

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -41,6 +41,9 @@ Added custom game configurations for Lies of P ([UE4SS #787](https://github.com/
 The GUI can now be rendered in the game thread if `RenderMode` in UE4SS-settings.ini is set to
 `EngineTick` or `GameViewportClientTick` ([UE4SS #768](https://github.com/UE4SS-RE/RE-UE4SS/pull/768), [UE4SS #794](https://github.com/UE4SS-RE/RE-UE4SS/pull/794)).
 
+Added override Lua files for ProcessLocalScriptFunction and
+ProcessInternal [UE4SS #823](https://github.com/UE4SS-RE/RE-UE4SS/pull/823) - M3C3I
+
 
 ### Live View 
 Added search filter: `IncludeClassNames`. ([UE4SS #472](https://github.com/UE4SS-RE/RE-UE4SS/pull/472)) - Buckminsterfullerene 

--- a/docs/guides/fixing-compatibility-problems.md
+++ b/docs/guides/fixing-compatibility-problems.md
@@ -33,9 +33,11 @@ For more in-depth instructions, see the [advanced guide](./fixing-compatibility-
     - FText_Constructor.lua (Optional)
     - StaticConstructObject.lua
     - GMalloc.lua
-    - GUObjectHashTables.lua(Optional)
+   - GUObjectHashTables.lua (Optional)
     - GNatives.lua          (Optional)
     - ConsoleManager.lua    (Optional)
+   - ProcessLocalScriptFunction.lua
+   - ProcessInternal.lua
 4. Inside the `.lua` file you need a global `Register` function with no params
     - Keep in mind that the names of functions in Lua files in the `UE4SS_Signatures` directory are case-senstive.
 5. The `Register` function must return the AOB that you want UE4SS to scan for.
@@ -75,6 +77,12 @@ For more in-depth instructions, see the [advanced guide](./fixing-compatibility-
    - Must return the exact address of the global variable named 'GNatives'.
 - GUObjectHashTables (WIP)  (Optional)
 - ConsoleManager (WIP)  (Optional)
+- ProcessLocalScriptFunction
+    - This is not required 99% of the time.
+    - Must return the exact address of ProcessLocalScriptFunction.
+- ProcessInternal
+    - This is not required 99% of the time.
+    - Must return the exact address of ProcessInternal.
 
 ## Example script (Simple, direct scan)
 


### PR DESCRIPTION
This change requires changes in the Unreal deps as well for this override to function.

**Description**

Added ability to use a lua script to override ProcessLocalScriptFunction


**Type of change**

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] Is/requires documentation update
    - Potentially could be added to [this page](https://docs.ue4ss.com/guides/fixing-compatibility-problems.html)

**How Has This Been Tested?**

- Created the file ProcessLocalScriptFunction.lua in ue4ss\UE4SS_Signatures which successfully overrides the built-in method.
- Removed the ProcessLocalScriptFunction.lua from that same directory and it successfully uses the built-in method.

**Checklist**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] Pull Request [HERE](https://github.com/Re-UE4SS/UEPseudo/pull/123) will need to be merged before this can be merged.

