### PR TITLE
fix: RegisterHook/UnregisterHook not working properly with functions with spaces in their name

### DIFF
--- a/UE4SS/src/Mod/LuaMod.cpp
+++ b/UE4SS/src/Mod/LuaMod.cpp
@@ -1456,8 +1456,12 @@ Overloads:
                     lua.throw_error(error_overload_not_found);
                 }
 
-                auto function_name = ensure_str(lua.get_string());
-                auto function_name_no_prefix = function_name.substr(function_name.find_first_of(STR(" ")) + 1, function_name.size());
+                auto function_name_no_prefix = ensure_str(lua.get_string());
+                static constexpr StringViewType function_prefix{STR("Function ")};
+                if (auto prefix_pos = function_name_no_prefix.find(function_prefix); prefix_pos != function_name_no_prefix.npos)
+                {
+                    function_name_no_prefix = function_name_no_prefix.substr(prefix_pos + function_prefix.size());
+                }
 
                 Unreal::UFunction* unreal_function = Unreal::UObjectGlobals::StaticFindObject<Unreal::UFunction*>(nullptr, nullptr, function_name_no_prefix);
                 if (!unreal_function)
@@ -3153,8 +3157,12 @@ Overloads:
                 lua.throw_error(error_overload_not_found);
             }
 
-            auto function_name = ensure_str(lua.get_string());
-            auto function_name_no_prefix = function_name.substr(function_name.find_first_of(STR("/")), function_name.size());
+            auto function_name_no_prefix = ensure_str(lua.get_string());
+            static constexpr StringViewType function_prefix{STR("Function ")};
+            if (auto prefix_pos = function_name_no_prefix.find(function_prefix); prefix_pos != function_name_no_prefix.npos)
+            {
+                function_name_no_prefix = function_name_no_prefix.substr(prefix_pos + function_prefix.size());
+            }
 
             if (!lua.is_function())
             {

--- a/UE4SS/src/Mod/LuaMod.cpp
+++ b/UE4SS/src/Mod/LuaMod.cpp
@@ -931,6 +931,19 @@ namespace RC
         }
     }
 
+    static auto get_function_name_without_prefix(const StringType& function_full_name) -> StringType
+    {
+        static constexpr StringViewType function_prefix{STR("Function ")};
+        if (auto prefix_pos = function_full_name.find(function_prefix); prefix_pos != function_full_name.npos)
+        {
+            return function_full_name.substr(prefix_pos + function_prefix.size());
+        }
+        else
+        {
+            return function_full_name;
+        }
+    }
+
     auto static setup_lua_global_functions_internal(const LuaMadeSimple::Lua& lua, Mod::IsTrueMod is_true_mod) -> void
     {
         lua.register_function("print", LuaLibrary::global_print);
@@ -1456,12 +1469,7 @@ Overloads:
                     lua.throw_error(error_overload_not_found);
                 }
 
-                auto function_name_no_prefix = ensure_str(lua.get_string());
-                static constexpr StringViewType function_prefix{STR("Function ")};
-                if (auto prefix_pos = function_name_no_prefix.find(function_prefix); prefix_pos != function_name_no_prefix.npos)
-                {
-                    function_name_no_prefix = function_name_no_prefix.substr(prefix_pos + function_prefix.size());
-                }
+                auto function_name_no_prefix = get_function_name_without_prefix(ensure_str(lua.get_string()));
 
                 Unreal::UFunction* unreal_function = Unreal::UObjectGlobals::StaticFindObject<Unreal::UFunction*>(nullptr, nullptr, function_name_no_prefix);
                 if (!unreal_function)
@@ -3159,12 +3167,7 @@ Overloads:
                 lua.throw_error(error_overload_not_found);
             }
 
-            auto function_name_no_prefix = ensure_str(lua.get_string());
-            static constexpr StringViewType function_prefix{STR("Function ")};
-            if (auto prefix_pos = function_name_no_prefix.find(function_prefix); prefix_pos != function_name_no_prefix.npos)
-            {
-                function_name_no_prefix = function_name_no_prefix.substr(prefix_pos + function_prefix.size());
-            }
+            auto function_name_no_prefix = get_function_name_without_prefix(ensure_str(lua.get_string()));
 
             if (!lua.is_function())
             {

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -264,6 +264,9 @@ Fixed problems that caused issues for language servers. ([UE4SS #821](https://gi
 
 Fixed errors being logged twice. ([UE4SS #833](https://github.com/UE4SS-RE/RE-UE4SS/pull/833))
 
+Fixed `RegisterHook` and `UnregisterHook` not working properly with functions that have spaces in their
+names. ([UE4SS #827](https://github.com/UE4SS-RE/RE-UE4SS/pull/827)
+
 ### C++ API 
 Fixed a crash caused by a race condition enabled by C++ mods using `UE4SS_ENABLE_IMGUI` in their constructor ([UE4SS #481](https://github.com/UE4SS-RE/RE-UE4SS/pull/481)) 
 


### PR DESCRIPTION
Fixes #827 

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

See test case in #827.

**Checklist**

- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
