### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,40 +2,39 @@
 name: Bug report
 about: Create a report to help us improve
 title: "[BUG - Release]"
-labels: ''
-assignees: ''
-
+labels: 'bug'
 ---
 
 **Branch or Release**
-The Tag for the Release you are using, or the commit you used if you built from source yourself.
+<!-- The Tag for the Release you are using, or the commit you used if you built from source yourself. -->
 
 
 **Game and Engine Version**
-Game where the bug occurred, and the UE engine version of the game.
+<!-- Game where the bug occurred, and the UE engine version of the game. -->
 
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
 
 
 **Mods directory**
-A zip of your Mods folder if you've installed any mods that don't come with UE4SS by default
+<!-- A zip of your Mods folder if you've installed any mods that don't come with UE4SS by default -->
 
 
-**To Reproduce**
+**To reproduce**
+<!--
 Steps to reproduce the behavior:
 1. Launch game
 2. Attempt UHT Dump
 3. See error in log
-
+-->
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what you expected to happen. -->
 
 
 **Screenshots, UE4SS Log, and .dmp file**
-If applicable, add screenshots to help explain your problem, and upload the log and .dmp files located in the Win64 directory.
+<!-- If applicable, add screenshots to help explain your problem, and upload the log and .dmp files located in the Win64 directory. -->
 
 
 **Desktop (please complete the following information):**
@@ -43,4 +42,4 @@ If applicable, add screenshots to help explain your problem, and upload the log 
 
 
 **Additional context**
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/docs_report.md
+++ b/.github/ISSUE_TEMPLATE/docs_report.md
@@ -1,0 +1,24 @@
+---
+name: Docs Report
+about: Create a report to help us improve the documentation
+title: "[Docs]"
+labels: 'documentation'
+---
+
+<!-- Please check that your change does not already exist at the development version of the docs at https://docs.ue4ss.com/dev/ -->
+
+**Description**
+<!-- A clear and concise description of how the docs should be changed or what the error is.-->
+
+
+**Pages to update**
+<!--https://docs.ue4ss.com/dev/...-->
+
+
+**Screenshots**
+<!--Add screenshots to help explain your problem, if needed.-->
+
+
+**Additional context**
+<!--Add any other context about the documentation here.-->
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea
+labels: feature request
+---
+
+**Is your feature request related to a problem? Please describe.**
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+
+**Describe the solution you'd like**
+<!-- A clear and concise description of what you want to happen. -->
+
+
+**Describe alternatives you've considered**
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+<!-- Any known work arounds? -->
+
+
+**Additional context**
+<!-- Add any other context or screenshots about the feature request here. -->
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,11 @@
 **Description**
+<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->
 
-Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change.
 
 Fixes # (issue) (if applicable)
 
 **Type of change**
-
-Please delete options that are not relevant.
+<!-- Please delete options that are not relevant. -->
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
@@ -14,21 +13,22 @@ Please delete options that are not relevant.
 - [ ] Is/requires documentation update
 - [ ] Other... Please describe:
 
-**How Has This Been Tested?**
+**How has this been tested?**
+<!-- Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration. -->
 
-Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration.
 
 **Checklist**
-
-Please delete options that are not relevant. Update the list as the PR progresses.
+<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->
 
 - [ ] I have commented my code, particularly in hard-to-understand areas.
 - [ ] I have made corresponding changes to the documentation.
 - [ ] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
 - [ ] Any dependent changes have been merged and published in downstream modules.
 
-**Screenshots (if appropriate)**
+**Screenshots**
+<!--Add screenshots to help explain your PR, if applicable.-->
+
 
 **Additional context**
+<!-- Add any other context about the pull request here. -->
 
-Add any other context about the pull request here.


### PR DESCRIPTION
**Description**

- Added new docs report & feature request issue templates
- Bug report and PR templates updated to put instructions into markdown comments so they don't need to be manually deleted (or left in which reads badly)
- Templates are auto-labelled on what they are

**Type of change**

- [x] Other... Please describe: Repo management

**How Has This Been Tested?**

It hasn't aside from checking the markdown is valid with preview mode and checking with the docs that the metadata is valid (e.g. labels with spaces in working as they are)

**Checklist**

N/A

**Screenshots (if appropriate)**

**Additional context**
