### PR TITLE
Allow errors from C++ LuaMadeSimple::throw_error to be handled by Lua

### DIFF
--- a/deps/first/LuaMadeSimple/src/LuaMadeSimple.cpp
+++ b/deps/first/LuaMadeSimple/src/LuaMadeSimple.cpp
@@ -936,7 +936,7 @@ namespace RC::LuaMadeSimple
         auto final_message = handle_error(lua_state, error_message);
 
         lua_state_errors.emplace(lua_state, final_message);
-        throw std::runtime_error{final_message};
+        luaL_error(lua_state, final_message.c_str());
     }
 
     auto new_state() -> Lua&


### PR DESCRIPTION
## Description

Use `luaL_error` instead of throwing a runtime_error so that Lua can handle it (e.g. via x/pcall). `luaL_error` (and `lua_error`) also throws an exception so it should result in similar output as before.

But, it seems that the change removed the duplicate stack traces from output, which may be a good side effect.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<details>
<summary>Test code</summary>

```lua
-- Test 1
error("Error test 1")

-- Test 2
ExecuteInGameThread(function()
    error("Error test 2")
end)

-- Test 3
ExecuteAsync(function()
    error("Error test 3")
end)

-- Test 4
ExecuteAsync(function()
    ExecuteInGameThread(function()
        error("Error test 4")
    end)
end)

-- Test 5
ExecuteInGameThread(function()
    local engine = FindFirstOf("Engine")
    -- assigning table to fstring (calls ::throw_error)
    engine.VertexColorMaterialName = {}
end)

-- Test 6
ExecuteInGameThread(function()
    local engine = FindFirstOf("Engine")

    local _, err = pcall(function()
        -- assigning table to fstring (calls ::throw_error)
        engine.VertexColorMaterialName = {}
    end)

    print("CAPTURED ERROR START >>>", err, "<<< CATPURED ERROR END")
end)
```

</details>

Before, after
![image](https://github.com/user-attachments/assets/3172984b-e177-4b56-a550-8420d2909496)

## Checklist

- [ ] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.

