### PR TITLE
Link to latest stable release instead of pre-release in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You may need to update AOBs on your own, and there's a guide for that below.
 
 ## Basic Installation
 
-The easiest installation is via downloading the non-dev version of the latest non-experimental build from [Releases](https://github.com/UE4SS-RE/RE-UE4SS/releases) and extracting the zip content to `{game directory}/GameName/Binaries/Win64/`.
+The easiest installation is via downloading the non-dev version of the latest non-experimental build from [Releases](https://github.com/UE4SS-RE/RE-UE4SS/releases/latest) and extracting the zip content to `{game directory}/GameName/Binaries/Win64/`.
 
 If your game is in the custom config list, extract the contents from the relevant folder to `Win64` as well.
 


### PR DESCRIPTION
Despite it being mentioned to use the non-dev and non-experimental version of UE4SS in the README, some end user still end up downloading the experimental version due to it being the very first thing they see on the linked release page, which may lead the mods that are expecting the stable version to have issues.

This at least helps elevate that. 

https://github.com/UE4SS-RE/RE-UE4SS/blob/8526b3bce9fc31edbe77056aee912bbd45c86034/README.md?plain=1#L24-L26
