### PR TITLE
UEHelpers: Fix GetActorFromHitResult and refactor it a little

### DIFF
--- a/assets/Mods/shared/UEHelpers/UEHelpers.lua
+++ b/assets/Mods/shared/UEHelpers/UEHelpers.lua
@@ -195,12 +195,12 @@ function UEHelpers.GetAllPlayers()
 end
 
 ---Returns hit actor from FHitResult.<br>
----The function handles the struct differance between UE4 and UE5
+---The function handles the struct difference between different UE versions
 ---@param HitResult FHitResult
 ---@return AActor|UObject
 function UEHelpers.GetActorFromHitResult(HitResult)
-    if not HitResult or not HitResult:IsValid() then
-        return CreateInvalidObject() ---@type AActor
+    if not HitResult then
+        return CreateInvalidObject()
     end
 
     if UnrealVersion:IsBelow(5, 0) then


### PR DESCRIPTION
**Description**
I found an embarrassing error that I didn't test properly.  
`FHitResult` is a struct and has no `IsValid()` function.

**Changes**
- Removed HitResult:IsValid() check. It's a struct and has no such function.
- Changed the description of GetActorFromHitResult to be slightly more accurate, as it doesn't just deal with the difference between UE4 and UE5
- Removed `---@type AActor` annotation from `return CreateInvalidObject()`. It returns an UObject, which is a valid return type for GetActorFromHitResult.


**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How has this been tested?**
Tested in my Line Trace mod.

