### PR TITLE
fix(docs): Incorrect label for NotifyOnNewObject callback params

### DIFF
--- a/docs/lua-api/global-functions/notifyonnewobject.md
+++ b/docs/lua-api/global-functions/notifyonnewobject.md
@@ -15,7 +15,7 @@ The callback can return `true` to remove (unregister) that specific `NotifyOnNew
 | 1 | string   | Full name of the class to get instance construction notifications for, without the type prefix |
 | 2 | function | The callback to execute when an instance of the supplied class is constructed |
 
-## Return Value
+## Callback Parameters
 
 | # | Type    | Information |
 |---|---------|-------------|


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

The callback parameter was listed as the non-callback return value.

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Is/requires documentation update
