### PR TITLE
feat(Lua): Backend support uninstalling Lua mods one at a time

### DIFF
--- a/UE4SS/include/UE4SSProgram.hpp
+++ b/UE4SS/include/UE4SSProgram.hpp
@@ -246,6 +246,7 @@ namespace RC
         {
             return m_processing_events;
         }
+        RC_UE4SS_API auto delete_mod(Mod*) -> void;
 
       public:
         // API pass-through for use outside the private scope of UE4SSProgram
@@ -257,6 +258,7 @@ namespace RC
                                                  void* custom_data2 = nullptr) -> void;
         RC_UE4SS_API auto is_keydown_event_registered(Input::Key) -> bool;
         RC_UE4SS_API auto is_keydown_event_registered(Input::Key, const Input::Handler::ModifierKeyArray&) -> bool;
+        RC_UE4SS_API auto get_all_input_events(std::function<void(Input::KeySet&)> callback) -> void;
 
       private:
         static auto install_cpp_mods() -> void;

--- a/UE4SS/src/UE4SSProgram.cpp
+++ b/UE4SS/src/UE4SSProgram.cpp
@@ -1387,6 +1387,22 @@ namespace RC
         LuaMod::global_uninstall();
     }
 
+    auto UE4SSProgram::delete_mod(Mod* mod) -> void
+    {
+        for (auto it = m_mods.begin(); it != m_mods.end();)
+        {
+            if (it->get() == mod)
+            {
+                it = m_mods.erase(it);
+                break;
+            }
+            else
+            {
+                ++it;
+            }
+        }
+    }
+
     auto UE4SSProgram::is_program_started() -> bool
     {
         return m_is_program_started;
@@ -1409,7 +1425,7 @@ namespace RC
                 auto& [_, key_data] = item;
                 bool were_all_events_registered_from_lua = true;
                 std::erase_if(key_data, [&](Input::KeyData& key_data) -> bool {
-                    // custom_data == 1: Bind came from Lua, and custom_data2 is nullptr.
+                    // custom_data == 1: Bind came from Lua, and custom_data2 is a pointer to LuaMod.
                     // custom_data == 2: Bind came from C++, and custom_data2 is a pointer to KeyDownEventData. Must free it.
                     if (key_data.custom_data == 1)
                     {
@@ -1633,6 +1649,13 @@ namespace RC
         return m_input_handler.is_keydown_event_registered(key, modifier_keys);
 #else
         return false;
+#endif
+    }
+
+    auto UE4SSProgram::get_all_input_events(std::function<void(Input::KeySet&)> callback) -> void
+    {
+#ifdef HAS_INPUT
+        m_input_handler.get_events_safe(callback);
 #endif
     }
 

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -118,6 +118,10 @@ Added hook for `UGameViewportClient::Tick`. ([UE4SS #767](https://github.com/UE4
 
 Added hook for `AActor::EndPlay`. ([UE4SS #769](https://github.com/UE4SS-RE/RE-UE4SS/pull/769))
 
+Added function 'UE4SSProgram::delete_mod'. ([UE4SS #843](https://github.com/UE4SS-RE/RE-UE4SS/pull/843))
+
+Added function 'UE4SSProgram::get_all_input_events'. ([UE4SS #843](https://github.com/UE4SS-RE/RE-UE4SS/pull/843))
+
 ### BPModLoader 
 
 ### Experimental 


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

This PR introduces backend changes to allow Lua mods to be uninstalled one-by-one instead of requiring all mods to be uninstalled at the same time.

It's exposed via `LuaMod::uninstall` which clears the mod out of the global state, and `UE4SSProgram::untrack_mod` which deletes the mod and this must be called after `LuaMod::uninstall`.

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.