### PR TITLE
feat: Added clear error messages when FText or FName (if found by Lua) causes a crash during init

### DIFF
--- a/UE4SS/include/ExceptionHandling.hpp
+++ b/UE4SS/include/ExceptionHandling.hpp
@@ -15,8 +15,45 @@
         printf_s("Internal Error: %s\n", e.what());                                                                                                            \
     }
 
+// These macros should never be used in header files because you are required to include Windows.h.
+#ifdef _WIN32
+#ifndef SEH_TRY
+#define SEH_TRY(Code)                                                                                                                                          \
+    __try                                                                                                                                                      \
+    Code
+#endif
+#ifndef SEH_EXCEPT
+#define SEH_EXCEPT(Code)                                                                                                                                       \
+    __except (SEH_exception_filter(GetExceptionCode(), GetExceptionInformation()))                                                                             \
+    {                                                                                                                                                          \
+        Code std::exit(EXIT_FAILURE);                                                                                                                          \
+    }
+#endif
+#else
+#ifndef SEH_TRY
+#define SEH_TRY(Code) Code
+#endif
+#ifndef SEH_EXCEPT
+#define SEH_EXCEPT(...)
+#endif
+#endif
+
 namespace RC
 {
+#ifdef _WIN32
+    enum SEH_FILTER_RESULT
+    {
+        EXECUTE_HANDLER = 1,
+        CONTINUE_SEARCH = 0,
+        CONTINUE_EXECUTION = -1,
+    };
+
+    inline int SEH_exception_filter(unsigned int code, struct _EXCEPTION_POINTERS* ep)
+    {
+        return EXECUTE_HANDLER;
+    }
+#endif
+
     // Will try some code and properly propagate any exceptions
     // This is a simple helper function to avoid having 15 extra lines of code everywhere
     template <typename CodeToTry>


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

This should help in diagnosing why the override isn't working, which would otherwise require attaching a debugger to see where it crashes.

We could potentially do a similar thing for other common init crashes like accessing an invalid GUObjectArray pointer, however, that will require UEPseudo changes and I'd like to try get these smaller changes merged before sprinkling SEH exception handlers all over the init code.

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
 
**How has this been tested?**
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration. -->

Create UE4SS_Signatures/FName_Constructor.lua, and put an AOB in there that exists but isn't actually the FName constructor, and start the game and let it crash and see if the new error message is in UE4SS.log.
Now change it to a correct AOB and start the game to confirm that it doesn't crash, and there's no error message in the log.

**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [x] I have commented my code, particularly in hard-to-understand areas.

**Screenshots**
<!--Add screenshots to help explain your PR, if applicable.-->

![image](https://github.com/user-attachments/assets/ed2cc945-a886-4941-accc-c3dd2d62bdc6)

