### PR TITLE
Updated release workflows to publish all files with version suffix

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -75,8 +75,8 @@ jobs:
           files: |
             release/UE4SS_v*.zip
             release/zDEV-UE4SS_v*.zip
-            release/zCustomGameConfigs.zip
-            release/zMapGenBP.zip
+            release/zCustomGameConfigs_v*.zip
+            release/zMapGenBP_v*.zip
 
       - name: Delete old release assets
         uses: mknejp/delete-release-assets@v1
@@ -94,5 +94,5 @@ jobs:
           files: |
             release/UE4SS_v*.zip
             release/zDEV-UE4SS_v*.zip
-            release/zCustomGameConfigs.zip
-            release/zMapGenBP.zip
+            release/zCustomGameConfigs_v*.zip
+            release/zMapGenBP_v*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,5 +74,5 @@ jobs:
           files: |
             release/UE4SS_v*.zip
             release/zDEV-UE4SS_v*.zip
-            release/zCustomGameConfigs.zip
-            release/zMapGenBP.zip
+            release/zCustomGameConfigs_v*.zip
+            release/zMapGenBP_v*.zip


### PR DESCRIPTION
**Description**
This updates the github workflow yamls, so that the custom game configs, and map gen zip files, have versions suffixed on them like the other release files.

Fixes
loss of old map gen and custom game config releases

**Type of change**
ci/cd