### PR TITLE
fix: pass scale to UEPseudo UWorld::SpawnActor

### DIFF
--- a/docs/lua-api/classes/uworld.md
+++ b/docs/lua-api/classes/uworld.md
@@ -8,3 +8,8 @@
 This function uses `UGameplayStatics:BeginDeferredActorSpawnFromClass` and `UGameplayStatics:FinishSpawningActor` to spawn an actor.  
 - **Return type:** `AActor`
 - **Returns:** Spawned actor object or an invalid object.
+
+### SpawnActor(UClass ActorClass, FVector Location, FRotator Rotation, FVector Scale)
+This function uses `UGameplayStatics:BeginDeferredActorSpawnFromClass` and `UGameplayStatics:FinishSpawningActor` to spawn an actor.  
+- **Return type:** `AActor`
+- **Returns:** Spawned actor object or an invalid object.


### PR DESCRIPTION
**Description**
Currently in UE4SS it is not easy to spawn scaled actors from Lua, and for some actors setting scale after spawning may not work (animated characters, etc.).

In [Re-UE4SS/UEPseudo/blob/main/src/World.cpp](https://github.com/Re-UE4SS/UEPseudo/blob/main/src/World.cpp), [the first implementation](https://github.com/Re-UE4SS/UEPseudo/blob/3185035434260bfd82224375f31043d18e362cac/src/World.cpp#L15) of `UWorld::SpawnActor` hardcodes the scale to 1.0:
```
    AActor* UWorld::SpawnActor(UClass* InClass, FVector const* Location, FRotator const* Rotation)
    {
        Unreal::FTransform Transform{
                Rotation ? FQuat(*Rotation) : FQuat(),
                Location ? *Location : FVector(),
                {1.0f, 1.0f, 1.0f},
...
```
and [the second](https://github.com/Re-UE4SS/UEPseudo/blob/3185035434260bfd82224375f31043d18e362cac/src/World.cpp#L32) `AActor* UWorld::SpawnActor(UClass* Class, FTransform const* Transform)` needs an `FTransform` which is not passed through Lua currently.

To follow the style of the existing API, we add another Lua overload, that also accepts one more, the fourth table parameter, a FVector-like table of scale:
```
SpawnActor(UClass ActorClass, FVector Location, FRotator Rotation, FVector Scale)
```
and constructs an `FTransform` to call the relevant second implementation from UEPseudo.

The original `SpawnActor(UClass ActorClass, FVector Location, FRotator Rotation)` should still work as before.

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How has this been tested?**
Built locally and tested manually.