### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/deps/first/LuaRaw/src/lparser.c
+++ b/deps/first/LuaRaw/src/lparser.c
@@ -468,6 +468,7 @@ static void singlevar (LexState *ls, expdesc *var) {
     expdesc key;
     singlevaraux(fs, ls->envn, var, 1);  /* get environment variable */
     lua_assert(var->k != VVOID);  /* this one must exist */
+    luaK_exp2anyregup(fs, var);  /* but could be a constant */
     codestring(&key, varname);  /* key is variable name */
     luaK_indexed(fs, var, &key);  /* env[varname] */
   }


### PR DESCRIPTION
**Description**

Hi again,

I identified another potential vulnerability in a clone function singlevar() in `deps/first/LuaRaw/src/lparser.c` sourced from [lua/lua](https://github.com/lua/lua). This issue, originally reported in [CVE-2022-28805](https://nvd.nist.gov/vuln/detail/CVE-2022-28805), was resolved in the repository via this commit https://github.com/lua/lua/commit/1f3c6f4534c6411313361697d98d1145a1f030fa.

This PR applies the corresponding patch to fix the vulnerability in this codebase.

Please review at your convenience. Thank you!

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x ] Bug fix (non-breaking change which fixes an issue)

