### PR TITLE
fix(Lua): Types with 'get' functions now also have 'Get' and vice versa

### DIFF
--- a/UE4SS/include/LuaType/LuaUObject.hpp
+++ b/UE4SS/include/LuaType/LuaUObject.hpp
@@ -831,6 +831,11 @@ Overloads:
 
         auto static setup_member_functions(LuaMadeSimple::Lua::Table& table) -> void
         {
+            table.add_pair("Get", [](const LuaMadeSimple::Lua& lua) -> int {
+                prepare_to_handle(Operation::Get, lua);
+                return 1;
+            });
+
             table.add_pair("get", [](const LuaMadeSimple::Lua& lua) -> int {
                 prepare_to_handle(Operation::Get, lua);
                 return 1;

--- a/UE4SS/src/LuaType/LuaFWeakObjectPtr.cpp
+++ b/UE4SS/src/LuaType/LuaFWeakObjectPtr.cpp
@@ -55,6 +55,12 @@ namespace RC::LuaType
             return 1;
         });
 
+        table.add_pair("get", [](const LuaMadeSimple::Lua& lua) -> int {
+            auto& lua_object = lua.get_userdata<FWeakObjectPtr>();
+            LuaType::auto_construct_object(lua, lua_object.get_local_cpp_object().Get());
+            return 1;
+        });
+
         if constexpr (is_final == LuaMadeSimple::Type::IsFinal::Yes)
         {
             table.add_pair("type", [](const LuaMadeSimple::Lua& lua) -> int {

--- a/UE4SS/src/LuaType/LuaUObject.cpp
+++ b/UE4SS/src/LuaType/LuaUObject.cpp
@@ -1501,6 +1501,11 @@ Overloads:
 
     auto RemoteUnrealParam::setup_member_functions(LuaMadeSimple::Lua::Table& table) -> void
     {
+        table.add_pair("Get", [](const LuaMadeSimple::Lua& lua) -> int {
+            prepare_to_handle(Operation::Get, lua);
+            return 1;
+        });
+
         table.add_pair("get", [](const LuaMadeSimple::Lua& lua) -> int {
             prepare_to_handle(Operation::Get, lua);
             return 1;

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -183,7 +183,9 @@ The callback of `NotifyOnNewObject` can now optionally return `true` to unregist
 Improved performance of script hooks created with `RegisterHook`, and
 `RegisterCustomEvent`. ([UE4SS #801](https://github.com/UE4SS-RE/RE-UE4SS/pull/801))
 
-**BREAKING:** `AActor:GetWorld()` and `AActor:GetLevel()` functions are now returning an invalid `UObject` instead of `nil`. ([UE4SS #810](https://github.com/UE4SS-RE/RE-UE4SS/pull/810)) 
+**BREAKING:** `AActor:GetWorld()` and `AActor:GetLevel()` functions are now returning an invalid `UObject` instead of `nil`. ([UE4SS #810](https://github.com/UE4SS-RE/RE-UE4SS/pull/810))
+
+Types with `get` or `Get` functions now have both variants. ([UE4SS #877](https://github.com/UE4SS-RE/RE-UE4SS/pull/877))
 
 #### UEHelpers [UE4SS #650](https://github.com/UE4SS-RE/RE-UE4SS/pull/650) 
 - Increased version to 3

--- a/docs/lua-api/classes/fweakobjectptr.md
+++ b/docs/lua-api/classes/fweakobjectptr.md
@@ -5,7 +5,7 @@
 
 ## Methods
 
-### Get()
+### Get() / get()
 
 - **Return type:** `UObjectDerivative`
 - **Returns:** the pointed to `UObject` or `UObject` derivative.

--- a/docs/lua-api/classes/localunrealparam.md
+++ b/docs/lua-api/classes/localunrealparam.md
@@ -9,7 +9,7 @@ This is a dynamic wrapper for any and all types & classes.
 
 ## Methods
 
-### get()
+### Get() / get()
 
 - **Return type:** `auto`
 - **Returns:** the underlying value for this param.

--- a/docs/lua-api/classes/remoteunrealparam.md
+++ b/docs/lua-api/classes/remoteunrealparam.md
@@ -9,7 +9,7 @@ This is a dynamic wrapper for any and all types & classes.
 
 ## Methods
 
-### get()
+### Get() / get()
 
 - **Return type:** `auto`
 - **Returns:** the underlying value for this param.


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

For whatever reason, `FWeakObjectPtr` uses `get` and `LocalUnrealParam` and `RemoteUnrealParam` uses `Get`.
This PR makes both variants available for all three types.

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [x] I have made corresponding changes to the documentation.
- [ ] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
