### PR TITLE
Feature: Live View search by memory address

### DIFF
--- a/UE4SS/include/SettingsManager.hpp
+++ b/UE4SS/include/SettingsManager.hpp
@@ -26,6 +26,7 @@ namespace RC
             int64_t SecondsToScanBeforeGivingUp{30};
             bool UseUObjectArrayCache{true};
             StringType InputSource{STR("Default")};
+            bool SearchByAddress{false};
         } General;
 
         struct SectionEngineVersionOverride

--- a/UE4SS/src/GUI/LiveView.cpp
+++ b/UE4SS/src/GUI/LiveView.cpp
@@ -177,6 +177,23 @@ namespace RC::GUI
         }
     }
 
+    static void attempt_to_add_search_by_address_result(uintptr_t address_to_search_by, UObject* object)
+    {
+        auto object_addr = std::bit_cast<uintptr_t>(object);
+        if (address_to_search_by < object_addr)
+        {
+            return;
+        }
+
+        auto uclass = object->IsA<UStruct>() ? static_cast<UClass*>(object) : object->GetClassPrivate();
+        uintptr_t end_addr = object_addr + uclass->GetPropertiesSize();
+        //Output::send<LogLevel::Default>(STR("object_addr {:016X}-{:016X}"), object_addr, end_addr);
+        if (address_to_search_by < end_addr) {
+            LiveView::s_name_search_results.emplace_back(object);
+            LiveView::s_name_search_results_set.emplace(object);
+        }
+    }
+
     static auto remove_search_result(UObject* object) -> void
     {
         LiveView::s_name_search_results.erase(std::remove_if(LiveView::s_name_search_results.begin(),
@@ -1817,8 +1834,25 @@ namespace RC::GUI
         Output::send(STR("Searching by name...\n"));
         s_name_search_results.clear();
         s_name_search_results_set.clear();
+
+        uintptr_t address_to_search_by = 0;
+        if (UE4SSProgram::settings_manager.General.SearchByAddress &&
+           (LiveView::s_name_to_search_by.size() >= 6 && LiveView::s_name_to_search_by.size() <= 16))
+        {
+            try
+            {
+                address_to_search_by = std::stoull(LiveView::s_name_to_search_by, nullptr, 16);
+                Output::send<LogLevel::Default>(STR("Searching for object with address: {:016X}"), address_to_search_by);
+            }
+            catch (...) {}
+        }
+
         UObjectGlobals::ForEachUObject([&](UObject* object, ...) {
             attempt_to_add_search_result(object);
+            if (address_to_search_by)
+            {
+                attempt_to_add_search_by_address_result(address_to_search_by, object);
+            }
             return LoopAction::Continue;
         });
     }

--- a/UE4SS/src/SettingsManager.cpp
+++ b/UE4SS/src/SettingsManager.cpp
@@ -57,6 +57,7 @@ namespace RC
         REGISTER_BOOL_SETTING(General.EnableDebugKeyBindings, section_general, EnableDebugKeyBindings)
         REGISTER_INT64_SETTING(General.SecondsToScanBeforeGivingUp, section_general, SecondsToScanBeforeGivingUp)
         REGISTER_BOOL_SETTING(General.UseUObjectArrayCache, section_general, bUseUObjectArrayCache)
+        REGISTER_BOOL_SETTING(General.SearchByAddress, section_general, bEnableSeachByMemoryAddress)
 
         constexpr static File::CharType section_engine_version_override[] = STR("EngineVersionOverride");
         REGISTER_INT64_SETTING(EngineVersionOverride.MajorVersion, section_engine_version_override, MajorVersion)

--- a/assets/UE4SS-settings.ini
+++ b/assets/UE4SS-settings.ini
@@ -23,6 +23,10 @@ SecondsToScanBeforeGivingUp = 30
 ; Default: true
 bUseUObjectArrayCache = true
 
+; When the search query in the Live View tab is a hex number, try to find the UObject that contains that memory address.
+; Default: false
+bEnableSeachByMemoryAddress = false
+
 [EngineVersionOverride]
 MajorVersion = 
 MinorVersion = 


### PR DESCRIPTION
**Description**
Add logic to the LiveView search to treat hex numbers as memory addresses, and return the object that probably contains it (reusing the size calculation from elsewhere; maybe inaccurate).
Disabled by default. Few people might use it, and it does add some time to the search (but not perceptibly on my machine).

**Type of change**
- [x] New feature (non-breaking change which adds functionality)

**How has this been tested?**
Only tested on UE 5.3 (Oblivion)
- find the address of an object, then search for it

**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
- [ ] Any dependent changes have been merged and published in downstream modules.