### PR TITLE
Fixes UTC crash timestamp to local time

### DIFF
--- a/deps/first/DynamicOutput/src/OutputDevice.cpp
+++ b/deps/first/DynamicOutput/src/OutputDevice.cpp
@@ -25,7 +25,7 @@ namespace RC::Output
 
     auto OutputDevice::get_now_as_string() -> const File::StringType
     {
-        auto now = std::chrono::system_clock::now();
+        auto now = std::chrono::current_zone()->to_local(std::chrono::system_clock::now());
         const File::StringType when_as_string = fmt::format(STR("{:%Y-%m-%d %X}"), now);
         return when_as_string;
     }


### PR DESCRIPTION
Because the amount of people capable of building of UE4SS can be counted by the fingers of my left hand (and I have all the fingers there) - I cannot test this.

