### PR TITLE
Fix package path not including the scripts folder

### DIFF
--- a/UE4SS/src/Mod/LuaMod.cpp
+++ b/UE4SS/src/Mod/LuaMod.cpp
@@ -1004,7 +1004,7 @@ namespace RC
             std::string scripts_path_utf8 = normalize_path_for_lua(m_scripts_path);
 
             // Create path strings with forward slashes for Lua
-            std::string script_path = fmt::format(";{}/{}/?.lua", mods_dir_utf8, mod_name_utf8);
+            std::string script_path = fmt::format(";{}/?.lua", scripts_path_utf8);
             std::string shared_path = fmt::format(";{}/shared/?.lua", mods_dir_utf8);
             std::string shared_nested_path = fmt::format(";{}/shared/?/?.lua", mods_dir_utf8);
 
@@ -1021,7 +1021,7 @@ namespace RC
             lua_pop(lua_state, 1);
 
             // Create cpath strings
-            std::string script_dll_path = fmt::format(";{}/{}/?.dll", mods_dir_utf8, mod_name_utf8);
+            std::string script_dll_path = fmt::format(";{}/?.dll", scripts_path_utf8);
             std::string mod_dll_path = fmt::format(";{}/{}/?/?.dll", mods_dir_utf8, mod_name_utf8);
 
             current_cpaths.append(script_dll_path);


### PR DESCRIPTION
**Description**
Fixes an issue with the scripts folder of a Lua mod not being included in the package path.
This caused `require()` to always need the scripts folder to be included (e.g. `require("Scripts.myScript")` instead of just `require("myScript")`)

Fixes [the issue discussed on Discord](https://discord.com/channels/1148976194050605066/1148977475234316339/1385422612175261756), which was introduced in [this commit](https://github.com/UE4SS-RE/RE-UE4SS/commit/b72dfae17ec0197d67387b9ddbdb4b3c0897e045).

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**How has this been tested?**
The scripts folder of Lua mods is now included in the package path and `require("myScript")` works properly.
