### PR TITLE
Expandable struct and array properties

### DIFF
--- a/UE4SS/src/GUI/LiveView.cpp
+++ b/UE4SS/src/GUI/LiveView.cpp
@@ -1957,12 +1957,37 @@ namespace RC::GUI
         {
             for (FProperty* property : ustruct->ForEachProperty())
             {
-                ImGui::TreeNodeEx(to_string(property->GetFullName()).c_str(), ImGuiTreeNodeFlags_Leaf);
-                if (ImGui::IsItemClicked())
+                bool is_struct_property = CastField<FStructProperty>(property) != nullptr;
+                if (ImGui::TreeNodeEx(to_string(property->GetFullName()).c_str(), is_struct_property ? 0 : ImGuiTreeNodeFlags_Leaf) && is_struct_property)
                 {
-                    select_property(0, property, AffectsHistory::Yes);
+                    ImGui::Indent();
+                    ImGui::Text("Struct");
+                    if (auto struct_property_struct = CastField<FStructProperty>(property)->GetStruct())
+                    {
+                        if (ImGui::TreeNode(get_object_full_name(struct_property_struct)))
+                        {
+                            render_struct_sub_tree_hierarchy(struct_property_struct);
+                            ImGui::TreePop();
+                        }
+                        else
+                        {
+                            if (ImGui::IsItemClicked())
+                            {
+                                select_object(0, struct_property_struct->GetObjectItem(), struct_property_struct, AffectsHistory::Yes);
+                            }
+                        }
+                    }
+                    ImGui::Unindent();
+                    ImGui::TreePop();
                 }
-                ImGui::TreePop();
+                else
+                {
+                    if (ImGui::IsItemClicked())
+                    {
+                        select_property(0, property, AffectsHistory::Yes);
+                    }
+                }
+                if (!is_struct_property) ImGui::TreePop();
             }
             ImGui::TreePop();
         }

--- a/UE4SS/src/GUI/LiveView.cpp
+++ b/UE4SS/src/GUI/LiveView.cpp
@@ -1987,12 +1987,36 @@ namespace RC::GUI
                         ImGui::Text("Inner");
                         if (auto array_property_inner = CastField<FArrayProperty>(property)->GetInner())
                         {
-                            ImGui::TreeNodeEx(to_string(array_property_inner->GetFullName()).c_str(), ImGuiTreeNodeFlags_Leaf);
-                            if (ImGui::IsItemClicked())
+                            bool is_inner_struct = CastField<FStructProperty>(array_property_inner) != nullptr;
+                            if (ImGui::TreeNodeEx(to_string(array_property_inner->GetFullName()).c_str(), is_inner_struct ? 0 : ImGuiTreeNodeFlags_Leaf) && is_inner_struct)
                             {
-                                select_property(0, array_property_inner, AffectsHistory::Yes);
+                                ImGui::Indent();
+                                ImGui::Text("Struct");
+                                auto inner_struct_property = CastField<FStructProperty>(array_property_inner);
+                                auto inner_struct_property_struct = inner_struct_property->GetStruct();
+                                if (ImGui::TreeNode(get_object_full_name(inner_struct_property_struct)))
+                                {
+                                    render_struct_sub_tree_hierarchy(inner_struct_property_struct);
+                                    ImGui::TreePop();
+                                }
+                                else
+                                {
+                                    if (ImGui::IsItemClicked())
+                                    {
+                                        select_object(0, inner_struct_property_struct->GetObjectItem(), inner_struct_property_struct, AffectsHistory::Yes);
+                                    }
+                                }
+                                ImGui::Unindent();
+                                ImGui::TreePop();
                             }
-                            ImGui::TreePop();
+                            else
+                            {
+                                if (ImGui::IsItemClicked())
+                                {
+                                    select_property(0, array_property_inner, AffectsHistory::Yes);
+                                }
+                            }
+                            if (!is_inner_struct) ImGui::TreePop();
                         }
                     }
                     ImGui::Unindent();

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -268,6 +268,9 @@ Fixed crash caused by using invalid iterator. ([UE4SS #771](https://github.com/U
 Fixed opened object getting clipped too early ([UE4SS #814](https://github.com/UE4SS-RE/RE-UE4SS/pull/814)) -
 Corporalwill123
 
+Made StructProperty and ArrayProperty Expandable, making contained properties directly viewable ([UE4SS #943](https://github.com/UE4SS-RE/RE-UE4SS/pull/943)) -
+Corporalwill123
+
 ### UHT Dumper 
 Fix SetupAttachment implementations randomly changing order ([UE4SS #606](https://github.com/UE4SS-RE/RE-UE4SS/pull/606)) - Buckminsterfullerene 
 


### PR DESCRIPTION
**Description**
Adds ability to expand StructProperty and ArrayProperty nodes within LiveView

- [x] New feature (non-breaking change which adds functionality)

**How has this been tested?**
Expanding `ScriptStruct /Script/CoreUObject.Transform` Struct Properties
Expanding `Class /Script/Engine.ActorComponent` UCSModifiedProperties Property

**Checklist**
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.