### PR TITLE
refactor(lua): create struct conversion helpers from push_structproperty

### DIFF
--- a/UE4SS/include/LuaType/LuaUObject.hpp
+++ b/UE4SS/include/LuaType/LuaUObject.hpp
@@ -349,6 +349,17 @@ namespace RC::LuaType
     RC_UE4SS_API auto construct_uclass(const LuaMadeSimple::Lua&) -> void;
     RC_UE4SS_API auto construct_xproperty(const LuaMadeSimple::Lua&, Unreal::FProperty* property) -> void;
 
+    auto convert_lua_table_to_struct(const LuaMadeSimple::Lua& lua,
+                                     Unreal::UScriptStruct* script_struct,
+                                     void* data,
+                                     int table_index,
+                                     Unreal::UObject* base = nullptr) -> void;
+    auto convert_struct_to_lua_table(const LuaMadeSimple::Lua& lua,
+                                     Unreal::UScriptStruct* script_struct,
+                                     void* data,
+                                     bool create_new_table = true,
+                                     Unreal::UObject* base = nullptr) -> void;
+
     // Push to Lua -> START
     RC_UE4SS_API auto push_unhandledproperty(const PusherParams&) -> void;
     RC_UE4SS_API auto push_objectproperty(const PusherParams&) -> void;


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->
Creates reusable convert_lua_table_to_struct and convert_struct_to_lua_table helper functions
- Extract convert_lua_table_to_struct and convert_struct_to_lua_table from push_structproperty to helper functions
- Add special handling for arrays with unsupported inner types
- Replace inline lambdas

Fixes # (issue) (if applicable)

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

**How has this been tested?**
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration. -->
Tested in a couple of games. More testing requested

**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [x] I have commented my code, particularly in hard-to-understand areas.

**Screenshots**
<!--Add screenshots to help explain your PR, if applicable.-->


**Additional context**
<!-- Add any other context about the pull request here. -->

