### PR TITLE
feat(Init): Do a single scan while blocking the game thread

### DIFF
--- a/UE4SS/include/ExceptionHandling.hpp
+++ b/UE4SS/include/ExceptionHandling.hpp
@@ -26,7 +26,10 @@
 #define SEH_EXCEPT(Code)                                                                                                                                       \
     __except (SEH_exception_filter(GetExceptionCode(), GetExceptionInformation()))                                                                             \
     {                                                                                                                                                          \
-        Code std::exit(EXIT_FAILURE);                                                                                                                          \
+        Code if (!Unreal::UnrealInitializer::StaticStorage::GlobalConfig.bIsForcedPreScan)                                                                           \
+        {                                                                                                                                                      \
+            std::exit(EXIT_FAILURE);                                                                                                                           \
+        }                                                                                                                                                      \
     }
 #endif
 #else

--- a/UE4SS/include/UE4SSProgram.hpp
+++ b/UE4SS/include/UE4SSProgram.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <functional>
 #include <mutex>
 #include <string>
@@ -94,6 +95,7 @@ namespace RC
       public:
         RC_UE4SS_API static SettingsManager settings_manager;
         static inline bool unreal_is_shutting_down{};
+        static inline std::atomic_bool cpp_mods_done_loading{};
 
       public:
         bool m_is_program_started;

--- a/UE4SS/src/main_ue4ss_rewritten.cpp
+++ b/UE4SS/src/main_ue4ss_rewritten.cpp
@@ -50,6 +50,8 @@ auto process_initialized(HMODULE moduleHandle) -> void
     {
         CloseHandle(handle);
     }
+
+    UE4SSProgram::cpp_mods_done_loading.wait(false, std::memory_order_relaxed);
 }
 
 auto get_main_thread_id() -> DWORD

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -182,6 +182,8 @@ release ([UE4SS #779](https://github.com/UE4SS-RE/RE-UE4SS/pull/779))
 
 Removed some development mods, `README.md` & `Changelog.md` from non-zDev release, added `LICENCE` file to both release types ([UE4SS #830](https://github.com/UE4SS-RE/RE-UE4SS/pull/830))
 
+The execution of the game is now paused durin the first AOB scan, and then resumed to complete potential further scans and initialization. ([UE4SS #985](https://github.com/UE4SS-RE/RE-UE4SS/pull/985))
+
 ### Live View 
 Fixed the majority of the lag ([UE4SS #512](https://github.com/UE4SS-RE/RE-UE4SS/pull/512)) 
 


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

The game thread is immediately unblocked after the scan, and then init continues asynchronously as usual.

<!-- Fixes # (issue) (if applicable) -->

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Other... Please describe: Internal non-breaking change, preparing for the future.

**How has this been tested?**
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration. -->

Tested with Palworld by making sure everything inits properly, and making sure it fails correctly with an improper UE4SS_Signature file to simulate an AOB not being found.

**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
- [x] Any dependent changes have been merged and published in downstream modules.

**Additional context**
<!-- Add any other context about the pull request here. -->

Dependent on https://github.com/Re-UE4SS/UEPseudo/pull/149