### PR TITLE
fix(UEHelpers): CacheDefaultObject erroring out instead of returning an invalid object

### DIFF
--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -321,6 +321,8 @@ names. ([UE4SS #827](https://github.com/UE4SS-RE/RE-UE4SS/pull/827)
 
 Fixed an error with Object properties causing stack corruption. ([UE4SS #939](https://github.com/UE4SS-RE/RE-UE4SS/pull/939)
 
+Fixed UEHelpers sometimes causing a runtime error. ([UE4SS #987](https://github.com/UE4SS-RE/RE-UE4SS/pull/987)
+
 ### C++ API 
 Fixed a crash caused by a race condition enabled by C++ mods using `UE4SS_ENABLE_IMGUI` in their constructor ([UE4SS #481](https://github.com/UE4SS-RE/RE-UE4SS/pull/481)) 
 

--- a/assets/Mods/shared/UEHelpers/UEHelpers.lua
+++ b/assets/Mods/shared/UEHelpers/UEHelpers.lua
@@ -21,7 +21,6 @@ local function CacheDefaultObject(ObjectFullName, VariableName, ForceInvalidateC
 
     DefaultObject = StaticFindObject(ObjectFullName)
     ModRef:SetSharedVariable(VariableName, DefaultObject)
-    if not DefaultObject:IsValid() then error(string.format("%s not found", ObjectFullName)) end
 
     return DefaultObject
 end


### PR DESCRIPTION
**Description**

This is inconsistent with the rest of UEHelpers which is supposed to never cause an error, it returns CreateInvalidObject instead.

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

**How has this been tested?**
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration. -->


**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.