### PR TITLE
fix(lua): add TArray userdata round-trip support

### DIFF
--- a/UE4SS/src/LuaType/LuaUObject.cpp
+++ b/UE4SS/src/LuaType/LuaUObject.cpp
@@ -869,23 +869,51 @@ namespace RC::LuaType
         };
 
         auto lua_to_memory = [&]() {
-            if (params.lua.is_userdata())
+            if (params.lua.is_userdata(params.stored_at_index))
             {
-                // TArray as userdata
-                params.throw_error("push_arrayproperty::lua_to_memory", "StructData as userdata is not yet implemented but there's userdata on the stack");
+                // Handle TArray userdata
+                auto& lua_tarray = params.lua.get_userdata<TArray>(params.stored_at_index);
+                Unreal::FScriptArray* source_array = lua_tarray.get_remote_cpp_object();
+                
+                Unreal::FArrayProperty* array_property = static_cast<Unreal::FArrayProperty*>(params.property);
+                Unreal::FProperty* inner = array_property->GetInner();
+                
+                auto dest_array = static_cast<Unreal::FScriptArray*>(params.data);
+                
+                // Clear destination array
+                dest_array->Empty(0, inner->GetSize(), inner->GetMinAlignment());
+                
+                // Copy elements from source to destination
+                int32_t num_elements = source_array->Num();
+                if (num_elements > 0)
+                {
+                    dest_array->AddZeroed(num_elements, inner->GetSize(), inner->GetMinAlignment());
+                    
+                    for (int32_t i = 0; i < num_elements; i++)
+                    {
+                        void* src_element = static_cast<uint8_t*>(source_array->GetData()) + (i * inner->GetSize());
+                        void* dest_element = static_cast<uint8_t*>(dest_array->GetData()) + (i * inner->GetSize());
+                        
+                        inner->CopySingleValueToScriptVM(dest_element, src_element);
+                    }
+                }
             }
-            else if (params.lua.is_table())
+            else if (params.lua.is_table(params.stored_at_index))
             {
                 // TArray as table
                 lua_table_to_memory();
             }
-            else if (params.lua.is_nil())
+            else if (params.lua.is_nil(params.stored_at_index))
             {
-                params.lua.discard_value();
+                // Empty array
+                auto array = static_cast<Unreal::FScriptArray*>(params.data);
+                Unreal::FArrayProperty* array_property = static_cast<Unreal::FArrayProperty*>(params.property);
+                Unreal::FProperty* inner = array_property->GetInner();
+                array->Empty(0, inner->GetSize(), inner->GetMinAlignment());
             }
             else
             {
-                params.throw_error("push_arrayproperty::lua_to_memory", "Parameter must be of type 'StructProperty' or table");
+                params.throw_error("push_arrayproperty::lua_to_memory", "Parameter must be of type 'TArray' or table");
             }
         };
 

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -63,6 +63,11 @@ Added ability to call UFunctions directly from the GUI. ([UE4SS #851](https://gi
 **Updated Lua version to 5.4.7** ([UE4SS #887](https://github.com/UE4SS-RE/RE-UE4SS/pull/887))
 - This is necessary to compile with Clang.
 
+Enhanced TArray support to enable round-trip functionality ([UE4SS #992](https://github.com/UE4SS-RE/RE-UE4SS/pull/992))
+- TArray userdata can now be passed as function parameters
+- Improved handling of empty arrays and nil values
+- Fixed proper element copying when passing arrays between Lua and C++
+
 Added `TSet` implementation. [UE4SS #883](https://github.com/UE4SS-RE/RE-UE4SS/pull/883)
 
 Added `TMap` implementation. [UE4SS #755](https://github.com/UE4SS-RE/RE-UE4SS/issues/755)


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

  - Implement TArray userdata handling in push_arrayproperty::lua_to_memory
  - Support copying TArray userdata to function parameters
  - Handle empty arrays and proper element copying with CopySingleValueToScriptVM

Enables passing TArray properties as function parameters, matching TSet functionality

Fixes # (issue) (if applicable)

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

**How has this been tested?**
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration. -->
Tested passing TArray properties as function parameters
Verified proper handling of empty arrays and nil values
Confirmed element copying maintains data integrity
Tested with various element types (int32, string, UObject references)

**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.


**Screenshots**
<!--Add screenshots to help explain your PR, if applicable.-->


**Additional context**
<!-- Add any other context about the pull request here. -->

