### PR TITLE
refactor(FName)!: default to FNAME_Add for string constructors

### DIFF
--- a/UE4SS/src/LuaType/LuaFName.cpp
+++ b/UE4SS/src/LuaType/LuaFName.cpp
@@ -50,8 +50,8 @@ namespace RC::LuaType
             std::string error_overload_not_found{R"(
 No overload found for function 'FName'.
 Overloads:
-#1: FName(string Name, EFindName = FName_Add)
-#2: FName(integer ComparisonIndex, EFindName = FName_Add))"};
+#1: FName(string Name, EFindName = FNAME_Add)
+#2: FName(integer ComparisonIndex, EFindName = FNAME_Add))"};
 
             if (lua.is_userdata())
             {

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -23,7 +23,12 @@ Added basic support for Development/Debug/Test built Unreal Engine games ([UE4SS
 Added new build definition "LessEqual421".  Using this definition for games on UE<=4.21 is not mandatory for UE4SS to function, but will ensure the correct alignment is used in containers. 
 
 **BREAKING:** - This also changes the default FName alignment from 8 to 4. 
-- To use this functionality, enter LessEqual421 in the <Target> section of the XMake configuration command. 
+- To use this functionality, enter LessEqual421 in the <Target> section of the XMake configuration command.
+
+**BREAKING:** Changed default `EFindName` parameter for FName constructors from `FNAME_Find` to `FNAME_Add`. 
+- FName constructors will now create new name table entries by default if the name doesn't exist, rather than returning NAME_None
+- To maintain the old behavior, explicitly pass `FNAME_Find` as the second parameter
+- This affects all string-based FName constructors 
 
 Added optional scans for GUObjectHashTables, GNatives and ConsoleManagerSingleton; made FText an optional scan; externed the found GNatives for use by mods([UE4SS #744](https://github.com/UE4SS-RE/RE-UE4SS/pull/744)) 
 - GUObjectHashTables and ConsoleManagerSingleton are currently unused and a WIP.


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->
BREAKING CHANGE: FName string constructors now default to FNAME_Add instead of FNAME_Find.
This means constructors will create new name table entries if the name doesn't exist, rather than returning NAME_None.

- Changed default FindType parameter from FNAME_Find to FNAME_Add for all string-based constructors
- Affects FName(const CharType*), FName(StringViewType), and FName(StringViewType, uint32) constructors
- Existing code relying on FNAME_Find behavior must now explicitly pass it as a parameter

Migration: Code that expects NAME_None for non-existent names should explicitly use FNAME_Find:
  Before: FName TestName(TEXT("MayNotExist"));
  After:  FName TestName(TEXT("MayNotExist"), FNAME_Find);


Fixes # (issue) (if applicable)

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Is/requires documentation update

**How has this been tested?**
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration. -->


**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
- [x] Any dependent changes have been merged and published in downstream modules.

**Screenshots**
<!--Add screenshots to help explain your PR, if applicable.-->


**Additional context**
<!-- Add any other context about the pull request here. -->

