### PR TITLE
Add Lua support for SoftObjectProperty

### DIFF
--- a/UE4SS/include/LuaType/LuaTSoftObjectPtr.hpp
+++ b/UE4SS/include/LuaType/LuaTSoftObjectPtr.hpp
@@ -1,24 +1,24 @@
 #pragma once
 
 #include <LuaType/LuaUObject.hpp>
-#include <Unreal/Property/FSoftClassProperty.hpp>
+#include <Unreal/Property/FSoftObjectProperty.hpp>
 
 namespace RC::LuaType
 {
-    struct TSoftClassPtrName
+    struct TSoftObjectPtrName
     {
         constexpr static const char* ToString()
         {
-            return "TSoftClassPtr";
+            return "TSoftObjectPtr";
         }
     };
-    class TSoftClassPtr : public LocalObjectBase<Unreal::FSoftObjectPtr, TSoftClassPtrName>
+    class TSoftObjectPtr : public LocalObjectBase<Unreal::FSoftObjectPtr, TSoftObjectPtrName>
     {
       private:
-        explicit TSoftClassPtr(Unreal::FSoftObjectPtr object);
+        explicit TSoftObjectPtr(Unreal::FSoftObjectPtr object);
 
       public:
-        TSoftClassPtr() = delete;
+        TSoftObjectPtr() = delete;
         auto static construct(const LuaMadeSimple::Lua&, Unreal::FSoftObjectPtr&) -> const LuaMadeSimple::Lua::Table;
         auto static construct(const LuaMadeSimple::Lua&, BaseObject&) -> const LuaMadeSimple::Lua::Table;
 

--- a/UE4SS/include/LuaType/LuaUObject.hpp
+++ b/UE4SS/include/LuaType/LuaUObject.hpp
@@ -384,7 +384,7 @@ namespace RC::LuaType
     RC_UE4SS_API auto push_nameproperty(const PusherParams&) -> void;
     RC_UE4SS_API auto push_textproperty(const PusherParams&) -> void;
     RC_UE4SS_API auto push_strproperty(const PusherParams&) -> void;
-    RC_UE4SS_API auto push_softclassproperty(const PusherParams&) -> void;
+    RC_UE4SS_API auto push_softobjectproperty(const PusherParams&) -> void;
     RC_UE4SS_API auto push_interfaceproperty(const PusherParams&) -> void;
 
     RC_UE4SS_API auto push_functionproperty(const FunctionPusherParams&) -> void;

--- a/UE4SS/src/LuaType/LuaTSoftObjectPtr.cpp
+++ b/UE4SS/src/LuaType/LuaTSoftObjectPtr.cpp
@@ -2,19 +2,19 @@
 #include <Helpers/String.hpp>
 #include <LuaType/LuaFSoftObjectPath.hpp>
 #include <LuaType/LuaFWeakObjectPtr.hpp>
-#include <LuaType/LuaTSoftClassPtr.hpp>
+#include <LuaType/LuaTSoftObjectPtr.hpp>
 
 namespace RC::LuaType
 {
-    TSoftClassPtr::TSoftClassPtr(Unreal::FSoftObjectPtr object) : LocalObjectBase<Unreal::FSoftObjectPtr, TSoftClassPtrName>(std::move(object))
+    TSoftObjectPtr::TSoftObjectPtr(Unreal::FSoftObjectPtr object) : LocalObjectBase<Unreal::FSoftObjectPtr, TSoftObjectPtrName>(std::move(object))
     {
     }
 
-    auto TSoftClassPtr::construct(const LuaMadeSimple::Lua& lua, Unreal::FSoftObjectPtr& unreal_object) -> const LuaMadeSimple::Lua::Table
+    auto TSoftObjectPtr::construct(const LuaMadeSimple::Lua& lua, Unreal::FSoftObjectPtr& unreal_object) -> const LuaMadeSimple::Lua::Table
     {
-        LuaType::TSoftClassPtr lua_object{unreal_object};
+        LuaType::TSoftObjectPtr lua_object{unreal_object};
 
-        auto metatable_name = "TSoftClassPtrUserdata";
+        auto metatable_name = "TSoftObjectPtrUserdata";
 
         LuaMadeSimple::Lua::Table table = lua.get_metatable(metatable_name);
         if (lua.is_nil(-1))
@@ -23,7 +23,7 @@ namespace RC::LuaType
             lua.prepare_new_table();
             setup_metamethods(lua_object);
             setup_member_functions<LuaMadeSimple::Type::IsFinal::Yes>(table, metatable_name);
-            lua.new_metatable<LuaType::TSoftClassPtr>(metatable_name, lua_object.get_metamethods());
+            lua.new_metatable<LuaType::TSoftObjectPtr>(metatable_name, lua_object.get_metamethods());
         }
 
         // Create object & surrender ownership to Lua
@@ -32,12 +32,12 @@ namespace RC::LuaType
         return table;
     }
 
-    auto TSoftClassPtr::construct(const LuaMadeSimple::Lua& lua, BaseObject& construct_to) -> const LuaMadeSimple::Lua::Table
+    auto TSoftObjectPtr::construct(const LuaMadeSimple::Lua& lua, BaseObject& construct_to) -> const LuaMadeSimple::Lua::Table
     {
         LuaMadeSimple::Lua::Table table = lua.prepare_new_table();
         ;
 
-        auto metatable_name = "TSoftClassPtrUserdata";
+        auto metatable_name = "TSoftObjectPtrUserdata";
 
         setup_metamethods(construct_to);
         setup_member_functions<LuaMadeSimple::Type::IsFinal::No>(table, metatable_name);
@@ -45,21 +45,27 @@ namespace RC::LuaType
         return table;
     }
 
-    auto TSoftClassPtr::setup_metamethods(BaseObject& base_object) -> void
+    auto TSoftObjectPtr::setup_metamethods(BaseObject& base_object) -> void
     {
     }
 
     template <LuaMadeSimple::Type::IsFinal is_final>
-    auto TSoftClassPtr::setup_member_functions(LuaMadeSimple::Lua::Table& table, std::string_view metatable_name) -> void
+    auto TSoftObjectPtr::setup_member_functions(LuaMadeSimple::Lua::Table& table, std::string_view metatable_name) -> void
     {
+        table.add_pair("GetWeakPtr", [](const LuaMadeSimple::Lua& lua) -> int {
+            auto& lua_object = lua.get_userdata<TSoftObjectPtr>();
+            FWeakObjectPtr::construct(lua, lua_object.get_local_cpp_object().WeakPtr);
+            return 1;
+        });
+
         table.add_pair("GetTagAtLastTest", [](const LuaMadeSimple::Lua& lua) -> int {
-            auto& lua_object = lua.get_userdata<TSoftClassPtr>();
+            auto& lua_object = lua.get_userdata<TSoftObjectPtr>();
             lua.set_integer(lua_object.get_local_cpp_object().TagAtLastTest);
             return 1;
         });
 
         table.add_pair("GetObjectID", [](const LuaMadeSimple::Lua& lua) -> int {
-            auto& lua_object = lua.get_userdata<TSoftClassPtr>();
+            auto& lua_object = lua.get_userdata<TSoftObjectPtr>();
             FSoftObjectPath::construct(lua, lua_object.get_local_cpp_object().ObjectID);
             return 1;
         });
@@ -67,7 +73,7 @@ namespace RC::LuaType
         if constexpr (is_final == LuaMadeSimple::Type::IsFinal::Yes)
         {
             table.add_pair("type", [](const LuaMadeSimple::Lua& lua) -> int {
-                lua.set_string("TSoftClassPtrUserdata");
+                lua.set_string("TSoftObjectPtrUserdata");
                 return 1;
             });
 

--- a/UE4SS/src/LuaType/LuaUObject.cpp
+++ b/UE4SS/src/LuaType/LuaUObject.cpp
@@ -8,7 +8,7 @@
 #include <LuaType/LuaTArray.hpp>
 #include <LuaType/LuaTSet.hpp>
 #include <LuaType/LuaTMap.hpp>
-#include <LuaType/LuaTSoftClassPtr.hpp>
+#include <LuaType/LuaTSoftObjectPtr.hpp>
 #include <LuaType/LuaUClass.hpp>
 #include <LuaType/LuaUEnum.hpp>
 #include <LuaType/LuaUFunction.hpp>
@@ -1655,22 +1655,22 @@ namespace RC::LuaType
         params.throw_error("push_strproperty", "Operation not supported");
     }
 
-    auto push_softclassproperty(const PusherParams& params) -> void
+    auto push_softobjectproperty(const PusherParams& params) -> void
     {
         auto soft_ptr = static_cast<Unreal::FSoftObjectPtr*>(params.data);
         if (!soft_ptr)
         {
-            params.throw_error("push_softclassproperty", "data pointer is nullptr");
+            params.throw_error("push_softobjectproperty", "data pointer is nullptr");
         }
 
         switch (params.operation)
         {
         case Operation::GetNonTrivialLocal:
         case Operation::Get:
-            LuaType::TSoftClassPtr::construct(params.lua, *soft_ptr);
+            LuaType::TSoftObjectPtr::construct(params.lua, *soft_ptr);
             return;
         case Operation::Set: {
-            auto& lua_object = params.lua.get_userdata<LuaType::TSoftClassPtr>(params.stored_at_index);
+            auto& lua_object = params.lua.get_userdata<LuaType::TSoftObjectPtr>(params.stored_at_index);
             *soft_ptr = lua_object.get_local_cpp_object();
             return;
         }
@@ -1678,11 +1678,11 @@ namespace RC::LuaType
             RemoteUnrealParam::construct(params.lua, params.data, params.base, params.property);
             return;
         default:
-            params.throw_error("push_softclassproperty", "Unhandled Operation");
+            params.throw_error("push_softobjectproperty", "Unhandled Operation");
             break;
         }
 
-        params.throw_error("push_softclassproperty", "Operation not supported");
+        params.throw_error("push_softobjectproperty", "Operation not supported");
     }
 
     auto push_interfaceproperty(const PusherParams& params) -> void

--- a/UE4SS/src/UE4SSProgram.cpp
+++ b/UE4SS/src/UE4SSProgram.cpp
@@ -1163,7 +1163,8 @@ namespace RC
         LuaType::StaticState::m_property_value_pushers.emplace(FName(STR("NameProperty")).GetComparisonIndex(), &LuaType::push_nameproperty);
         LuaType::StaticState::m_property_value_pushers.emplace(FName(STR("TextProperty")).GetComparisonIndex(), &LuaType::push_textproperty);
         LuaType::StaticState::m_property_value_pushers.emplace(FName(STR("StrProperty")).GetComparisonIndex(), &LuaType::push_strproperty);
-        LuaType::StaticState::m_property_value_pushers.emplace(FName(STR("SoftClassProperty")).GetComparisonIndex(), &LuaType::push_softclassproperty);
+        LuaType::StaticState::m_property_value_pushers.emplace(FName(STR("SoftObjectProperty")).GetComparisonIndex(), &LuaType::push_softobjectproperty);
+        LuaType::StaticState::m_property_value_pushers.emplace(FName(STR("SoftClassProperty")).GetComparisonIndex(), &LuaType::push_softobjectproperty);
         LuaType::StaticState::m_property_value_pushers.emplace(FName(STR("InterfaceProperty")).GetComparisonIndex(), &LuaType::push_interfaceproperty);
     }
 


### PR DESCRIPTION
**Description**
Renamed _TSoftClassProperty_ class to _TSoftObjectProperty_, which now handles both types of soft properties. Also added a new Lua `GetWeakPtr` method to retrieve weak pointer from a SoftObjectProperty.

**Type of change**
<!-- Please delete options that are not relevant. -->

- [X] New feature (non-breaking change which adds functionality)

**How has this been tested?**
Both types of soft properties can now be interacted with in Lua.

