### PR TITLE
feat(Lua): Option to auto-reload individual mods when a change is detected in the Scripts directory

### DIFF
--- a/UE4SS/include/FilesystemWatcher.hpp
+++ b/UE4SS/include/FilesystemWatcher.hpp
@@ -34,19 +34,6 @@ namespace RC
         }
     };
 
-    // clang-format off
-    enum class LibReloaderState
-    {
-        Idle = -1,                          // Main thread is executing, loader thread is waiting for notification from the OS.
-        ReloadRequested_WaitForMain = 0,    // Loader got notification from OS, and is now paused until main thread replies it's safe to reload the .dll/.so file.
-                                            // This allows the main thread to finish executing its current frame before the .dll/.so file is unloaded.
-                                            // Without this, the .dll/.so file could be unloaded at the same time that it's being used which would cause a SIGSEGV or SIGBUS error.
-        ReloadCanStart_WaitForLoader = 1,   // Main thread received notification from loader, and is now in a safe state to reload, and is now paused until loader replies it's safe to continue executing.
-        ReloadCompleted = 2,                // Loader thread has finished reloading the .dll/.so file, and now notifies main of such and then immediately goes into idle state.
-                                            // When the main thread receives the notification from the loader, it also go into idle state.
-    };
-    // clang-format on
-
     class FilesystemWatcher
     {
       public:

--- a/UE4SS/include/FilesystemWatcher.hpp
+++ b/UE4SS/include/FilesystemWatcher.hpp
@@ -17,12 +17,6 @@
 
 namespace RC
 {
-    enum class FilesystemWatcherThreadType
-    {
-        Main = 0,
-        Loader = 1,
-    };
-
     struct FilesystemWatch
     {
       public:

--- a/UE4SS/include/FilesystemWatcher.hpp
+++ b/UE4SS/include/FilesystemWatcher.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+// A thread-safe type (if used correctly) used to watch for filesystem changes.
+// Create a FilesystemWatcher, and call 'add' on it once for each file or directory that you want to watch.
+// You can use Sync.hpp to synchronize between the main thread and the loader thread, useful for automatic hot-reloading.
+
+#include <filesystem>
+#include <utility>
+#include <vector>
+#include <thread>
+#include <stop_token>
+#include <chrono>
+#include <functional>
+#include <cstdint>
+
+#include <Sync.hpp>
+
+namespace RC
+{
+    enum class FilesystemWatcherThreadType
+    {
+        Main = 0,
+        Loader = 1,
+    };
+
+    struct FilesystemWatch
+    {
+      public:
+        using NotificationFunctionType = std::function<void(const std::filesystem::path& file, bool match_all)>;
+        NotificationFunctionType notify{};
+        std::string name{};
+
+      public:
+        FilesystemWatch() = default;
+        FilesystemWatch(NotificationFunctionType notify, std::string name) : notify{std::move(notify)}, name{std::move(name)}
+        {
+        }
+        FilesystemWatch(NotificationFunctionType notify, const std::filesystem::path& name) : notify{std::move(notify)}, name{name.filename().string()}
+        {
+        }
+    };
+
+    // clang-format off
+    enum class LibReloaderState
+    {
+        Idle = -1,                          // Main thread is executing, loader thread is waiting for notification from the OS.
+        ReloadRequested_WaitForMain = 0,    // Loader got notification from OS, and is now paused until main thread replies it's safe to reload the .dll/.so file.
+                                            // This allows the main thread to finish executing its current frame before the .dll/.so file is unloaded.
+                                            // Without this, the .dll/.so file could be unloaded at the same time that it's being used which would cause a SIGSEGV or SIGBUS error.
+        ReloadCanStart_WaitForLoader = 1,   // Main thread received notification from loader, and is now in a safe state to reload, and is now paused until loader replies it's safe to continue executing.
+        ReloadCompleted = 2,                // Loader thread has finished reloading the .dll/.so file, and now notifies main of such and then immediately goes into idle state.
+                                            // When the main thread receives the notification from the loader, it also go into idle state.
+    };
+    // clang-format on
+
+    class FilesystemWatcher
+    {
+      public:
+        std::vector<std::filesystem::path> m_paths{};
+        void* m_handle{};
+        std::vector<void*> m_handles{};
+        std::vector<FilesystemWatch> m_watches{};
+        std::stop_source m_stop_source{};
+        std::thread m_polling_thread{};
+        ThreadState m_state{};
+        std::chrono::time_point<std::chrono::high_resolution_clock> m_last_notification{std::chrono::high_resolution_clock::now()};
+        std::chrono::milliseconds m_min_duration_between_notifications{4000};
+
+      private:
+        static constexpr int32_t s_polling_timeout_ms = 100;
+
+      public:
+        FilesystemWatcher() = default;
+        FilesystemWatcher(FilesystemWatcher&& other) noexcept;
+        FilesystemWatcher& operator=(FilesystemWatcher&& other) noexcept;
+        ~FilesystemWatcher();
+
+      public:
+        auto add_dir(const std::filesystem::path& dir) -> void;
+        auto start_async_polling(const FilesystemWatch::NotificationFunctionType& notify) -> void;
+        auto get_thread_state() -> ThreadState&
+        {
+            return m_state;
+        }
+
+      private:
+        auto poll(std::stop_token) -> void;
+
+      private:
+        friend auto init_filesystem_watcher(FilesystemWatcher&, const std::filesystem::path&) -> void;
+    };
+} // namespace RC

--- a/UE4SS/include/FilesystemWatcher_Linux.cpp_impl
+++ b/UE4SS/include/FilesystemWatcher_Linux.cpp_impl
@@ -1,0 +1,151 @@
+/*
+
+    NOTE THAT THIS FILE IS OUTDATED!!! IT HASN'T BEEN UPDATED TO MATCH THE BEHAVIOR OF THE Windows VERSION!
+    THIS FILE PROBABLY DOESN'T EVEN COMPILE IN ITS CURRENT STATE!
+
+
+*/
+
+#include <bit>
+#include <iostream>
+#include <cstdint>
+#include <cstring>
+#include <sys/inotify.h>
+#include <sys/poll.h>
+#include <unistd.h>
+
+namespace RC
+{
+    auto handle_to_fd(void* handle) -> int32_t
+    {
+        return static_cast<int32_t>(reinterpret_cast<uintptr_t>(handle));
+    }
+
+    auto init_filesystem_watcher(FilesystemWatcher& watcher, const std::filesystem::path& path) -> void
+    {
+        watcher.m_path = path;
+        auto handle = inotify_init1(IN_NONBLOCK);
+        watcher.m_handle = reinterpret_cast<void*>(handle);
+        auto file_descriptor = handle;
+        if (file_descriptor == -1)
+        {
+            Output::send<LogLevel::Error>(STR("Error watching '{}': {}"), path.string(), std::strerror(errno));
+            return;
+        }
+        if (inotify_add_watch(file_descriptor, path.c_str(), IN_CREATE) == -1)
+        {
+            Output::send<LogLevel::Error>(STR("Error watching '{}': {}"), path.string(), std::strerror(errno));
+            return;
+        }
+    }
+
+    FilesystemWatcher::FilesystemWatcher(const std::filesystem::path& path)
+    {
+        init_filesystem_watcher(*this, path);
+    }
+
+    FilesystemWatcher::FilesystemWatcher(const std::filesystem::path& path, std::chrono::milliseconds min_duration_between_notifications)
+        : m_min_duration_between_notifications{min_duration_between_notifications}
+    {
+        init_filesystem_watcher(*this, path);
+    }
+
+    FilesystemWatcher::~FilesystemWatcher()
+    {
+        m_stop_source.request_stop();
+        m_polling_thread.join();
+        if (m_handle)
+        {
+            close(handle_to_fd(m_handle));
+        }
+    }
+
+    auto FilesystemWatcher::poll(std::stop_token stop_token) -> void
+    {
+        while (!stop_token.stop_requested())
+        {
+            pollfd file_descriptors[2]{};
+            file_descriptors[0].fd = STDIN_FILENO;
+            file_descriptors[0].events = POLLIN;
+            file_descriptors[1].fd = handle_to_fd(m_handle);
+            file_descriptors[1].events = POLLIN;
+
+            auto poll_num = ::poll(file_descriptors, 2, s_polling_timeout_ms);
+            if (poll_num == 0 && stop_token.stop_requested())
+            {
+                break;
+            }
+            else if (poll_num == -1)
+            {
+                if (errno == EINTR)
+                {
+                    return;
+                }
+                else
+                {
+                    Output::send<LogLevel::Error>(STR("Error: {}"), std::strerror(errno));
+                    std::exit(EXIT_FAILURE);
+                }
+            }
+            else if (poll_num > 0)
+            {
+                if (file_descriptors[0].revents & POLLIN)
+                {
+                    char buffer{};
+                    while (read(STDIN_FILENO, &buffer, 1) > 0 && buffer != '\n')
+                    {
+                        continue;
+                    }
+                }
+                if (file_descriptors[1].revents & POLLIN)
+                {
+                    while (true)
+                    {
+                        // See https://www.man7.org/linux/man-pages/man7/inotify.7.html#EXAMPLES for why this is aligned like this.
+                        char buffer[4096] __attribute__((aligned(__alignof__(struct inotify_event))));
+                        auto length = read(handle_to_fd(m_handle), buffer, sizeof(buffer));
+                        if (length == -1 && errno != EAGAIN)
+                        {
+                            Output::send<LogLevel::Error>(STR("Error: {}"), std::strerror(errno));
+                            std::exit(EXIT_FAILURE);
+                        }
+                        else if (length <= 0)
+                        {
+                            break;
+                        }
+                        const inotify_event* event{};
+                        for (auto ptr = buffer; ptr < buffer + length; ptr += sizeof(inotify_event) + event->len)
+                        {
+                            event = std::bit_cast<const inotify_event*>(ptr);
+                            if (event->mask & IN_CREATE && event->len > 0)
+                            {
+                                std::string name_string{event->name};
+                                // Attempting to allow non-standard names for libraries on Linux.
+                                // The standard name is lib<Name>.so.
+                                if (name_string.starts_with("lib") && name_string.ends_with(".so"))
+                                {
+                                    name_string.erase(0, 3);
+                                }
+                                auto name = std::filesystem::path{name_string};
+                                name.replace_extension();
+                                for (const auto& watch : m_watches)
+                                {
+                                    if (watch.name == "*" || name == watch.name)
+                                    {
+                                        auto now = std::chrono::high_resolution_clock::now();
+                                        if (now - m_last_notification < m_min_duration_between_notifications)
+                                        {
+                                            continue;
+                                        }
+                                        m_last_notification = now;
+                                        watch.notify(std::filesystem::path{});
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+} // namespace RC

--- a/UE4SS/include/FilesystemWatcher_Windows.cpp_impl
+++ b/UE4SS/include/FilesystemWatcher_Windows.cpp_impl
@@ -1,0 +1,130 @@
+#include <future>
+#include <ranges>
+
+#include <Windows.h>
+
+#include <DynamicOutput/DynamicOutput.hpp>
+#include <Helpers/String.hpp>
+
+namespace RC
+{
+    struct Data
+    {
+        HANDLE handle{};
+        std::vector<uint8_t> buffer{};
+        std::filesystem::path path{};
+        Data()
+        {
+            buffer.resize(1000);
+        }
+    };
+
+    auto init_filesystem_watcher(FilesystemWatcher& watcher, const std::filesystem::path& path) -> void
+    {
+        auto data = new Data{};
+        watcher.m_handle = data;
+        watcher.m_handles.emplace_back(static_cast<void*>(data));
+        data->handle = CreateFileW(path.native().c_str(),
+                                   FILE_LIST_DIRECTORY,
+                                   FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                   nullptr,
+                                   OPEN_EXISTING,
+                                   FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED,
+                                   nullptr);
+        data->path = path;
+    }
+
+    FilesystemWatcher::~FilesystemWatcher()
+    {
+        m_stop_source.request_stop();
+        m_polling_thread.join();
+        auto data = static_cast<Data*>(m_handle);
+        if (data && data->handle)
+        {
+            FindCloseChangeNotification(data->handle);
+            delete data;
+            m_handle = nullptr;
+        }
+    }
+
+    auto FilesystemWatcher::poll(std::stop_token stop_token) -> void
+    {
+        std::vector<HANDLE> handles{};
+        for (const auto& handle_data_raw : m_handles)
+        {
+            auto handle_data = static_cast<Data*>(handle_data_raw);
+            handles.emplace_back(FindFirstChangeNotificationW(handle_data->path.wstring().c_str(), false, FILE_NOTIFY_CHANGE_LAST_WRITE));
+            if (handles.back() == INVALID_HANDLE_VALUE)
+            {
+                Output::send<LogLevel::Error>(STR("ERROR: FindFirstChangeNotification function failed.\n"));
+                return;
+            }
+        }
+
+        std::vector<std::future<void>> futures{};
+        static constexpr int32_t s_max_objects_per_thread = MAXIMUM_WAIT_OBJECTS;
+        const auto use_single_thread = handles.size() <= s_max_objects_per_thread;
+        futures.resize(use_single_thread ? 1 : handles.size() / s_max_objects_per_thread);
+
+        size_t range_start{};
+        for (const auto& [index, future] : std::ranges::enumerate_view(futures))
+        {
+            if (stop_token.stop_requested())
+            {
+                break;
+            }
+            const auto data = &handles[range_start];
+            const auto last_chunk = handles.size() <= s_max_objects_per_thread;
+            const auto size = last_chunk ? handles.size() : s_max_objects_per_thread;
+            Output::send<LogLevel::Verbose>(STR("Creating filesystem watcher {} with range {}-{}, range_start: {}, data: {}\n"), index, range_start, range_start + size, range_start, (void*)data);
+            future = std::async(std::launch::async, [](FilesystemWatcher* watcher, std::vector<HANDLE>* in_handles, const HANDLE* data, const size_t size, const size_t range_start, std::stop_token* stop_token) {
+                while (!stop_token->stop_requested())
+                {
+                    auto status = WaitForMultipleObjects(size, data, false, INFINITE);
+                    if (status == WAIT_TIMEOUT || status == WAIT_ABANDONED_0 || status == WAIT_FAILED)
+                    {
+                        continue;
+                    }
+                    auto index = status + range_start;
+                    auto handle_data = static_cast<Data*>(watcher->m_handles[index]);
+                    for (const auto& watch : watcher->m_watches)
+                    {
+                        // The intent here is to allow notifiers based on the file that was changed.
+                        // But because the FindFirst/NextChangeNotification APIs don't allow you to retrieve any information about what has changed, we can't do that.
+                        // Instead, we allow everything through via the "*" option.
+                        // When/if this code is revamped to use ReadDirectoryChangesW, we can retrieve the file name and stop bypassing with "*".
+                        // For now, if the name of the watcher notifier isn't "*", the watch will never get notified.
+                        bool match_all = watch.name == "*";
+                        if (match_all/* || watch.name == name_no_extension*/)
+                        {
+                            auto now = std::chrono::high_resolution_clock::now();
+                            if (now - watcher->m_last_notification < watcher->m_min_duration_between_notifications)
+                            {
+                                continue;
+                            }
+                            watcher->m_last_notification = now;
+                            // TODO: If 'match_all' is true, we don't have any file information besides what was registered for the watch.
+                            //       It would be useful for the user to have this information.
+                            //       We never actully have this information right now because the FindFirst/NextChangeNotification APIs don't allow you to know what changed.
+                            //       The ReadDirectoryChangesW API does, but it's a more complicated API.
+                            watch.notify(handle_data->path, match_all);
+                        }
+                    }
+                    if (!FindNextChangeNotification((*in_handles)[index]))
+                    {
+                        Output::send<LogLevel::Error>(STR("ERROR: FindNextChangeNotification function failed. Code: {}\n"), GetLastError());
+                    }
+                }
+            }, this, &handles, data, size, range_start, &stop_token);
+            range_start += s_max_objects_per_thread;
+        }
+
+        // Note that we'll only ever execute this code if all the futures have returned.
+        // Futures can be triggered to return via the stop_token passed to this function.
+        // This stop_token is triggered when FilesystemWatcher goes out of scope.
+        for (const auto& [index, future] : std::ranges::enumerate_view(futures))
+        {
+            future.wait();
+        }
+    }
+} // namespace RC

--- a/UE4SS/include/FilesystemWatcher_Windows.cpp_impl
+++ b/UE4SS/include/FilesystemWatcher_Windows.cpp_impl
@@ -17,6 +17,15 @@ namespace RC
         {
             buffer.resize(1000);
         }
+        ~Data()
+        {
+            if (handle)
+            {
+                FindCloseChangeNotification(handle);
+                CloseHandle(handle);
+                handle = nullptr;
+            }
+        }
     };
 
     auto init_filesystem_watcher(FilesystemWatcher& watcher, const std::filesystem::path& path) -> void
@@ -36,14 +45,21 @@ namespace RC
 
     FilesystemWatcher::~FilesystemWatcher()
     {
-        m_stop_source.request_stop();
-        m_polling_thread.join();
-        auto data = static_cast<Data*>(m_handle);
-        if (data && data->handle)
+        if (m_stop_source.stop_possible())
         {
-            FindCloseChangeNotification(data->handle);
-            delete data;
-            m_handle = nullptr;
+            m_stop_source.request_stop();
+        }
+        if (m_polling_thread.joinable())
+        {
+            m_polling_thread.join();
+        }
+        for (auto& handle : m_handles)
+        {
+            auto data = static_cast<Data*>(handle);
+            if (data)
+            {
+                delete data;
+            }
         }
     }
 

--- a/UE4SS/include/FilesystemWatcher_Windows.cpp_impl
+++ b/UE4SS/include/FilesystemWatcher_Windows.cpp_impl
@@ -1,6 +1,7 @@
-#include <future>
+#include <chrono>
 #include <ranges>
 
+#define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
 #include <DynamicOutput/DynamicOutput.hpp>
@@ -77,70 +78,50 @@ namespace RC
             }
         }
 
-        std::vector<std::future<void>> futures{};
-        static constexpr int32_t s_max_objects_per_thread = MAXIMUM_WAIT_OBJECTS;
-        const auto use_single_thread = handles.size() <= s_max_objects_per_thread;
-        futures.resize(use_single_thread ? 1 : handles.size() / s_max_objects_per_thread);
-
-        size_t range_start{};
-        for (const auto& [index, future] : std::ranges::enumerate_view(futures))
+        while (!stop_token.stop_requested())
         {
-            if (stop_token.stop_requested())
+            for (size_t index = 0; index < handles.size(); ++index)
             {
-                break;
-            }
-            const auto data = &handles[range_start];
-            const auto last_chunk = handles.size() <= s_max_objects_per_thread;
-            const auto size = last_chunk ? handles.size() : s_max_objects_per_thread;
-            Output::send<LogLevel::Verbose>(STR("Creating filesystem watcher {} with range {}-{}, range_start: {}, data: {}\n"), index, range_start, range_start + size, range_start, (void*)data);
-            future = std::async(std::launch::async, [](FilesystemWatcher* watcher, std::vector<HANDLE>* in_handles, const HANDLE* data, const size_t size, const size_t range_start, std::stop_token* stop_token) {
-                while (!stop_token->stop_requested())
+                if (stop_token.stop_requested())
                 {
-                    auto status = WaitForMultipleObjects(size, data, false, INFINITE);
-                    if (status == WAIT_TIMEOUT || status == WAIT_ABANDONED_0 || status == WAIT_FAILED)
+                    return;
+                }
+                const auto& handle = handles[index];
+                auto status = WaitForSingleObject(handle, s_polling_timeout_ms);
+                if (status == WAIT_TIMEOUT || status == WAIT_ABANDONED_0 || status == WAIT_FAILED)
+                {
+                    continue;
+                }
+                const auto handle_data = static_cast<Data*>(m_handles[index]);
+                for (const auto& watch : m_watches)
+                {
+                    if (stop_token.stop_requested())
                     {
-                        continue;
+                        return;
                     }
-                    auto index = status + range_start;
-                    auto handle_data = static_cast<Data*>(watcher->m_handles[index]);
-                    for (const auto& watch : watcher->m_watches)
+                    // The intent here is to allow notifiers based on the file that was changed.
+                    // But because the FindFirst/NextChangeNotification APIs don't allow you to retrieve any information about what has changed, we can't do that.
+                    // Instead, we allow everything through via the "*" option.
+                    // When/if this code is revamped to use ReadDirectoryChangesW, we can retrieve the file name and stop bypassing with "*".
+                    // For now, if the name of the watcher notifier isn't "*", the watch will never get notified.
+                    bool match_all = watch.name == "*";
+                    if (match_all/* || watch.name == name_no_extension*/)
                     {
-                        // The intent here is to allow notifiers based on the file that was changed.
-                        // But because the FindFirst/NextChangeNotification APIs don't allow you to retrieve any information about what has changed, we can't do that.
-                        // Instead, we allow everything through via the "*" option.
-                        // When/if this code is revamped to use ReadDirectoryChangesW, we can retrieve the file name and stop bypassing with "*".
-                        // For now, if the name of the watcher notifier isn't "*", the watch will never get notified.
-                        bool match_all = watch.name == "*";
-                        if (match_all/* || watch.name == name_no_extension*/)
-                        {
-                            auto now = std::chrono::high_resolution_clock::now();
-                            if (now - watcher->m_last_notification < watcher->m_min_duration_between_notifications)
-                            {
-                                continue;
-                            }
-                            watcher->m_last_notification = now;
-                            // TODO: If 'match_all' is true, we don't have any file information besides what was registered for the watch.
-                            //       It would be useful for the user to have this information.
-                            //       We never actully have this information right now because the FindFirst/NextChangeNotification APIs don't allow you to know what changed.
-                            //       The ReadDirectoryChangesW API does, but it's a more complicated API.
-                            watch.notify(handle_data->path, match_all);
-                        }
-                    }
-                    if (!FindNextChangeNotification((*in_handles)[index]))
-                    {
-                        Output::send<LogLevel::Error>(STR("ERROR: FindNextChangeNotification function failed. Code: {}\n"), GetLastError());
+                        // Minimum duration between notifications is enforced by a thread sleep after this loop.
+                        // TODO: If 'match_all' is true, we don't have any file information besides what was registered for the watch.
+                        //       It would be useful for the user to have this information.
+                        //       We never actully have this information right now because the FindFirst/NextChangeNotification APIs don't allow you to know what changed.
+                        //       The ReadDirectoryChangesW API does, but it's a more complicated API.
+                        watch.notify(handle_data->path, match_all);
                     }
                 }
-            }, this, &handles, data, size, range_start, &stop_token);
-            range_start += s_max_objects_per_thread;
-        }
-
-        // Note that we'll only ever execute this code if all the futures have returned.
-        // Futures can be triggered to return via the stop_token passed to this function.
-        // This stop_token is triggered when FilesystemWatcher goes out of scope.
-        for (const auto& [index, future] : std::ranges::enumerate_view(futures))
-        {
-            future.wait();
+                if (!FindNextChangeNotification((handles)[index]))
+                {
+                    Output::send<LogLevel::Error>(STR("ERROR: FindNextChangeNotification function failed. Code: {}\n"), GetLastError());
+                }
+            }
+            // To prevent taxing the CPU.
+            std::this_thread::sleep_for(std::chrono::milliseconds{m_min_duration_between_notifications});
         }
     }
 } // namespace RC

--- a/UE4SS/include/FilesystemWatcher_Windows.cpp_impl
+++ b/UE4SS/include/FilesystemWatcher_Windows.cpp_impl
@@ -107,7 +107,12 @@ namespace RC
                     bool match_all = watch.name == "*";
                     if (match_all/* || watch.name == name_no_extension*/)
                     {
-                        // Minimum duration between notifications is enforced by a thread sleep after this loop.
+                        auto now = std::chrono::high_resolution_clock::now();
+                        if (now - m_last_notification < m_min_duration_between_notifications)
+                        {
+                            continue;
+                        }
+                        m_last_notification = now;
                         // TODO: If 'match_all' is true, we don't have any file information besides what was registered for the watch.
                         //       It would be useful for the user to have this information.
                         //       We never actully have this information right now because the FindFirst/NextChangeNotification APIs don't allow you to know what changed.

--- a/UE4SS/include/FilesystemWatcher_Windows.cpp_impl
+++ b/UE4SS/include/FilesystemWatcher_Windows.cpp_impl
@@ -70,6 +70,7 @@ namespace RC
         for (const auto& handle_data_raw : m_handles)
         {
             auto handle_data = static_cast<Data*>(handle_data_raw);
+            // logging here would crash
             handles.emplace_back(FindFirstChangeNotificationW(handle_data->path.wstring().c_str(), false, FILE_NOTIFY_CHANGE_LAST_WRITE));
             if (handles.back() == INVALID_HANDLE_VALUE)
             {
@@ -92,7 +93,6 @@ namespace RC
                 {
                     continue;
                 }
-                const auto handle_data = static_cast<Data*>(m_handles[index]);
                 for (const auto& watch : m_watches)
                 {
                     if (stop_token.stop_requested())
@@ -107,17 +107,18 @@ namespace RC
                     bool match_all = watch.name == "*";
                     if (match_all/* || watch.name == name_no_extension*/)
                     {
-                        auto now = std::chrono::high_resolution_clock::now();
-                        if (now - m_last_notification < m_min_duration_between_notifications)
+                        if (std::chrono::high_resolution_clock::now() - m_last_notification < m_min_duration_between_notifications)
                         {
                             continue;
                         }
-                        m_last_notification = now;
+                        const auto handle_data = static_cast<Data*>(m_handles[index]);
+
                         // TODO: If 'match_all' is true, we don't have any file information besides what was registered for the watch.
                         //       It would be useful for the user to have this information.
                         //       We never actully have this information right now because the FindFirst/NextChangeNotification APIs don't allow you to know what changed.
                         //       The ReadDirectoryChangesW API does, but it's a more complicated API.
                         watch.notify(handle_data->path, match_all);
+                        m_last_notification = std::chrono::high_resolution_clock::now();
                     }
                 }
                 if (!FindNextChangeNotification((handles)[index]))
@@ -126,7 +127,7 @@ namespace RC
                 }
             }
             // To prevent taxing the CPU.
-            std::this_thread::sleep_for(std::chrono::milliseconds{m_min_duration_between_notifications});
+            std::this_thread::sleep_for(std::chrono::milliseconds{std::chrono::milliseconds{20}});
         }
     }
 } // namespace RC

--- a/UE4SS/include/SettingsManager.hpp
+++ b/UE4SS/include/SettingsManager.hpp
@@ -31,6 +31,7 @@ namespace RC
         {
             bool EnableHotReloadSystem{};
             Input::Key HotReloadKey{Input::Key::R};
+            bool EnableAutoReloadingLuaMods{};
             bool UseCache{true};
             bool InvalidateCacheIfDLLDiffers{true};
             bool EnableDebugKeyBindings{false};

--- a/UE4SS/include/Sync.hpp
+++ b/UE4SS/include/Sync.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <functional>
+#include <atomic>
+
+namespace RC
+{
+    enum class ThreadSyncStateValue
+    {
+        Idle = -1,
+        WaitForMain = 0,
+        WaitForOther = 1,
+        Complete = 2,
+    };
+
+    struct ThreadState
+    {
+        std::atomic<ThreadSyncStateValue> underlying{ThreadSyncStateValue::Idle};
+
+        ThreadState() = default;
+        ThreadState(ThreadState&& other) noexcept : underlying(other.underlying.load())
+        {
+        }
+        ThreadState& operator=(ThreadState&& other) noexcept
+        {
+            if (this == &other) return *this;
+            underlying = other.underlying.load();
+            return *this;
+        }
+    };
+
+    // Force the current thread to block until the main thread replies, and then execute the provided function.
+    using SyncExecutionFunc = std::function<void()>;
+    auto sync_and_execute(ThreadState& state_manager, const SyncExecutionFunc& callable) -> void;
+
+    // Block the current thread if another thread has requested it.
+    auto process_sync_request(ThreadState& state_manager) -> void;
+
+    // Same as 'sync_and_execute', but using RAII instead of providing a function.
+    class ScopedThreadSynchronizer
+    {
+      private:
+        ThreadState& m_state_manager;
+
+      public:
+        explicit ScopedThreadSynchronizer(ThreadState& state_manager) : m_state_manager{state_manager}
+        {
+            m_state_manager.underlying.store(ThreadSyncStateValue::WaitForMain);
+            m_state_manager.underlying.wait(ThreadSyncStateValue::WaitForMain);
+        }
+
+        ~ScopedThreadSynchronizer()
+        {
+            m_state_manager.underlying.store(ThreadSyncStateValue::Complete);
+            m_state_manager.underlying.notify_one();
+        }
+    };
+} // namespace RC

--- a/UE4SS/include/UE4SSProgram.hpp
+++ b/UE4SS/include/UE4SSProgram.hpp
@@ -294,6 +294,13 @@ namespace RC
         RC_UE4SS_API auto is_keydown_event_registered(Input::Key) -> bool;
         RC_UE4SS_API auto is_keydown_event_registered(Input::Key, const Input::Handler::ModifierKeyArray&) -> bool;
         RC_UE4SS_API auto get_all_input_events(std::function<void(Input::KeySet&)> callback) -> void;
+        enum class AllMods
+        {
+            Yes,
+            No,
+        };
+        // If 'AllMods' is 'Yes', then 'mod' can be nullptr.
+        auto unregister_keydown_events_for_lua_mod(LuaMod* mod, AllMods = AllMods::No) -> void;
 
       private:
         static auto install_cpp_mods() -> void;

--- a/UE4SS/src/FilesystemWatcher.cpp
+++ b/UE4SS/src/FilesystemWatcher.cpp
@@ -1,0 +1,46 @@
+#include <FilesystemWatcher.hpp>
+
+#ifdef _MSC_VER
+#include "FilesystemWatcher_Windows.cpp_impl"
+#else
+#include "FilesystemWatcher_Linux.cpp_impl"
+#endif
+
+namespace RC
+{
+    FilesystemWatcher::FilesystemWatcher(FilesystemWatcher&& other) noexcept
+        : m_paths(std::move(other.m_paths)), m_handle(other.m_handle), m_watches(std::move(other.m_watches)), m_stop_source(std::move(other.m_stop_source)),
+          m_polling_thread(std::move(other.m_polling_thread)), m_state(std::move(other.m_state)), m_last_notification(other.m_last_notification),
+          m_min_duration_between_notifications(other.m_min_duration_between_notifications)
+    {
+    }
+
+    FilesystemWatcher& FilesystemWatcher::operator=(FilesystemWatcher&& other) noexcept
+    {
+        if (this == &other) return *this;
+        m_paths = std::move(other.m_paths);
+        m_handle = other.m_handle;
+        m_watches = std::move(other.m_watches);
+        m_stop_source = std::move(other.m_stop_source);
+        m_polling_thread = std::move(other.m_polling_thread);
+        m_state = std::move(other.m_state);
+        m_last_notification = other.m_last_notification;
+        m_min_duration_between_notifications = other.m_min_duration_between_notifications;
+        return *this;
+    }
+
+    auto FilesystemWatcher::add_dir(const std::filesystem::path& dir) -> void
+    {
+        m_paths.emplace_back(dir);
+    }
+
+    auto FilesystemWatcher::start_async_polling(const FilesystemWatch::NotificationFunctionType& notify) -> void
+    {
+        for (const auto& path : m_paths)
+        {
+            init_filesystem_watcher(*this, path);
+        }
+        m_watches.emplace_back(notify, std::string{"*"});
+        m_polling_thread = std::thread{&FilesystemWatcher::poll, this, m_stop_source.get_token()};
+    }
+} // namespace RC

--- a/UE4SS/src/Mod/Mod.cpp
+++ b/UE4SS/src/Mod/Mod.cpp
@@ -51,11 +51,6 @@ namespace RC
         return m_mod_name;
     }
 
-    auto Mod::get_path() const -> const std::filesystem::path&
-    {
-        return m_mod_path;
-    }
-
     auto Mod::set_installable(bool is_installable) -> void
     {
         m_installable = is_installable;

--- a/UE4SS/src/Mod/Mod.cpp
+++ b/UE4SS/src/Mod/Mod.cpp
@@ -51,6 +51,11 @@ namespace RC
         return m_mod_name;
     }
 
+    auto Mod::get_path() const -> const std::filesystem::path&
+    {
+        return m_mod_path;
+    }
+
     auto Mod::set_installable(bool is_installable) -> void
     {
         m_installable = is_installable;

--- a/UE4SS/src/SettingsManager.cpp
+++ b/UE4SS/src/SettingsManager.cpp
@@ -81,6 +81,7 @@ namespace RC
                 throw std::runtime_error{fmt::format("Invalid value for 'General.HotReloadKey': {}\n", to_string(hot_reload_key))};
             }
         }
+        REGISTER_BOOL_SETTING(General.EnableAutoReloadingLuaMods, section_general, EnableAutoReloadingLuaMods)
         REGISTER_BOOL_SETTING(General.UseCache, section_general, UseCache)
         REGISTER_BOOL_SETTING(General.InvalidateCacheIfDLLDiffers, section_general, InvalidateCacheIfDLLDiffers)
         REGISTER_BOOL_SETTING(General.EnableDebugKeyBindings, section_general, EnableDebugKeyBindings)

--- a/UE4SS/src/Sync.cpp
+++ b/UE4SS/src/Sync.cpp
@@ -1,0 +1,23 @@
+#include <Sync.hpp>
+
+namespace RC
+{
+    auto sync_and_execute(ThreadState& state_manager, const SyncExecutionFunc& callable) -> void
+    {
+        state_manager.underlying.store(ThreadSyncStateValue::WaitForMain);
+        state_manager.underlying.wait(ThreadSyncStateValue::WaitForMain);
+        callable();
+        state_manager.underlying.store(ThreadSyncStateValue::Complete);
+    }
+
+    auto process_sync_request(ThreadState& state_manager) -> void
+    {
+        if (state_manager.underlying.load() == ThreadSyncStateValue::WaitForMain)
+        {
+            state_manager.underlying.store(ThreadSyncStateValue::WaitForOther);
+            state_manager.underlying.notify_one();
+            state_manager.underlying.wait(ThreadSyncStateValue::WaitForOther);
+            state_manager.underlying.store(ThreadSyncStateValue::Idle);
+        }
+    }
+} // namespace RC

--- a/UE4SS/src/UE4SSProgram.cpp
+++ b/UE4SS/src/UE4SSProgram.cpp
@@ -62,6 +62,8 @@
 
 #include <polyhook2/PE/IatHook.hpp>
 
+#include <FilesystemWatcher.hpp>
+
 namespace RC
 {
     // Commented out because this system (turn off hotkeys when in-game console is open) it doesn't work properly.
@@ -1092,6 +1094,68 @@ namespace RC
 
         on_program_start();
 
+        FilesystemWatcher filesystem_watcher{};
+        if (settings_manager.General.EnableAutoReloadingLuaMods)
+        {
+            filesystem_watcher.m_min_duration_between_notifications = std::chrono::milliseconds{100};
+            for (const auto& mod : m_mods)
+            {
+                if (dynamic_cast<CppMod*>(mod.get()))
+                {
+                    filesystem_watcher.add_dir(std::filesystem::path{get_mods_directory()} / mod->get_name() / "dlls");
+                }
+                else if (dynamic_cast<LuaMod*>(mod.get()))
+                {
+                    filesystem_watcher.add_dir(std::filesystem::path{get_mods_directory()} / mod->get_name() / "Scripts");
+                }
+            }
+            filesystem_watcher.start_async_polling([&](const std::filesystem::path& file, bool match_all) {
+                ScopedThreadSynchronizer thread_synchronizer{filesystem_watcher.get_thread_state()};
+                const auto mod_name = file.parent_path().filename();
+                auto dir_name = file.filename().string();
+                const auto is_cpp_mod = String::iequal(dir_name, "dlls");
+                if (is_cpp_mod)
+                {
+                    auto staged_file = file / mod_name;
+                    staged_file.replace_extension(".dll");
+                    if (!std::filesystem::exists(staged_file))
+                    {
+                        return;
+                    }
+                    // TODO: Unload the dll (uninstall).
+                    //       Delete 'main.dll'.
+                    //       Rename 'staged_file' to 'main.dll'.
+                    //       Load 'main.dll' (install & start).
+
+                    // TODO: To reload C++ mods, we need to add a way to unregister hooks, and then C++ mods need to unregister on they get notified that they're getting unloaded.
+                    //       For Lua mods, there's no notification, but we track all the hooks internally, so we can unregister automatically, we just need to
+                    //       call Lua::Uninstall, and We must also remove the keybinds like we do in UE4SSProgram::reinstall_mods.
+                    //       Unsure about loading and starting mods again.
+                }
+                else
+                {
+                    auto mod = find_lua_mod_by_name(ensure_str(mod_name), IsInstalled::Yes, IsStarted::Yes);
+                    if (!mod)
+                    {
+                        return;
+                    }
+                    m_pause_events_processing = true;
+                    mod->uninstall();
+                    auto& mod_ref = *std::ranges::find_if(m_mods, [&](const std::unique_ptr<Mod>& mod_ptr) {
+                        return mod_ptr.get() == mod;
+                    });
+                    if (!mod_ref)
+                    {
+                        return;
+                    }
+                    mod_ref = std::make_unique<LuaMod>(*this, StringType{mod_ref->get_name()}, mod_ref->get_path());
+                    m_pause_events_processing = false;
+                    Output::send(STR("Auto-reloading Lua mod '{}'\n"), mod_ref->get_name());
+                    mod_ref->start_mod();
+                }
+            });
+        }
+
         Output::send(STR("Event loop start\n"));
         for (m_processing_events = true; m_processing_events;)
         {
@@ -1155,6 +1219,12 @@ namespace RC
                         mod->fire_update();
                     }
                 }
+            }
+
+            if (settings_manager.General.EnableAutoReloadingLuaMods)
+            {
+                // Process any mod file changes, and wait until done.
+                process_sync_request(filesystem_watcher.get_thread_state());
             }
 
             std::this_thread::sleep_for(std::chrono::milliseconds(5));
@@ -1354,6 +1424,23 @@ namespace RC
                 cpp_mod->fire_on_cpp_mods_loaded();
             }
         }
+    }
+
+    auto UE4SSProgram::unregister_keydown_events_for_lua_mod(LuaMod* mod, AllMods all_mods) -> void
+    {
+#ifdef HAS_INPUT
+        m_input_handler.get_events_safe([&](auto& key_set) {
+            std::erase_if(key_set.key_data, [&](auto& item) -> bool {
+                auto& [_, key_data] = item;
+                std::erase_if(key_data, [&](Input::KeyData& key_data) -> bool {
+                    // custom_data == 1: Bind came from Lua, and custom_data2 is a pointer to LuaMod.
+                    // custom_data == 2: Bind came from C++, and custom_data2 is a pointer to KeyDownEventData. Must free it.
+                    return key_data.custom_data == 1 && (all_mods == AllMods::Yes || static_cast<LuaMod*>(key_data.custom_data2) == mod);
+                });
+                return key_data.empty();
+            });
+        });
+#endif
     }
 
     template <typename ModType>
@@ -1646,31 +1733,6 @@ namespace RC
         m_pause_events_processing = true;
 
         uninstall_mods();
-
-// Remove key binds that were set from Lua scripts
-#ifdef HAS_INPUT
-        m_input_handler.get_events_safe([&](auto& key_set) {
-            std::erase_if(key_set.key_data, [&](auto& item) -> bool {
-                auto& [_, key_data] = item;
-                bool were_all_events_registered_from_lua = true;
-                std::erase_if(key_data, [&](Input::KeyData& key_data) -> bool {
-                    // custom_data == 1: Bind came from Lua, and custom_data2 is a pointer to LuaMod.
-                    // custom_data == 2: Bind came from C++, and custom_data2 is a pointer to KeyDownEventData. Must free it.
-                    if (key_data.custom_data == 1)
-                    {
-                        return true;
-                    }
-                    else
-                    {
-                        were_all_events_registered_from_lua = false;
-                        return false;
-                    }
-                });
-
-                return were_all_events_registered_from_lua;
-            });
-        });
-#endif
 
         // Remove all custom properties
         // Uncomment when custom properties are working

--- a/UE4SS/src/UE4SSProgram.cpp
+++ b/UE4SS/src/UE4SSProgram.cpp
@@ -1787,18 +1787,7 @@ namespace RC
         mod->uninstall();
 
         // Remove key binds registered by this specific mod
-#ifdef HAS_INPUT
-        m_input_handler.get_events_safe([&](auto& key_set) {
-            std::erase_if(key_set.key_data, [&](auto& item) -> bool {
-                auto& [_, key_data] = item;
-                std::erase_if(key_data, [&](Input::KeyData& kd) -> bool {
-                    // custom_data == 1: Bind came from Lua, custom_data2 is pointer to LuaMod
-                    return kd.custom_data == 1 && kd.custom_data2 == mod;
-                });
-                return key_data.empty();
-            });
-        });
-#endif
+        unregister_keydown_events_for_lua_mod(mod, AllMods::No);
 
         // Remove the old mod from the list
         delete_mod(mod);
@@ -1839,18 +1828,7 @@ namespace RC
         mod->uninstall();
 
         // Remove key binds registered by this specific mod
-#ifdef HAS_INPUT
-        m_input_handler.get_events_safe([&](auto& key_set) {
-            std::erase_if(key_set.key_data, [&](auto& item) -> bool {
-                auto& [_, key_data] = item;
-                std::erase_if(key_data, [&](Input::KeyData& kd) -> bool {
-                    // custom_data == 1: Bind came from Lua, custom_data2 is pointer to LuaMod
-                    return kd.custom_data == 1 && kd.custom_data2 == mod;
-                });
-                return key_data.empty();
-            });
-        });
-#endif
+        unregister_keydown_events_for_lua_mod(mod, AllMods::No);
 
         delete_mod(mod);
 

--- a/UE4SS/src/UE4SSProgram.cpp
+++ b/UE4SS/src/UE4SSProgram.cpp
@@ -1097,7 +1097,6 @@ namespace RC
         FilesystemWatcher filesystem_watcher{};
         if (settings_manager.General.EnableAutoReloadingLuaMods)
         {
-            filesystem_watcher.m_min_duration_between_notifications = std::chrono::milliseconds{100};
             for (const auto& mod : m_mods)
             {
                 if (dynamic_cast<CppMod*>(mod.get()))

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -72,6 +72,8 @@ Add error messages in places where only error codes were previously logged (e.g.
 
 Added `[f: <address_or_module_offset>` section to UE4SS_ObjectDump.txt [UE4SS #866](https://github.com/UE4SS-RE/RE-UE4SS/pull/866) 
 
+Added option `EnableAutoReloadingLuaMods` in the `General` section of UE4SS-settings.ini [UE4SS #1004](https://github.com/UE4SS-RE/RE-UE4SS/pull/1004) 
+
 Added line in the [docs](https://docs.ue4ss.com/dev/guides/fixing-compatibility-problems.html) to add `FText::FromString(FString&)` as an alternative to `FText::FText(FString&)` for UE5 games - ([UE4SS #1078](https://github.com/UE4SS-RE/RE-UE4SS/pull/1078))
 
 Added `FUObjectItem`, `FUObjectArray`, and `TUObjectArray` to MemberVariableLayout.ini ([UE4SS #????](https://github.com/UE4SS-RE/RE-UE4SS/pull/????))
@@ -556,6 +558,11 @@ HotReloadKey = R
 ; Valid values (case-insensitive): Scan, Conv_NameToString
 ; Default: Scan
 DefaultFNameToStringMethod = Scan
+
+; Whether to automatically reload mods when a change is detected.
+; The reload triggers when any file is edited or a new file is added to the 'Scripts' directory.
+; Default: 0
+EnableAutoReloadingLuaMods = 0
 
 [EngineVersionOverride]
 ; True if the game is built as Debug, Development, or Test.

--- a/assets/CustomGameConfigs/Atomic Heart/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Atomic Heart/UE4SS-settings.ini
@@ -31,6 +31,11 @@ EnableHotReloadSystem = 1
 ; Default: R
 HotReloadKey = R
 
+; Whether to automatically reload mods when a change is detected.
+; The reload triggers when any file is edited or a new file is added to the 'Scripts' directory.
+; Default: 0
+EnableAutoReloadingLuaMods = 0
+
 ; Whether caches will be invalidated if ue4ss.dll has changed
 ; Default: 1
 InvalidateCacheIfDLLDiffers = 1

--- a/assets/CustomGameConfigs/Borderlands 3/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Borderlands 3/UE4SS-settings.ini
@@ -31,6 +31,11 @@ EnableHotReloadSystem = 0
 ; Default: R
 HotReloadKey = R
 
+; Whether to automatically reload mods when a change is detected.
+; The reload triggers when any file is edited or a new file is added to the 'Scripts' directory.
+; Default: 0
+EnableAutoReloadingLuaMods = 0
+
 ; Whether caches will be invalidated if ue4ss.dll has changed
 ; Default: 1
 InvalidateCacheIfDLLDiffers = 1

--- a/assets/CustomGameConfigs/Final Fantasy 7 Rebirth/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Final Fantasy 7 Rebirth/UE4SS-settings.ini
@@ -31,6 +31,11 @@ EnableHotReloadSystem = 1
 ; Default: R
 HotReloadKey = R
 
+; Whether to automatically reload mods when a change is detected.
+; The reload triggers when any file is edited or a new file is added to the 'Scripts' directory.
+; Default: 0
+EnableAutoReloadingLuaMods = 0
+
 ; Whether the cache system for AOBs will be used.
 ; Default: 1
 UseCache = 1

--- a/assets/CustomGameConfigs/Final Fantasy 7 Remake/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Final Fantasy 7 Remake/UE4SS-settings.ini
@@ -31,6 +31,11 @@ EnableHotReloadSystem = 1
 ; Default: R
 HotReloadKey = R
 
+; Whether to automatically reload mods when a change is detected.
+; The reload triggers when any file is edited or a new file is added to the 'Scripts' directory.
+; Default: 0
+EnableAutoReloadingLuaMods = 0
+
 ; Whether the cache system for AOBs will be used.
 ; Default: 1
 UseCache = 1

--- a/assets/CustomGameConfigs/Kingdom Hearts 3/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Kingdom Hearts 3/UE4SS-settings.ini
@@ -31,6 +31,11 @@ EnableHotReloadSystem = 0
 ; Default: R
 HotReloadKey = R
 
+; Whether to automatically reload mods when a change is detected.
+; The reload triggers when any file is edited or a new file is added to the 'Scripts' directory.
+; Default: 0
+EnableAutoReloadingLuaMods = 0
+
 ; Whether caches will be invalidated if ue4ss.dll has changed
 ; Default: 1
 InvalidateCacheIfDLLDiffers = 1

--- a/assets/CustomGameConfigs/Lies of P/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Lies of P/UE4SS-settings.ini
@@ -31,6 +31,11 @@ EnableHotReloadSystem = 0
 ; Default: R
 HotReloadKey = R
 
+; Whether to automatically reload mods when a change is detected.
+; The reload triggers when any file is edited or a new file is added to the 'Scripts' directory.
+; Default: 0
+EnableAutoReloadingLuaMods = 0
+
 ; Whether the cache system for AOBs will be used.
 ; Default: 1
 UseCache = 1

--- a/assets/CustomGameConfigs/Split Fiction/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Split Fiction/UE4SS-settings.ini
@@ -31,6 +31,11 @@ EnableHotReloadSystem = 1
 ; Default: R
 HotReloadKey = R
 
+; Whether to automatically reload mods when a change is detected.
+; The reload triggers when any file is edited or a new file is added to the 'Scripts' directory.
+; Default: 0
+EnableAutoReloadingLuaMods = 0
+
 ; Whether the cache system for AOBs will be used.
 ; Default: 1
 UseCache = 1

--- a/assets/CustomGameConfigs/Star Wars Jedi Survivor/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Star Wars Jedi Survivor/UE4SS-settings.ini
@@ -35,6 +35,11 @@ HotReloadKey = R
 ; Default: 1
 UseCache = 1
 
+; Whether to automatically reload mods when a change is detected.
+; The reload triggers when any file is edited or a new file is added to the 'Scripts' directory.
+; Default: 0
+EnableAutoReloadingLuaMods = 0
+
 ; Whether caches will be invalidated if ue4ss.dll has changed
 ; Default: 1
 InvalidateCacheIfDLLDiffers = 1
@@ -73,7 +78,7 @@ MajorVersion = 4
 MinorVersion = 26
 ; True if the game is built as Debug, Development, or Test.
 ; Default: false
-DebugBuild = 
+DebugBuild =
 
 [ObjectDumper]
 ; Whether to force all assets to be loaded before dumping objects

--- a/assets/CustomGameConfigs/The Outer Worlds Spacer's Choice/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/The Outer Worlds Spacer's Choice/UE4SS-settings.ini
@@ -31,6 +31,11 @@ EnableHotReloadSystem = 0
 ; Default: R
 HotReloadKey = R
 
+; Whether to automatically reload mods when a change is detected.
+; The reload triggers when any file is edited or a new file is added to the 'Scripts' directory.
+; Default: 0
+EnableAutoReloadingLuaMods = 0
+
 ; Whether caches will be invalidated if ue4ss.dll has changed
 ; Default: 1
 InvalidateCacheIfDLLDiffers = 1

--- a/assets/CustomGameConfigs/The Outer Worlds/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/The Outer Worlds/UE4SS-settings.ini
@@ -31,6 +31,11 @@ EnableHotReloadSystem = 0
 ; Default: R
 HotReloadKey = R
 
+; Whether to automatically reload mods when a change is detected.
+; The reload triggers when any file is edited or a new file is added to the 'Scripts' directory.
+; Default: 0
+EnableAutoReloadingLuaMods = 0
+
 ; Whether caches will be invalidated if ue4ss.dll has changed
 ; Default: 1
 InvalidateCacheIfDLLDiffers = 1

--- a/assets/UE4SS-settings.ini
+++ b/assets/UE4SS-settings.ini
@@ -31,6 +31,11 @@ EnableHotReloadSystem = 1
 ; Default: R
 HotReloadKey = R
 
+; Whether to automatically reload mods when a change is detected.
+; The reload triggers when any file is edited or a new file is added to the 'Scripts' directory.
+; Default: 0
+EnableAutoReloadingLuaMods = 0
+
 ; Whether the cache system for AOBs will be used.
 ; Default: 1
 UseCache = 1


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

When `EnableAutoReloadingLuaMods` is set to `1` in the `General` section of `UE4SS-settings.ini`, any file changed or added in the `Mods/<ModName>/Scripts` directory will automatically trigger a reload of that particular mod.

Changes in sub-directories will not trigger a reload.


**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)


**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
