### PR TITLE
Update custom game configs for Abiotic Factor v1.0.0.21035

### DIFF
--- a/assets/CustomGameConfigs/Abiotic Factor/MemberVariableLayout.ini
+++ b/assets/CustomGameConfigs/Abiotic Factor/MemberVariableLayout.ini
@@ -1,3 +1,11 @@
+[UEnum]
+CppForm = 0x50
+CppType = 0x30
+EnumDisplayNameFn = 0x58
+EnumFlags = 0x54
+EnumPackage = 0x60
+Names = 0x40
+
 [FDelegateProperty]
 SignatureFunction = 0x70
 
@@ -8,13 +16,29 @@ NamePrivate = 0x18
 ObjectFlags = 0x8
 OuterPrivate = 0x20
 
-[FChunkedFixedUObjectArray]
-MaxChunks = 0x18
-MaxElements = 0x10
-NumChunks = 0x1C
-NumElements = 0x14
-Objects = 0x0
-PreAllocatedObjects = 0x8
+[FSetProperty]
+ElementProp = 0x70
+SetLayout = 0x78
+
+[UClass]
+AllFunctionsCache = 0x180
+ClassCastFlags = 0xD8
+ClassConfigName = 0xE8
+ClassConstructor = 0xB0
+ClassDefaultObject = 0x110
+ClassFlags = 0xD4
+ClassUnique = 0xC8
+ClassVTableHelperCtorCaller = 0xB8
+ClassWithin = 0xE0
+FirstOwnedClassRep = 0xCC
+FuncMap = 0x128
+Interfaces = 0x1D8
+NetFields = 0x100
+ReferenceSchema = 0x1E8
+SparseClassData = 0x118
+SparseClassDataStruct = 0x120
+bCooked = 0xD0
+bLayoutChanging = 0xD1
 
 [FArchiveState]
 ArAllowLazyLoading = 0x2A
@@ -61,77 +85,6 @@ NextProxy = 0x88
 SerializedProperty = 0x70
 bCustomVersionsAreReset = 0x80
 
-[FWorldContext]
-AudioDeviceID = 0x240
-ContextHandle = 0xA0
-CustomDescription = 0x248
-ExternalReferences = 0x2B0
-GameViewport = 0x200
-LevelsToLoadForPendingMapChange = 0x1A8
-PIEAccumulatedTickSeconds = 0x25C
-PIEFixedTickSeconds = 0x258
-PIEInstance = 0x220
-PIEPrefix = 0x228
-PendingMapChangeFailureDescription = 0x1C8
-RunAsDedicated = 0x23C
-ThisCurrentWorld = 0x2C0
-TravelType = 0xB8
-TravelURL = 0xA8
-bIsPrimaryPIEInstance = 0x23E
-bShouldCommitPendingMapChange = 0x1D8
-bWaitingOnOnlineSubsystem = 0x23D
-
-[ULocalPlayer]
-AspectRatioAxisConstraint = 0xB8
-CachedUniqueNetId = 0x48
-ControllerId = 0xE0
-OnPlayerControllerChangedEvent = 0x120
-PlatformUserId = 0x100
-SlateOperations = 0x1F8
-ViewportClient = 0x78
-bSentSplitJoin = 0xC8
-
-[FByteProperty]
-Enum = 0x70
-
-[FUObjectItem]
-ClusterRootIndex = 0xC
-Flags = 0x8
-Object = 0x0
-SerialNumber = 0x10
-
-[FFixedUObjectArray]
-MaxElements = 0x8
-NumElements = 0xC
-Objects = 0x0
-
-[FBoolProperty]
-ByteMask = 0x72
-ByteOffset = 0x71
-FieldMask = 0x73
-FieldSize = 0x70
-
-[FUObjectArray]
-MaxObjectsNotConsideredByGC = 0x8
-ObjAvailableList = 0x58
-ObjFirstGCIndex = 0x0
-ObjLastNonGCIndex = 0x4
-ObjObjects = 0x10
-OpenForDisregardForGC = 0xC
-UObjectCreateListeners = 0x68
-UObjectDeleteListeners = 0x78
-bShouldRecycleObjectIndices = 0xB4
-
-[FField]
-ClassPrivate = 0x8
-FlagsPrivate = 0x28
-NamePrivate = 0x20
-Next = 0x18
-Owner = 0x10
-
-[FMulticastDelegateProperty]
-SignatureFunction = 0x70
-
 [AGameModeBase]
 DefaultPlayerName = 0x308
 GameNetDriverReplicationSystem = 0x31C
@@ -154,35 +107,8 @@ MetaClass = 0x78
 bAutoEmitLineTerminator = 0x9
 bSuppressEventTag = 0x8
 
-[UEnum]
-CppForm = 0x50
-CppType = 0x30
-EnumDisplayNameFn = 0x58
-EnumFlags = 0x54
-EnumPackage = 0x60
-Names = 0x40
-
-[UClass]
-AllFunctionsCache = 0x180
-ClassConfigName = 0xE8
-ClassConstructor = 0xB0
-ClassDefaultObject = 0x110
-ClassFlags = 0xD4
-ClassUnique = 0xC8
-ClassVTableHelperCtorCaller = 0xB8
-ClassWithin = 0xE0
-FirstOwnedClassRep = 0xCC
-FuncMap = 0x128
-Interfaces = 0x1D8
-NetFields = 0x100
-ReferenceSchema = 0x1E8
-SparseClassData = 0x118
-SparseClassDataStruct = 0x120
-bCooked = 0xD0
-bLayoutChanging = 0xD1
-
-[FSetProperty]
-ElementProp = 0x70
+[FMulticastDelegateProperty]
+SignatureFunction = 0x70
 
 [FInterfaceProperty]
 InterfaceClass = 0x70
@@ -201,6 +127,47 @@ ReturnValueOffset = 0xB8
 
 [UField]
 Next = 0x28
+
+[FBoolProperty]
+ByteMask = 0x72
+ByteOffset = 0x71
+FieldMask = 0x73
+FieldSize = 0x70
+
+[FWorldContext]
+AudioDeviceID = 0x240
+ContextHandle = 0xA0
+CustomDescription = 0x248
+ExternalReferences = 0x2B0
+GameViewport = 0x200
+GarbageObjectsToVerify = 0x260
+LastRemoteURL = 0x128
+LastURL = 0xC0
+LevelsToLoadForPendingMapChange = 0x1A8
+PIEAccumulatedTickSeconds = 0x25C
+PIEFixedTickSeconds = 0x258
+PIEInstance = 0x220
+PIEPrefix = 0x228
+PendingMapChangeFailureDescription = 0x1C8
+RunAsDedicated = 0x23C
+ThisCurrentWorld = 0x2C0
+TravelType = 0xB8
+TravelURL = 0xA8
+bIsPrimaryPIEInstance = 0x23E
+bShouldCommitPendingMapChange = 0x1D8
+bWaitingOnOnlineSubsystem = 0x23D
+
+[ULocalPlayer]
+AspectRatioAxisConstraint = 0xB8
+CachedUniqueNetId = 0x48
+ControllerId = 0xE0
+PlatformUserId = 0x100
+SlateOperations = 0x1F8
+ViewportClient = 0x78
+bSentSplitJoin = 0xC8
+
+[FByteProperty]
+Enum = 0x70
 
 [FProperty]
 ArrayDim = 0x30
@@ -232,9 +199,17 @@ UnresolvedScriptProperties = 0xA0
 Enum = 0x78
 UnderlyingProp = 0x70
 
+[FField]
+ClassPrivate = 0x8
+FlagsPrivate = 0x28
+NamePrivate = 0x20
+Next = 0x18
+Owner = 0x10
+
 [FMapProperty]
 KeyProp = 0x70
 MapFlags = 0x98
+MapLayout = 0x80
 ValueProp = 0x78
 
 [FClassProperty]
@@ -242,6 +217,13 @@ MetaClass = 0x78
 
 [FObjectPropertyBase]
 PropertyClass = 0x70
+
+[FArrayProperty]
+ArrayFlags = 0x70
+Inner = 0x78
+
+[FStructProperty]
+Struct = 0x70
 
 [UScriptStruct]
 CppStructOps = 0xB8
@@ -251,13 +233,6 @@ bPrepareCppStructOpsCompleted = 0xB4
 [UScriptStruct::ICppStructOps]
 Alignment = 0xC
 Size = 0x8
-
-[FArrayProperty]
-ArrayFlags = 0x70
-Inner = 0x78
-
-[FStructProperty]
-Struct = 0x70
 
 [FFieldPathProperty]
 PropertyClass = 0x70
@@ -368,7 +343,6 @@ CurrentNetSpeed = 0x38
 
 [UWorld]
 ActiveLevelCollectionIndex = 0x198
-AllLevelsChangedEvent = 0x540
 AudioTimeSeconds = 0x6D8
 AuthorityGameMode = 0x158
 BlockTillLevelStreamingCompletedEpoch = 0x148
@@ -384,7 +358,6 @@ LastTimeUnbuiltLightingWasEncountered = 0x6B8
 NextSwitchCountdown = 0x720
 NextURL = 0x740
 NumStreamingLevelsBeingLoaded = 0x73A
-OnBeginPlay = 0x1A0
 PauseDelay = 0x6E8
 PerModuleDataObjects = 0x78
 PlayerNum = 0x678
@@ -393,6 +366,7 @@ RealTimeSeconds = 0x6D0
 StreamingLevelsPrefix = 0xC8
 StreamingVolumeUpdateDelay = 0x67C
 TimeSeconds = 0x6C0
+URL = 0x5A0
 UnpausedTimeSeconds = 0x6C8
 bActorsInitialized = 0x13C
 bAggressiveLOD = 0x13C
@@ -428,6 +402,8 @@ bShouldSimulatePhysics = 0x13C
 bShouldTick = 0x13E
 bStartup = 0x13D
 bStreamingDataDirty = 0x13E
+bSupportsMakingInvisibleTransactionRequests = 0xDA
+bSupportsMakingVisibleTransactionRequests = 0xD8
 bTickNewlySpawned = 0x13B
 bTriggerPostLoadMap = 0x13B
 bWorldWasLoadedThisTick = 0x13B

--- a/assets/CustomGameConfigs/Abiotic Factor/VTableLayout.ini
+++ b/assets/CustomGameConfigs/Abiotic Factor/VTableLayout.ini
@@ -1,16 +1,3 @@
-[FField]
-__vecDelDtor
-Serialize
-PostLoad
-GetPreloadDependencies
-BeginDestroy
-AddReferencedObjects
-AddCppProperty
-Bind
-PostDuplicate
-GetInnerFieldByName
-GetInnerFields
-
 [ITextData]
 __vecDelDtor
 GetSourceString
@@ -246,38 +233,6 @@ SetEngineVer
 SetEngineNetVer
 SetGameNetVer
 
-[FMulticastDelegateProperty]
-__vecDelDtor
-GetMulticastDelegate
-SetMulticastDelegate
-AddDelegate
-RemoveDelegate
-ClearDelegate
-GetMulticastScriptDelegate
-
-[FNumericProperty]
-__vecDelDtor
-IsFloatingPoint
-IsInteger
-GetIntPropertyEnum
-; void SetIntPropertyValue(void*, int64)const;
-SetIntPropertyValue
-; void SetIntPropertyValue_1(void*, uint64)const;
-SetIntPropertyValue_1
-SetFloatingPointPropertyValue
-SetNumericPropertyValueFromString
-SetNumericPropertyValueFromString_InContainer
-GetSignedIntPropertyValue
-GetSignedIntPropertyValue_InContainer
-GetUnsignedIntPropertyValue
-GetUnsignedIntPropertyValue_InContainer
-GetFloatingPointPropertyValue
-GetNumericPropertyValueToString
-GetNumericPropertyValueToString_InContainer
-CanHoldDoubleValueInternal
-CanHoldSignedValueInternal
-CanHoldUnsignedValueInternal
-
 [AGameModeBase]
 __vecDelDtor
 InitializeHUDForPlayer_Implementation
@@ -362,6 +317,38 @@ CanBeUsedOnAnyThread
 CanBeUsedOnMultipleThreads
 CanBeUsedOnPanicThread
 
+[FMulticastDelegateProperty]
+__vecDelDtor
+GetMulticastDelegate
+SetMulticastDelegate
+AddDelegate
+RemoveDelegate
+ClearDelegate
+GetMulticastScriptDelegate
+
+[FNumericProperty]
+__vecDelDtor
+IsFloatingPoint
+IsInteger
+GetIntPropertyEnum
+; void SetIntPropertyValue(void*, int64)const;
+SetIntPropertyValue
+; void SetIntPropertyValue_1(void*, uint64)const;
+SetIntPropertyValue_1
+SetFloatingPointPropertyValue
+SetNumericPropertyValueFromString
+SetNumericPropertyValueFromString_InContainer
+GetSignedIntPropertyValue
+GetSignedIntPropertyValue_InContainer
+GetUnsignedIntPropertyValue
+GetUnsignedIntPropertyValue_InContainer
+GetFloatingPointPropertyValue
+GetNumericPropertyValueToString
+GetNumericPropertyValueToString_InContainer
+CanHoldDoubleValueInternal
+CanHoldSignedValueInternal
+CanHoldUnsignedValueInternal
+
 [UField]
 __vecDelDtor
 AddCppProperty
@@ -409,6 +396,19 @@ LoadTypeName
 SaveTypeName
 CanSerializeFromTypeName
 SameType
+
+[FField]
+__vecDelDtor
+Serialize
+PostLoad
+GetPreloadDependencies
+BeginDestroy
+AddReferencedObjects
+AddCppProperty
+Bind
+PostDuplicate
+GetInnerFieldByName
+GetInnerFields
 
 [FObjectPropertyBase]
 __vecDelDtor


### PR DESCRIPTION
**Description**
- Dumped Abiotic Factor v1.0.0.21035 PDB `MemberVariableLayout.ini` and `VTableLayout.ini` with latest `UVTD` from main.  
- Fixed FMalloc vtable manually, like before, to add 3 missing functions after `__vecDelDtor

**Note**  
While some member variables were added, there are no visible changes in the quality of how well UE4SS works in Abiotic Factor compared to the previous version.