### PR TITLE
fix(Lua): Use-after-free when UnregisterHook is called in a RegisterHook callback

### DIFF
--- a/UE4SS/include/Mod/LuaMod.hpp
+++ b/UE4SS/include/Mod/LuaMod.hpp
@@ -87,6 +87,7 @@ namespace RC
             const LuaMadeSimple::Lua* lua;
             Unreal::UClass* instance_of_class;
             std::vector<std::pair<const LuaMadeSimple::Lua*, RegistryIndex>> registry_indexes;
+            bool scheduled_for_removal{};
         };
         struct LuaCancellableCallbackData
         {


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

The fix was to delay the removal of the hook until after the callback data is done being used.

For script hooks, we no longer delete the registry index from the callback data vector, instead we just mark it unregistered and skip it when iterating.

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

**How has this been tested?**
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration. -->

I've tested that ClientRestart doesn't cause a crash by using ConsoleEnablerMod, and starting the game, loading a save, going back to the main menu, and loading another save.

I haven't tested non-native hooks.
Someone needs to test calling `UnregisterHook` on a non-native function inside the hook callback.

