### PR TITLE
fix(Build): Clang is available on Windows as well, and as such, we need to push/pop diagnostics there too

### DIFF
--- a/deps/first/Helpers/include/Helpers/String.hpp
+++ b/deps/first/Helpers/include/Helpers/String.hpp
@@ -191,16 +191,16 @@ namespace RC
 
     auto inline to_wstring(std::string_view input) -> std::wstring
     {
+#if __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
 #ifdef PLATFORM_WINDOWS
 #pragma warning(disable : 4996)
         static std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter{};
         return converter.from_bytes(input.data(), input.data() + input.length());
 #pragma warning(default : 4996)
 #else
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#endif
         static std::wstring_convert<std::codecvt_utf8<wchar_t>> converter{};
         return converter.from_bytes(input.data(), input.data() + input.length());
 #endif


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

Before this, the diagnostic was only pushed on non-Windows platforms, but it was popped on all platforms, so not only was the logic incorrect, but the push/pop was uneven which caused warnings when using Clang on Windows.

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)



