### PR TITLE
Add custom signatures for Tokyo Xtreme Racer

### DIFF
--- a/assets/CustomGameConfigs/Tokyo Xtreme Racer/UE4SS_Signatures/StaticConstructObject.lua
+++ b/assets/CustomGameConfigs/Tokyo Xtreme Racer/UE4SS_Signatures/StaticConstructObject.lua
@@ -1,0 +1,7 @@
+function Register()
+    return "4C 8B DC 55 53 41 56 49 8D AB 28 FE FF FF 48 81 EC C0 02 00 00 48 8B"
+end
+
+function OnMatchFound(MatchAddress)
+    return MatchAddress
+end


### PR DESCRIPTION
**Description**

Tokyo Xtreme Racer has left Early Access today, and one of its signatures doesn't match the current range of UE5.6 signatures shipped by UE5.6. Fix this by providing a custom config in-repo.

**Type of change**

Custom game config.

**How has this been tested?**

Lua mods work again on TXR2025.

**Checklist**

N/A

**Screenshots**
<img width="1920" height="1080" alt="2634950_20250925173614_1" src="https://github.com/user-attachments/assets/562d9185-1a31-4e78-b75a-5f1db72373b6" />
