### PR TITLE
Adds `LoadExport` function, and the ability for UE4SS_Signatures Lua files to return the address instead of using the two global functions

### DIFF
--- a/UE4SS/include/LuaLibrary.hpp
+++ b/UE4SS/include/LuaLibrary.hpp
@@ -31,6 +31,7 @@ namespace RC::LuaLibrary
 
     // Global Lua functions are meant to be called with intact Lua stack
     auto global_print(const LuaMadeSimple::Lua&) -> int;
+    auto load_export(const LuaMadeSimple::Lua&) -> int;
 
     // Used exclusively for the scripts inside the 'UE4SS_Signatures' folder
     auto deref_to_int32(const LuaMadeSimple::Lua&) -> int;

--- a/UE4SS/src/LuaLibrary.cpp
+++ b/UE4SS/src/LuaLibrary.cpp
@@ -142,17 +142,7 @@ namespace RC::LuaLibrary
 
         const auto symbol_name = std::string{lua.get_string()};
 
-        intptr_t symbol_address{};
-        for (const auto& module_info : SigScannerStaticData::m_modules_info.array)
-        {
-            symbol_address = std::bit_cast<intptr_t>(GetProcAddress(static_cast<HMODULE>(module_info.lpBaseOfDll), symbol_name.data()));
-            if (symbol_address)
-            {
-                break;
-            }
-        }
-
-        lua.set_integer(symbol_address);
+        lua.set_integer(std::bit_cast<intptr_t>(Unreal::UnrealInitializer::LoadExport(symbol_name)));
         return 1;
     }
 

--- a/UE4SS/src/LuaLibrary.cpp
+++ b/UE4SS/src/LuaLibrary.cpp
@@ -131,6 +131,31 @@ namespace RC::LuaLibrary
         return 1;
     }
 
+    auto load_export(const LuaMadeSimple::Lua& lua) -> int
+    {
+        if (lua.get_stack_size() != 1 || !lua.is_string())
+        {
+            Output::send(STR("[Fatal] Lua function 'LoadExport' must have only 1 parameter and it must be of type 'string'.\n"));
+            lua.set_nil();
+            return 1;
+        }
+
+        const auto symbol_name = std::string{lua.get_string()};
+
+        intptr_t symbol_address{};
+        for (const auto& module_info : SigScannerStaticData::m_modules_info.array)
+        {
+            symbol_address = std::bit_cast<intptr_t>(GetProcAddress(static_cast<HMODULE>(module_info.lpBaseOfDll), symbol_name.data()));
+            if (symbol_address)
+            {
+                break;
+            }
+        }
+
+        lua.set_integer(symbol_address);
+        return 1;
+    }
+
     static auto error_handler_for_exported_functions(std::string_view e) -> void
     {
         // If the output system errored out then use printf_s as a fallback

--- a/UE4SS/src/Mod/LuaMod.cpp
+++ b/UE4SS/src/Mod/LuaMod.cpp
@@ -1181,6 +1181,7 @@ namespace RC
     auto static setup_lua_global_functions_internal(const LuaMadeSimple::Lua& lua, Mod::IsTrueMod is_true_mod) -> void
     {
         lua.register_function("print", LuaLibrary::global_print);
+        lua.register_function("LoadExport", LuaLibrary::load_export);
 
         lua.register_function("CreateInvalidObject", [](const LuaMadeSimple::Lua& lua) -> int {
             LuaType::auto_construct_object(lua, nullptr);

--- a/UE4SS/src/Signatures.cpp
+++ b/UE4SS/src/Signatures.cpp
@@ -46,6 +46,13 @@ namespace RC
 
         lua.execute_file(script_file_path_and_name.string());
 
+        if (lua.get_stack_size() > 0 && lua.is_integer())
+        {
+            auto found_address = reinterpret_cast<void*>(lua.get_integer());
+            match_found_func(found_address);
+            return;
+        }
+
         constexpr const char* global_register_func_name = "Register";
         constexpr const char* global_on_match_found_func_name = "OnMatchFound";
 

--- a/UE4SS/src/Signatures.cpp
+++ b/UE4SS/src/Signatures.cpp
@@ -41,6 +41,8 @@ namespace RC
         lua.register_function("print", LuaLibrary::global_print);
         lua.register_function("DerefToInt32", LuaLibrary::deref_to_int32);
         lua.register_function("dereftoint32", LuaLibrary::deref_to_int32);
+        lua.register_function("LoadExport", LuaLibrary::load_export);
+        lua.register_function("loadexport", LuaLibrary::load_export);
 
         lua.execute_file(script_file_path_and_name.string());
 

--- a/UE4SS/src/Signatures.cpp
+++ b/UE4SS/src/Signatures.cpp
@@ -46,11 +46,18 @@ namespace RC
 
         lua.execute_file(script_file_path_and_name.string());
 
-        if (lua.get_stack_size() > 0 && lua.is_integer())
+        if (lua.get_stack_size() > 0)
         {
-            auto found_address = reinterpret_cast<void*>(lua.get_integer());
-            match_found_func(found_address);
-            return;
+            if (lua.is_integer())
+            {
+                auto found_address = reinterpret_cast<void*>(lua.get_integer());
+                match_found_func(found_address);
+                return;
+            }
+            else if (lua.is_nil())
+            {
+                throw std::runtime_error{fmt::format("Lua file returned nil (symbol not found): {}", to_string(script_file_path_and_name))};
+            }
         }
 
         constexpr const char* global_register_func_name = "Register";

--- a/deps/first/SinglePassSigScanner/src/SinglePassSigScanner.cpp
+++ b/deps/first/SinglePassSigScanner/src/SinglePassSigScanner.cpp
@@ -813,8 +813,9 @@ namespace RC
 
             if (merged_containers.empty())
             {
-                throw std::runtime_error{"[SinglePassScanner::start_scan] Could not merge containers. Either there were not containers to merge or there was "
-                                         "an internal error."};
+                // No containers means no scanning was actually done.
+                // We can return safely to the caller.
+                return;
             }
 
             uint8_t* module_start_address = static_cast<uint8_t*>(merged_module_info.lpBaseOfDll);

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -100,6 +100,7 @@
     - [DumpStaticMeshes](./lua-api/global-functions/dumpstaticmeshes.md)
     - [DumpAllActors](./lua-api/global-functions/dumpallactors.md)
     - [DumpUSMAP](./lua-api/global-functions/dumpusmap.md)
+    - [LoadExport](./lua-api/global-functions/loadexport.md)
   - [Examples](./lua-api/examples.md)
   - [Creating a Lua Mod](./guides/creating-a-lua-mod.md)
   - [Using Custom Lua Bindings](./guides/using-custom-lua-bindings.md)

--- a/docs/guides/fixing-compatibility-problems.md
+++ b/docs/guides/fixing-compatibility-problems.md
@@ -39,8 +39,9 @@ For more in-depth instructions, see the [advanced guide](./fixing-compatibility-
    - ProcessLocalScriptFunction.lua
    - ProcessInternal.lua
    - CallFunctionByNameWithArguments.lua
-4. Inside the `.lua` file you need a global `Register` function with no params
-    - Keep in mind that the names of functions in Lua files in the `UE4SS_Signatures` directory are case-senstive.
+4. Inside the `.lua` file, you need to either return the address of the symbol at file-scope, or you need a `Register` and `OnMatchFound` function to perform an AOB scan.
+    - Keep in mind that the names of functions in Lua files in the `UE4SS_Signatures` directory are case-sensitive.
+    - If you choose to return the symbol address at file-scope, the `LoadExport` function may be useful, but usually only if the game is built modularly.
 5. The `Register` function must return the AOB that you want UE4SS to scan for.
     - The format is a list of nibbles, and every two forms a byte.  
     - I like putting a space between each byte just for clarity but this is not a requirement. 

--- a/docs/lua-api/global-functions/loadexport.md
+++ b/docs/lua-api/global-functions/loadexport.md
@@ -1,0 +1,18 @@
+# LoadExport
+
+The `LoadExport` function is used to load a symbol that's been exported by the game.
+
+> [!IMPORTANT]
+> This function doesn't handle undecorated symbol names.
+
+## Parameters
+
+| #      | Type  | Information             |
+|--------|-------|-------------------------|
+| string | any   | The name of the symbol. |
+
+## Example
+```lua
+-- If the game exports GUObjectArray, like it does when UE is build modularly, this retrieves its address.
+local GUObjectArray = LoadExport("?GUObjectArray@@3VFUObjectArray@@A")
+```

--- a/docs/lua-api/global-functions/loadexport.md
+++ b/docs/lua-api/global-functions/loadexport.md
@@ -13,6 +13,6 @@ The `LoadExport` function is used to load a symbol that's been exported by the g
 
 ## Example
 ```lua
--- If the game exports GUObjectArray, like it does when UE is build modularly, this retrieves its address.
+-- If the game exports GUObjectArray, like it does when UE is built modularly, this retrieves its address.
 local GUObjectArray = LoadExport("?GUObjectArray@@3VFUObjectArray@@A")
 ```


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

### LoadExport

This function takes a decorated symbol name, and returns either nil or the address of the symbol as an integer.
It's available both for UE4SS_Signatures Lua files, and also main.lua for regular mods, though I suspect it won't be particularly useful there.

### UE4SS_Signatures

You are no longer required to use the `Register` and `OnMatchFound` functions for Lua files in the `UE4SS_Signatures` directory.
Instead, you can use `LoadExport` and return its return value at file-scope.
Note that this only works if the game exports the symbol.
This is usually only the case if the game is built modularly, like Satisfactory.
Example:
```lua
-- UE4SS_Signatures/GUObjectArray.lua
return LoadExport("?GUObjectArray@@3VFUObjectArray@@A")
```

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

**How has this been tested?**
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration. -->
