### PR TITLE
feat: Added DoEarlyScan to UE4SS-settings.ini

### DIFF
--- a/UE4SS/include/SettingsManager.hpp
+++ b/UE4SS/include/SettingsManager.hpp
@@ -28,7 +28,7 @@ namespace RC
             int64_t SecondsToScanBeforeGivingUp{30};
             bool UseUObjectArrayCache{true};
             StringType InputSource{STR("Default")};
-            bool DoEarlyScan{true};
+            bool DoEarlyScan{false};
         } General;
 
         struct SectionEngineVersionOverride

--- a/UE4SS/include/SettingsManager.hpp
+++ b/UE4SS/include/SettingsManager.hpp
@@ -28,6 +28,7 @@ namespace RC
             int64_t SecondsToScanBeforeGivingUp{30};
             bool UseUObjectArrayCache{true};
             StringType InputSource{STR("Default")};
+            bool DoEarlyScan{true};
         } General;
 
         struct SectionEngineVersionOverride

--- a/UE4SS/src/SettingsManager.cpp
+++ b/UE4SS/src/SettingsManager.cpp
@@ -71,6 +71,7 @@ namespace RC
         REGISTER_BOOL_SETTING(General.EnableDebugKeyBindings, section_general, EnableDebugKeyBindings)
         REGISTER_INT64_SETTING(General.SecondsToScanBeforeGivingUp, section_general, SecondsToScanBeforeGivingUp)
         REGISTER_BOOL_SETTING(General.UseUObjectArrayCache, section_general, bUseUObjectArrayCache)
+        REGISTER_BOOL_SETTING(General.DoEarlyScan, section_general, DoEarlyScan)
 
         constexpr static File::CharType section_engine_version_override[] = STR("EngineVersionOverride");
         REGISTER_INT64_SETTING(EngineVersionOverride.MajorVersion, section_engine_version_override, MajorVersion)

--- a/UE4SS/src/UE4SSProgram.cpp
+++ b/UE4SS/src/UE4SSProgram.cpp
@@ -859,15 +859,18 @@ namespace RC
         // Apply Debug Build setting from settings file only for now.
         Unreal::Version::DebugBuild = settings_manager.EngineVersionOverride.DebugBuild;
         Output::send<LogLevel::Warning>(STR("DebugGame Setting Enabled? {}\n"), Unreal::Version::DebugBuild);
-        // Scan a single time while the game thread is locked after UE4SS is attached.
-        Unreal::UnrealInitializer::PreInitialize(config);
-        try
+        if (settings_manager.General.DoEarlyScan)
         {
-            Unreal::UnrealInitializer::ScanGame();
-        }
-        catch (std::runtime_error&)
-        {
-            // No work to be done here. Error is non-fatal, just let the 'Initialize' function take it from here.
+            // Scan a single time while the game thread is locked after UE4SS is attached.
+            Unreal::UnrealInitializer::PreInitialize(config);
+            try
+            {
+                Unreal::UnrealInitializer::ScanGame();
+            }
+            catch (std::runtime_error&)
+            {
+                // No work to be done here. Error is non-fatal, just let the 'Initialize' function take it from here.
+            }
         }
         cpp_mods_done_loading.store(true);
         cpp_mods_done_loading.notify_one();

--- a/assets/CustomGameConfigs/Atomic Heart/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Atomic Heart/UE4SS-settings.ini
@@ -31,6 +31,10 @@ MaxScanAttemptsModular = 2500
 ; Default: true
 bUseUObjectArrayCache = true
 
+; Whether to perform a single AOB scan as soon as possible after the game starts.
+; Default: 1
+DoEarlyScan = 1
+
 [EngineVersionOverride]
 MajorVersion = 
 MinorVersion =

--- a/assets/CustomGameConfigs/Atomic Heart/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Atomic Heart/UE4SS-settings.ini
@@ -32,8 +32,8 @@ MaxScanAttemptsModular = 2500
 bUseUObjectArrayCache = true
 
 ; Whether to perform a single AOB scan as soon as possible after the game starts.
-; Default: 1
-DoEarlyScan = 1
+; Default: 0
+DoEarlyScan = 0
 
 [EngineVersionOverride]
 MajorVersion = 

--- a/assets/CustomGameConfigs/Borderlands 3/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Borderlands 3/UE4SS-settings.ini
@@ -26,6 +26,10 @@ MaxScanAttemptsNormal = 60
 ; Default: 2000
 MaxScanAttemptsModular = 2500
 
+; Whether to perform a single AOB scan as soon as possible after the game starts.
+; Default: 1
+DoEarlyScan = 1
+
 [EngineVersionOverride]
 MajorVersion = 4
 MinorVersion = 20

--- a/assets/CustomGameConfigs/Borderlands 3/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Borderlands 3/UE4SS-settings.ini
@@ -27,8 +27,8 @@ MaxScanAttemptsNormal = 60
 MaxScanAttemptsModular = 2500
 
 ; Whether to perform a single AOB scan as soon as possible after the game starts.
-; Default: 1
-DoEarlyScan = 1
+; Default: 0
+DoEarlyScan = 0
 
 [EngineVersionOverride]
 MajorVersion = 4

--- a/assets/CustomGameConfigs/Deadly Days Roadtrip/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Deadly Days Roadtrip/UE4SS-settings.ini
@@ -32,8 +32,8 @@ SecondsToScanBeforeGivingUp = 30
 bUseUObjectArrayCache = true
 
 ; Whether to perform a single AOB scan as soon as possible after the game starts.
-; Default: 1
-DoEarlyScan = 1
+; Default: 0
+DoEarlyScan = 0
 
 [EngineVersionOverride]
 MajorVersion = 5

--- a/assets/CustomGameConfigs/Deadly Days Roadtrip/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Deadly Days Roadtrip/UE4SS-settings.ini
@@ -31,6 +31,10 @@ SecondsToScanBeforeGivingUp = 30
 ; Default: true
 bUseUObjectArrayCache = true
 
+; Whether to perform a single AOB scan as soon as possible after the game starts.
+; Default: 1
+DoEarlyScan = 1
+
 [EngineVersionOverride]
 MajorVersion = 5
 MinorVersion = 6

--- a/assets/CustomGameConfigs/Final Fantasy 7 Rebirth/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Final Fantasy 7 Rebirth/UE4SS-settings.ini
@@ -32,8 +32,8 @@ SecondsToScanBeforeGivingUp = 30
 bUseUObjectArrayCache = true
 
 ; Whether to perform a single AOB scan as soon as possible after the game starts.
-; Default: 1
-DoEarlyScan = 1
+; Default: 0
+DoEarlyScan = 0
 
 [EngineVersionOverride]
 MajorVersion = 4

--- a/assets/CustomGameConfigs/Final Fantasy 7 Rebirth/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Final Fantasy 7 Rebirth/UE4SS-settings.ini
@@ -31,6 +31,10 @@ SecondsToScanBeforeGivingUp = 30
 ; Default: true
 bUseUObjectArrayCache = true
 
+; Whether to perform a single AOB scan as soon as possible after the game starts.
+; Default: 1
+DoEarlyScan = 1
+
 [EngineVersionOverride]
 MajorVersion = 4
 MinorVersion = 26

--- a/assets/CustomGameConfigs/Final Fantasy 7 Remake/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Final Fantasy 7 Remake/UE4SS-settings.ini
@@ -32,8 +32,8 @@ SecondsToScanBeforeGivingUp = 30
 bUseUObjectArrayCache = false
 
 ; Whether to perform a single AOB scan as soon as possible after the game starts.
-; Default: 1
-DoEarlyScan = 1
+; Default: 0
+DoEarlyScan = 0
 
 [EngineVersionOverride]
 MajorVersion = 4

--- a/assets/CustomGameConfigs/Final Fantasy 7 Remake/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Final Fantasy 7 Remake/UE4SS-settings.ini
@@ -31,6 +31,10 @@ SecondsToScanBeforeGivingUp = 30
 ; Default: true
 bUseUObjectArrayCache = false
 
+; Whether to perform a single AOB scan as soon as possible after the game starts.
+; Default: 1
+DoEarlyScan = 1
+
 [EngineVersionOverride]
 MajorVersion = 4
 MinorVersion = 18

--- a/assets/CustomGameConfigs/Kingdom Hearts 3/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Kingdom Hearts 3/UE4SS-settings.ini
@@ -31,6 +31,10 @@ MaxScanAttemptsModular = 2500
 ; Default: true
 bUseUObjectArrayCache = true
 
+; Whether to perform a single AOB scan as soon as possible after the game starts.
+; Default: 1
+DoEarlyScan = 1
+
 [EngineVersionOverride]
 MajorVersion = 
 MinorVersion =

--- a/assets/CustomGameConfigs/Kingdom Hearts 3/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Kingdom Hearts 3/UE4SS-settings.ini
@@ -32,8 +32,8 @@ MaxScanAttemptsModular = 2500
 bUseUObjectArrayCache = true
 
 ; Whether to perform a single AOB scan as soon as possible after the game starts.
-; Default: 1
-DoEarlyScan = 1
+; Default: 0
+DoEarlyScan = 0
 
 [EngineVersionOverride]
 MajorVersion = 

--- a/assets/CustomGameConfigs/Lies of P/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Lies of P/UE4SS-settings.ini
@@ -32,8 +32,8 @@ SecondsToScanBeforeGivingUp = 30
 bUseUObjectArrayCache = false
 
 ; Whether to perform a single AOB scan as soon as possible after the game starts.
-; Default: 1
-DoEarlyScan = 1
+; Default: 0
+DoEarlyScan = 0
 
 [EngineVersionOverride]
 MajorVersion = 4

--- a/assets/CustomGameConfigs/Lies of P/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Lies of P/UE4SS-settings.ini
@@ -31,6 +31,10 @@ SecondsToScanBeforeGivingUp = 30
 ; Default: true
 bUseUObjectArrayCache = false
 
+; Whether to perform a single AOB scan as soon as possible after the game starts.
+; Default: 1
+DoEarlyScan = 1
+
 [EngineVersionOverride]
 MajorVersion = 4
 MinorVersion = 27

--- a/assets/CustomGameConfigs/Split Fiction/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Split Fiction/UE4SS-settings.ini
@@ -32,8 +32,8 @@ SecondsToScanBeforeGivingUp = 30
 bUseUObjectArrayCache = true
 
 ; Whether to perform a single AOB scan as soon as possible after the game starts.
-; Default: 1
-DoEarlyScan = 1
+; Default: 0
+DoEarlyScan = 0
 
 [EngineVersionOverride]
 MajorVersion = 5

--- a/assets/CustomGameConfigs/Split Fiction/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Split Fiction/UE4SS-settings.ini
@@ -31,6 +31,10 @@ SecondsToScanBeforeGivingUp = 30
 ; Default: true
 bUseUObjectArrayCache = true
 
+; Whether to perform a single AOB scan as soon as possible after the game starts.
+; Default: 1
+DoEarlyScan = 1
+
 [EngineVersionOverride]
 MajorVersion = 5
 MinorVersion = 4

--- a/assets/CustomGameConfigs/Star Wars Jedi Survivor/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Star Wars Jedi Survivor/UE4SS-settings.ini
@@ -31,6 +31,10 @@ MaxScanAttemptsModular = 2500
 ; Default: true
 bUseUObjectArrayCache = true
 
+; Whether to perform a single AOB scan as soon as possible after the game starts.
+; Default: 1
+DoEarlyScan = 1
+
 [EngineVersionOverride]
 MajorVersion = 4
 MinorVersion = 26

--- a/assets/CustomGameConfigs/Star Wars Jedi Survivor/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Star Wars Jedi Survivor/UE4SS-settings.ini
@@ -32,8 +32,8 @@ MaxScanAttemptsModular = 2500
 bUseUObjectArrayCache = true
 
 ; Whether to perform a single AOB scan as soon as possible after the game starts.
-; Default: 1
-DoEarlyScan = 1
+; Default: 0
+DoEarlyScan = 0
 
 [EngineVersionOverride]
 MajorVersion = 4

--- a/assets/CustomGameConfigs/The Outer Worlds Spacer's Choice/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/The Outer Worlds Spacer's Choice/UE4SS-settings.ini
@@ -26,6 +26,10 @@ MaxScanAttemptsNormal = 60
 ; Default: 2000
 MaxScanAttemptsModular = 2500
 
+; Whether to perform a single AOB scan as soon as possible after the game starts.
+; Default: 1
+DoEarlyScan = 1
+
 [EngineVersionOverride]
 MajorVersion = 4
 MinorVersion = 27

--- a/assets/CustomGameConfigs/The Outer Worlds Spacer's Choice/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/The Outer Worlds Spacer's Choice/UE4SS-settings.ini
@@ -27,8 +27,8 @@ MaxScanAttemptsNormal = 60
 MaxScanAttemptsModular = 2500
 
 ; Whether to perform a single AOB scan as soon as possible after the game starts.
-; Default: 1
-DoEarlyScan = 1
+; Default: 0
+DoEarlyScan = 0
 
 [EngineVersionOverride]
 MajorVersion = 4

--- a/assets/CustomGameConfigs/The Outer Worlds/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/The Outer Worlds/UE4SS-settings.ini
@@ -26,6 +26,10 @@ MaxScanAttemptsNormal = 60
 ; Default: 2000
 MaxScanAttemptsModular = 2500
 
+; Whether to perform a single AOB scan as soon as possible after the game starts.
+; Default: 1
+DoEarlyScan = 1
+
 [EngineVersionOverride]
 MajorVersion = 
 MinorVersion =

--- a/assets/CustomGameConfigs/The Outer Worlds/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/The Outer Worlds/UE4SS-settings.ini
@@ -27,8 +27,8 @@ MaxScanAttemptsNormal = 60
 MaxScanAttemptsModular = 2500
 
 ; Whether to perform a single AOB scan as soon as possible after the game starts.
-; Default: 1
-DoEarlyScan = 1
+; Default: 0
+DoEarlyScan = 0
 
 [EngineVersionOverride]
 MajorVersion = 

--- a/assets/UE4SS-settings.ini
+++ b/assets/UE4SS-settings.ini
@@ -32,8 +32,8 @@ SecondsToScanBeforeGivingUp = 30
 bUseUObjectArrayCache = true
 
 ; Whether to perform a single AOB scan as soon as possible after the game starts.
-; Default: 1
-DoEarlyScan = 1
+; Default: 0
+DoEarlyScan = 0
 
 [EngineVersionOverride]
 MajorVersion = 

--- a/assets/UE4SS-settings.ini
+++ b/assets/UE4SS-settings.ini
@@ -31,6 +31,10 @@ SecondsToScanBeforeGivingUp = 30
 ; Default: true
 bUseUObjectArrayCache = true
 
+; Whether to perform a single AOB scan as soon as possible after the game starts.
+; Default: 1
+DoEarlyScan = 1
+
 [EngineVersionOverride]
 MajorVersion = 
 MinorVersion = 


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

If set to `0`, the entire first phase will be skipped, restoring behavior what it was before #985

**How has this been tested?**
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration. -->

Test both values in UE4SS-settings.ini, and make sure the `Phase 1` / `Phase 2` messages in UE4SS.log appear appropriately and that no crash occurs.
