### PR TITLE
fix(Lua): Safer IsValid

### DIFF
--- a/UE4SS/include/LuaType/LuaUObject.hpp
+++ b/UE4SS/include/LuaType/LuaUObject.hpp
@@ -716,8 +716,8 @@ Overloads:
 
             table.add_pair("IsValid", [](const LuaMadeSimple::Lua& lua) -> int {
                 const auto& lua_object = lua.get_userdata<SelfType>();
-                if (lua_object.get_remote_cpp_object() && !lua_object.get_remote_cpp_object()->IsUnreachable() &&
-                    is_object_in_global_unreal_object_map(lua_object.get_remote_cpp_object()))
+                if (lua_object.get_remote_cpp_object() && is_object_in_global_unreal_object_map(lua_object.get_remote_cpp_object()) &&
+                    !lua_object.get_remote_cpp_object()->IsUnreachable())
                 {
                     lua.set_bool(true);
                 }

--- a/UE4SS/src/LuaType/LuaUObject.cpp
+++ b/UE4SS/src/LuaType/LuaUObject.cpp
@@ -49,27 +49,39 @@
 namespace RC::LuaType
 {
     std::unordered_set<size_t> s_lua_unreal_objects{};
+    std::mutex s_lua_unreal_objects_map_mutex{};
 
     auto add_to_global_unreal_objects_map(Unreal::UObject* object) -> void
     {
         if (object)
         {
+            std::lock_guard lock{s_lua_unreal_objects_map_mutex};
             s_lua_unreal_objects.emplace(object->HashObject());
+        }
+    }
+
+    auto remove_from_global_unreal_objects_map(const Unreal::UObject* object) -> void
+    {
+        if (object)
+        {
+            std::lock_guard lock{s_lua_unreal_objects_map_mutex};
+            if (const auto it = s_lua_unreal_objects.find(object->HashObject()); it != s_lua_unreal_objects.end())
+            {
+                s_lua_unreal_objects.erase(it);
+            }
         }
     }
 
     auto is_object_in_global_unreal_object_map(Unreal::UObject* object) -> bool
     {
+        std::lock_guard lock{s_lua_unreal_objects_map_mutex};
         return object && s_lua_unreal_objects.contains(object->HashObject());
     }
 
     FLuaObjectDeleteListener FLuaObjectDeleteListener::s_lua_object_delete_listener{};
     void FLuaObjectDeleteListener::NotifyUObjectDeleted(const Unreal::UObjectBase* object, [[maybe_unused]] int32_t index)
     {
-        if (auto it = s_lua_unreal_objects.find(static_cast<const Unreal::UObject*>(object)->HashObject()); it != s_lua_unreal_objects.end())
-        {
-            s_lua_unreal_objects.erase(it);
-        }
+        remove_from_global_unreal_objects_map(static_cast<const Unreal::UObject*>(object));
     }
 
     auto call_ufunction_from_lua(const LuaMadeSimple::Lua& lua) -> int


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

Using a lock to make the UObjectArray map safer, and we also shouldn't be dereferencing a UObject when checking for validity before we check if that UObect exists in the UObjectArray map.

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

