### PR TITLE
fix(Log): Crash when chrono::current_zone fails

### DIFF
--- a/UE4SS/src/CrashDumper.cpp
+++ b/UE4SS/src/CrashDumper.cpp
@@ -8,6 +8,7 @@
 #include <polyhook2/PE/IatHook.hpp>
 #include <dbghelp.h>
 #include <Helpers/SysError.hpp>
+#include <Helpers/Time.hpp>
 #include <String/StringType.hpp>
 
 namespace fs = std::filesystem;
@@ -25,25 +26,7 @@ namespace RC
 
     LONG WINAPI ExceptionHandler(_EXCEPTION_POINTERS* exception_pointers)
     {
-        StringType dump_path{};
-        bool use_local_time = true;
-#ifdef _WIN32
-        if (auto module = GetModuleHandleW(L"ntdll.dll"); module && GetProcAddress(module, "wine_get_version"))
-        {
-            use_local_time = false;
-        }
-#endif
-        if (use_local_time)
-        {
-            static const auto timezone = std::chrono::current_zone();
-            const auto now = time_point_cast<seconds>(timezone->to_local(system_clock::now()));
-            dump_path = fmt::format(STR("{}\\crash_{:%Y_%m_%d_%H_%M_%S}.dmp"), StringType{UE4SSProgram::get_program().get_working_directory()}, now);
-        }
-        else
-        {
-            const auto now = time_point_cast<seconds>(system_clock::now());
-            dump_path = fmt::format(STR("{}\\crash_{:%Y_%m_%d_%H_%M_%S}.dmp"), StringType{UE4SSProgram::get_program().get_working_directory()}, now);
-        }
+        StringType dump_path = fmt::format(STR("{}\\crash_{}.dmp"), StringType{UE4SSProgram::get_program().get_working_directory()}, get_now_as_string(STR("{:%Y_%m_%d_%H_%M_%S}")));
 
         const HANDLE file =
                 CreateFileW(FromCharTypePtr<wchar_t>(dump_path.c_str()), GENERIC_WRITE, FILE_SHARE_WRITE, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);

--- a/deps/first/DynamicOutput/include/DynamicOutput/OutputDevice.hpp
+++ b/deps/first/DynamicOutput/include/DynamicOutput/OutputDevice.hpp
@@ -68,7 +68,6 @@ namespace RC::Output
         auto set_formatter(Formatter new_formatter) -> void;
 
       protected:
-        auto static get_now_as_string() -> const File::StringType;
         auto static default_format_string(File::StringViewType) -> File::StringType;
     };
 } // namespace RC::Output

--- a/deps/first/DynamicOutput/src/OutputDevice.cpp
+++ b/deps/first/DynamicOutput/src/OutputDevice.cpp
@@ -3,6 +3,7 @@
 #include <fmt/xchar.h>
 #include <fmt/chrono.h>
 #include <DynamicOutput/OutputDevice.hpp>
+#include <Helpers/Time.hpp>
 
 #if _WIN32
 #define NOMINMAX
@@ -31,32 +32,8 @@ namespace RC::Output
         m_formatter = new_formatter;
     }
 
-    auto OutputDevice::get_now_as_string() -> const File::StringType
-    {
-        File::StringType when_as_string{};
-        bool use_local_time = true;
-#ifdef _WIN32
-        if (auto module = GetModuleHandleW(L"ntdll.dll"); module && GetProcAddress(module, "wine_get_version"))
-        {
-            use_local_time = false;
-        }
-#endif
-        if (use_local_time)
-        {
-            static const auto timezone = std::chrono::current_zone();
-            auto now = std::chrono::time_point_cast<std::chrono::system_clock::duration>(timezone->to_local(std::chrono::system_clock::now()));
-            when_as_string = fmt::format(STR("{:%Y-%m-%d %X}"), now);
-        }
-        else
-        {
-            auto now = std::chrono::system_clock::now();
-            when_as_string = fmt::format(STR("{:%Y-%m-%d %X}"), now);
-        }
-        return when_as_string;
-    }
-
     auto OutputDevice::default_format_string(File::StringViewType string_to_format) -> File::StringType
     {
-        return fmt::format(STR("[{}] {}"), get_now_as_string(), string_to_format);
+        return fmt::format(STR("[{}] {}"), get_now_as_string(STR("{:%Y-%m-%d %X}")), string_to_format);
     }
 } // namespace RC::Output

--- a/deps/first/Helpers/CMakeLists.txt
+++ b/deps/first/Helpers/CMakeLists.txt
@@ -7,6 +7,7 @@ option(UE4SS_${TARGET}_BUILD_SHARED "Build as a shared lib" OFF)
 set(${TARGET}_Sources
         "${CMAKE_CURRENT_SOURCE_DIR}/src/Casting.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/SysError.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/Time.cpp"
         )
 
 string(REGEX REPLACE "(.)([A-Z])" "\\1_\\2" MODULE_NAME ${TARGET})
@@ -29,7 +30,7 @@ target_compile_definitions(${TARGET} PRIVATE
             RC_${MODULE_NAME}_BUILD_STATIC>)
 
 target_include_directories(${TARGET} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(${TARGET} PUBLIC String)
+target_link_libraries(${TARGET} PUBLIC String fmt)
 
 # Make headers visible in the IDE
 # Uses make_headers_visible() from cmake/modules/IDEVisibility.cmake

--- a/deps/first/Helpers/include/Helpers/Time.hpp
+++ b/deps/first/Helpers/include/Helpers/Time.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <String/StringType.hpp>
+
+namespace RC
+{
+    auto get_now_as_string(StringViewType format = STR("{:%Y_%m_%d_%H_%M_%S}")) -> StringType;
+} // namespace RC

--- a/deps/first/Helpers/src/Time.cpp
+++ b/deps/first/Helpers/src/Time.cpp
@@ -1,0 +1,53 @@
+#include <chrono>
+
+#include <Helpers/Time.hpp>
+#include <fmt/xchar.h>
+#include <fmt/chrono.h>
+
+#if _WIN32
+#define NOMINMAX
+#include <Windows.h>
+#ifdef TEXT
+#undef TEXT
+#endif
+#endif
+
+#if RC_IS_ANSI == 1
+#define RC_STD_MAKE_FORMAT_ARGS fmt::make_format_args
+#else
+#define RC_STD_MAKE_FORMAT_ARGS fmt::make_format_args<fmt::buffered_context<CharType>>
+#endif
+
+namespace RC
+{
+    auto get_now_as_string(StringViewType format) -> StringType
+    {
+        bool use_local_time = true;
+#ifdef _WIN32
+        if (auto module = GetModuleHandleW(L"ntdll.dll"); module && GetProcAddress(module, "wine_get_version"))
+        {
+            use_local_time = false;
+        }
+#endif
+
+        if (use_local_time)
+        {
+            try
+            {
+                static const auto timezone = std::chrono::current_zone();
+                const auto now = std::chrono::time_point_cast<std::chrono::system_clock::duration>(timezone->to_local(std::chrono::system_clock::now()));
+                return fmt::vformat(fmt::detail::to_string_view(format), RC_STD_MAKE_FORMAT_ARGS(now));
+            }
+            catch (std::runtime_error&)
+            {
+                const auto now = std::chrono::system_clock::now();
+                return fmt::vformat(fmt::detail::to_string_view(format), RC_STD_MAKE_FORMAT_ARGS(now));
+            }
+        }
+        else
+        {
+            const auto now = std::chrono::system_clock::now();
+            return fmt::vformat(fmt::detail::to_string_view(format), RC_STD_MAKE_FORMAT_ARGS(now));
+        }
+    }
+} // namespace RC

--- a/deps/first/Helpers/xmake.lua
+++ b/deps/first/Helpers/xmake.lua
@@ -7,6 +7,7 @@ target(projectName)
     add_rules("ue4ss.dependency")
 
     add_deps("String")
+    add_packages("fmt")
     
     add_includedirs("include", { public = true })
     add_headerfiles("include/**.hpp")


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->


Fixes # (issue) (if applicable)

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

**How has this been tested?**
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration. -->

Doesn't crash when using Wine.
Someone please test non-Wine, and on a system where `chrono::current_zone` fails.

