### PR TITLE
perf(UEHelpers): Fast path for GetPlayerController

### DIFF
--- a/assets/Mods/shared/UEHelpers/UEHelpers.lua
+++ b/assets/Mods/shared/UEHelpers/UEHelpers.lua
@@ -69,6 +69,14 @@ end
 function UEHelpers.GetPlayerController()
     -- local Controllers = jsb.simpleBench("FindAllOf: PlayerController", FindAllOf, "PlayerController")
     -- Controllers = jsb.simpleBench("FindAllOf: Controller", FindAllOf, "Controller")
+    local Players = UEHelpers.GetGameInstance().LocalPlayers
+    if Players:IsValid() and Players:GetArrayNum() >= 1 then
+        local FirstController = Players[1].PlayerController
+        if FirstController:IsValid() and (FirstController.IsPlayerController and FirstController:IsPlayerController() or FirstController:IsLocalPlayerController()) then
+            return FirstController
+        end
+    end
+
     local Controllers = FindAllOf("PlayerController") or FindAllOf("Controller") ---@type AController[]?
     if Controllers then
         for _, Controller in ipairs(Controllers) do


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

It now tries to get the player controller via GameInstance.LocalPlayers[0], and only falls back on the slow FindAllOf method if that fails.

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Other... Please describe: Performance improvement

**How has this been tested?**
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration. -->

The following script was run, followed by jumping in Palworld.
No testing has been performed on any other game, or on any server software.
```lua
RegisterHook("/Script/Engine.Character:CanJumpInternal", function(ContextParam)
    local Controller = UEHelpers.GetPlayerController()
    if Controller:IsValid() then
        print(string.format("Controller: %s\n", Controller:GetFullName()))
    end
end)
```
