### PR TITLE
fix(Lua): NotifyOnNewObject broke from #1054

### DIFF
--- a/UE4SS/src/Mod/LuaMod.cpp
+++ b/UE4SS/src/Mod/LuaMod.cpp
@@ -2255,7 +2255,7 @@ Overloads:
             }
 
             auto mod = get_mod_ref(lua);
-            auto hook_lua = get_hook_lua(mod);
+            auto [hook_lua, thread_ref] = make_hook_state(mod);
 
             // Duplicate the Lua function to the top of the stack for lua_xmove and luaL_ref
             lua_pushvalue(lua.get_lua_state(), 1);
@@ -2263,7 +2263,6 @@ Overloads:
             lua_xmove(lua.get_lua_state(), hook_lua->get_lua_state(), 1);
 
             const auto func_ref = hook_lua->registry().make_ref();
-            const auto thread_ref = mod->lua().registry().make_ref();
 
             Unreal::UClass* instance_of_class = Unreal::UObjectGlobals::StaticFindObject<Unreal::UClass*>(nullptr, nullptr, class_name);
 


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

The PR #1054 broke `NotifyOnNewObject` by consuming a luathread on the stack that used to not be consumed.
This PR fixes this by using the ref already created instead of trying to create a new one.

Fixes # (issue) (if applicable)

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

**How has this been tested?**
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration. -->

Call `NotifyOnNewObject`, verify that it doesn't crash, and that the callback is called.
