### PR TITLE
feat(proxy): add --ue4ss-path command line/launch arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,12 @@ If your game is in the custom config list, extract the contents from the relevan
 
 If you are planning on doing mod development using UE4SS, you can do the same as above but download the zDEV version instead.
 
-### Disabling UE4SS Temporarily
+### Command Line Options
 
-If RE-UE4SS is installed via proxy DLL, you can temporarily disable it without uninstalling by launching the game with the `--disable-ue4ss` command line argument. 
+If RE-UE4SS is installed via proxy DLL, the following command line options are available:
+
+- `--disable-ue4ss` - Temporarily disable UE4SS without uninstalling by launching the game with this argument.
+- `--ue4ss-path <path>` - Specify a custom path to UE4SS.dll. Supports both absolute paths (e.g., `C:\custom\UE4SS.dll`) and relative paths (e.g., `dev\builds\UE4SS.dll` relative to the game executable directory). Useful for testing different UE4SS builds without modifying installation files. 
 
 ## Links
 

--- a/UE4SS/proxy_generator/main.cpp
+++ b/UE4SS/proxy_generator/main.cpp
@@ -282,6 +282,30 @@ int _tmain(int argc, TCHAR* argv[])
     cpp_file << "}" << endl;
     cpp_file << endl;
 
+    cpp_file << "std::wstring get_ue4ss_path_from_args()" << endl;
+    cpp_file << "{" << endl;
+    cpp_file << "    int argc = 0;" << endl;
+    cpp_file << "    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);" << endl;
+    cpp_file << "    if (!argv)" << endl;
+    cpp_file << "    {" << endl;
+    cpp_file << "        return L\"\";" << endl;
+    cpp_file << "    }" << endl;
+    cpp_file << endl;
+    cpp_file << "    std::wstring ue4ss_path;" << endl;
+    cpp_file << "    for (int i = 0; i < argc - 1; i++)" << endl;
+    cpp_file << "    {" << endl;
+    cpp_file << "        if (wcscmp(argv[i], L\"--ue4ss-path\") == 0)" << endl;
+    cpp_file << "        {" << endl;
+    cpp_file << "            ue4ss_path = argv[i + 1];" << endl;
+    cpp_file << "            break;" << endl;
+    cpp_file << "        }" << endl;
+    cpp_file << "    }" << endl;
+    cpp_file << endl;
+    cpp_file << "    LocalFree(argv);" << endl;
+    cpp_file << "    return ue4ss_path;" << endl;
+    cpp_file << "}" << endl;
+    cpp_file << endl;
+
     cpp_file << "HMODULE load_ue4ss_dll(HMODULE moduleHandle)" << endl;
     cpp_file << "{" << endl;
     cpp_file << "    HMODULE hModule = nullptr;" << endl;
@@ -289,6 +313,25 @@ int _tmain(int argc, TCHAR* argv[])
     cpp_file << "    GetModuleFileNameW(moduleHandle, moduleFilenameBuffer, sizeof(moduleFilenameBuffer) / sizeof(wchar_t));" << endl;
     cpp_file << "    const auto currentPath = std::filesystem::path(moduleFilenameBuffer).parent_path();" << endl;
     cpp_file << "    const fs::path ue4ssPath = currentPath / \"ue4ss\" / \"UE4SS.dll\";" << endl;
+    cpp_file << endl;
+
+    cpp_file << "    // Check for --ue4ss-path command line argument" << endl;
+    cpp_file << "    std::wstring cmdLineUe4ssPath = get_ue4ss_path_from_args();" << endl;
+    cpp_file << "    if (!cmdLineUe4ssPath.empty())" << endl;
+    cpp_file << "    {" << endl;
+    cpp_file << "        fs::path ue4ssArgPath = cmdLineUe4ssPath;" << endl;
+    cpp_file << "        if (!ue4ssArgPath.is_absolute())" << endl;
+    cpp_file << "        {" << endl;
+    cpp_file << "            ue4ssArgPath = currentPath / ue4ssArgPath;" << endl;
+    cpp_file << "        }" << endl;
+    cpp_file << endl;
+    cpp_file << "        // Attempt to load UE4SS.dll from the command line path" << endl;
+    cpp_file << "        hModule = LoadLibrary(ue4ssArgPath.c_str());" << endl;
+    cpp_file << "        if (hModule)" << endl;
+    cpp_file << "        {" << endl;
+    cpp_file << "            return hModule;" << endl;
+    cpp_file << "        }" << endl;
+    cpp_file << "    }" << endl;
     cpp_file << endl;
 
     cpp_file << "    // Check for override.txt" << endl;

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -22,6 +22,8 @@ Added basic support for Development/Debug/Test built Unreal Engine games ([UE4SS
 
 Added command line option to disable RE-UE4SS loading via proxy DLL. Use `--disable-ue4ss` to launch game without UE4SS while keeping the proxy DLL installed. ([UE4SS #1069](https://github.com/UE4SS-RE/RE-UE4SS/pull/1069))
 
+Added command line option to specify custom UE4SS.dll path via proxy DLL. Use `--ue4ss-path <path>` to load UE4SS.dll from a custom location, supporting both absolute and relative paths. This allows developers to easily test different UE4SS builds without modifying files. ([UE4SS #1074](https://github.com/UE4SS-RE/RE-UE4SS/pull/1074))
+
 Added new build definition "LessEqual421".  Using this definition for games on UE<=4.21 is not mandatory for UE4SS to function, but will ensure the correct alignment is used in containers. 
 
 **BREAKING:** - This also changes the default FName alignment from 8 to 4. 

--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -64,6 +64,33 @@ For example, possible paths could be:
 - `C:/ue4ss/`
 - `../../Content/Paks`
 
+### Command Line Path Override
+
+You can also specify a custom path to `UE4SS.dll` via a command line argument. This takes priority over the `override.txt` file.
+
+Use the `--ue4ss-path` argument when launching your game:
+
+```
+game.exe --ue4ss-path "C:\custom\path\to\UE4SS.dll"
+```
+
+Both absolute and relative paths are supported. Relative paths are resolved from the `game executable directory`:
+
+```
+game.exe --ue4ss-path "dev\builds\UE4SS.dll"
+```
+
+This is particularly useful for:
+- Developers testing different UE4SS builds without modifying files
+- Quick switching between UE4SS versions
+- Automated testing with different configurations
+
+**Load Priority Order:**
+1. `--ue4ss-path` command line argument (highest priority)
+2. `override.txt` file
+3. `<game executable directory>/ue4ss/UE4SS.dll`
+4. `<game executable directory>/UE4SS.dll` (lowest priority)
+
 ## Manual Injection
 
 > Using manual injection will mean that the `root directory` and `working directory` are treated as one single directory that happens to also be the same directory as your `game executable directory`, but any directory may be used.


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->
This PR adds a new command line option `--ue4ss-path <path>` to the proxy generator, allowing users to specify a custom path to `UE4SS.dll` when launching games. This complements the existing `--disable-ue4ss` option and provides developers with flexible control over which UE4SS build to load.

Fixes # (issue) (if applicable)

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Is/requires documentation update

**How has this been tested?**
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration. -->
Launches from different directories as expected.

**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.


**Screenshots**
<!--Add screenshots to help explain your PR, if applicable.-->


**Additional context**
<!-- Add any other context about the pull request here. -->

