### PR TITLE
Fix possible alteration of folder names in IterateGameDirectories

### DIFF
--- a/UE4SS/src/Mod/LuaMod.cpp
+++ b/UE4SS/src/Mod/LuaMod.cpp
@@ -2801,10 +2801,10 @@ Overloads:
 
                             // Set metadata using safe string conversion
                             // TODO: When UE5 String conversion is implemented, replace with StringCast<ANSICHAR>
-                            std::string safe_stem = to_utf8_string(directory.stem());
+                            std::string safe_filename = to_utf8_string(directory.filename());
                             std::string safe_path = to_utf8_string(directory);
 
-                            meta_table.add_pair("__name", safe_stem.c_str());
+                            meta_table.add_pair("__name", safe_filename.c_str());
                             meta_table.add_pair("__absolute_path", safe_path.c_str());
                             lua_setmetatable(lua.get_lua_state(), -2);
                         }


### PR DESCRIPTION
**Description**
``IterateGameDirectories`` currently uses the ``stem()`` method on the retrieved folder path, which causes folder names to be incorrectly stripped of "extensions".
Example: Voyage.rep becomes Voyage


**Type of change**
This PR replaces the usage of ``stem()`` with ``filename()``, which provides the unaltered folder name.

- [x] Bug fix (non-breaking change which fixes an issue)

**How has this been tested?**
The retrieved name of the folder is now unchanged.

