### PR TITLE
Don't add default mod directory path if overridden in config

### DIFF
--- a/UE4SS/src/UE4SSProgram.cpp
+++ b/UE4SS/src/UE4SSProgram.cpp
@@ -497,6 +497,9 @@ namespace RC
 
     auto UE4SSProgram::setup_mod_directory_path() -> void
     {
+        // don't add a new path if we already specified one in the config
+        if (m_mods_directories.size() > 0) return;
+
         std::filesystem::path default_mods_path = m_working_directory / "Mods";
 
         // If no paths were added, check legacy location for fallback


### PR DESCRIPTION
**Description**
I recently noted a bug where, on the latest commit on the "main" branch, the default mod directory path is always added to the list of mod directories, even when the mod directory path overridden in the config using the ModsFolderPath setting. Because it seems to me that the last mod directory is used to read the mods.txt file (?), this means that it is simply not possible to completely override the default Mods directory. It is also not possible to simply remove the default path within the config file, because it is added to the list after the settings file is already parsed. This PR simply modifies the UE4SSProgram::setup_mod_directory_path method to avoid adding the new path altogether when an overridden path is present.

**Type of change**
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Is/requires documentation update
- [ ] Other... Please describe:

**How has this been tested?**
You can experimentally verify the bug by moving the local Mods directory to a new location, and overriding the ModsFolderPath to that new location. You should observe that the default Mods directory is still added to the list, and no mods load properly. I tested this on the latest commit on the "main" branch (c4b5add).

With this fix, by default, I observed that behavior is unchanged (the only Mods directory is the default, and mods do load properly from that directory). When the ModsFolderPath setting is changed, I observed that only one Mods directory is logged, which is the new directory that was specified in the config file. Mods seem to load as expected.

**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.

I have not updated the changelog because this bug was not present in version v3.0.1. It is a regression.

**Screenshots**
Current behavior is depicted below with ModsFolderPath overridden to a new path. Both paths are read, and UE4SS fails to recognize the existence of "mods.txt" in the overridden path.
<img width="719" height="71" alt="image" src="https://github.com/user-attachments/assets/b617e0f1-1247-4923-b9d2-84573e3bf4d8" />

New behavior is depicted below (overridden)
<img width="661" height="115" alt="image" src="https://github.com/user-attachments/assets/65712916-043c-481c-823f-c103d75eeb98" />
(default/not overridden; note that my Mods directory does not exist in this test, so this operates exactly as expected)
<img width="839" height="86" alt="image" src="https://github.com/user-attachments/assets/2e978468-5d03-47af-be00-16fa7849f358" />

**Additional context**
I want to note that this is not the first time that this feature has been essentially completely broken from a bug that went completely unnoticed. More rigorous testing is definitely necessary moving forward to avoid breaking this feature again.
