### PR TITLE
fix: Prevent Function::m_is_ready from being true if the function is in fact not ready

### DIFF
--- a/deps/first/Function/include/Function/Function.hpp
+++ b/deps/first/Function/include/Function/Function.hpp
@@ -47,7 +47,7 @@ namespace RC
             m_active_func = func_ptr;
             m_function_address = std::bit_cast<void*>(func_ptr);
             m_stored_original_func = m_active_func;
-            m_is_ready = true;
+            m_is_ready = m_function_address;
         }
 
         // Assign a void* to this Function object as the function address
@@ -57,7 +57,7 @@ namespace RC
             m_active_func = std::bit_cast<FunctionSignature>(func_address);
             m_stored_original_func = m_active_func;
             m_function_address = func_address;
-            m_is_ready = true;
+            m_is_ready = func_address;
         }
 
         // Assign a new function pointer (same type) to this Function object and store the old one
@@ -65,7 +65,7 @@ namespace RC
         {
             m_active_func = func_ptr;
             m_function_address = std::bit_cast<void*>(func_ptr);
-            m_is_ready = true;
+            m_is_ready = m_function_address;
         }
 
         // Assign a new void* to this Function object and store the old function pointer
@@ -78,7 +78,7 @@ namespace RC
             }
             m_active_func = std::bit_cast<FunctionSignature>(address);
             m_function_address = address;
-            m_is_ready = true;
+            m_is_ready = address;
         }
 
         // Reset the function pointer back to the original one


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

I noticed StaticConstructObject was causing an assertion when UE4SS is compiled in debug mode.
This was because my override didn't work correctly, leaving SCO as nullptr, but previously assigning nullptr to a `Function` didn't set the function as unready.

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)