### PR TITLE
fix(BPModLoaderMod): Fixed config.lua not being able to access the 'Mods' variable to apply the custom config

### DIFF
--- a/assets/Mods/BPModLoaderMod/Scripts/main.lua
+++ b/assets/Mods/BPModLoaderMod/Scripts/main.lua
@@ -10,7 +10,7 @@ end
 package.path = '.\\Mods\\ModLoaderMod\\?.lua;' .. package.path
 package.path = '.\\Mods\\ModLoaderMod\\BPMods\\?.lua;' .. package.path
 
-local Mods = {}
+Mods = {}
 local OrderedMods = {}
 
 -- Contains mod names from Mods/BPModLoaderMod/load_order.txt and is used to determine the load order of BP mods.


### PR DESCRIPTION
I haven't tested this, this change is fully reliant on the testing done in #1107