### PR TITLE
fix: Dead GMalloc pointer

### DIFF
--- a/UE4SS/src/Signatures.cpp
+++ b/UE4SS/src/Signatures.cpp
@@ -221,8 +221,7 @@ namespace RC
                         signature_containers,
                         [](void* address) {
                             Output::send(STR("GMalloc address: {} <- Lua Script\n"), address);
-                            Unreal::FMalloc::UnrealStaticGMalloc = static_cast<Unreal::FMalloc**>(address);
-                            Unreal::GMalloc = *Unreal::FMalloc::UnrealStaticGMalloc;
+                            Unreal::GMalloc = static_cast<Unreal::FMalloc**>(address);
                             return DidLuaScanSucceed::Yes;
                         },
                         [&](DidLuaScanSucceed did_lua_scan_succeed) {
@@ -268,6 +267,11 @@ namespace RC
                         lua_ftc_scan_script,
                         signature_containers,
                         [&scan_result](void* address) {
+                            if (!Unreal::GMalloc || !*Unreal::GMalloc)
+                            {
+                                    scan_result.Errors.emplace_back("Lua script 'FText_Constructor.lua' cannot be tried; GMalloc nullptr.");
+                                    return DidLuaScanSucceed::No;
+                            }
                             Unreal::FText text{};
                             SEH_TRY({ text = Unreal::FText(STR("bCanBeDamaged"), address); })
                             SEH_EXCEPT({ Output::send<LogLevel::Error>(STR("Error: Crashed calling FText constructor.\n")); });


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any 
dependencies that are required for this change. -->

This happened if the GMalloc scan finished so quickly that UE hadn't yet initialized it, leaving us with a pointer to a nullptr value.

Fixed by replacing 'UnrealStaticGMalloc' with 'GMalloc', and dereferencing GMalloc when access is needed.

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [ ] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
- [ ] Any dependent changes have been merged and published in downstream modules.

**Screenshots**
<!--Add screenshots to help explain your PR, if applicable.-->


**Additional context**
<!-- Add any other context about the pull request here. -->

Needs this PR to be merged: https://github.com/Re-UE4SS/UEPseudo/pull/164