### PR TITLE
feat: Export find_mod_by_name to C++ mods and add on_cpp_mods_loaded

### DIFF
--- a/UE4SS/include/Mod/CppMod.hpp
+++ b/UE4SS/include/Mod/CppMod.hpp
@@ -63,5 +63,6 @@ namespace RC
         auto fire_program_start() -> void override;
         auto fire_update() -> void override;
         auto fire_dll_load(StringViewType dll_name) -> void;
+        auto fire_on_cpp_mods_loaded() -> void;
     };
 } // namespace RC

--- a/UE4SS/include/Mod/CppUserModBase.hpp
+++ b/UE4SS/include/Mod/CppUserModBase.hpp
@@ -201,6 +201,13 @@ namespace RC
         {
         }
 
+        /**
+         * Executes after every C++ mod has been loaded.
+         */
+        RC_UE4SS_API virtual auto on_cpp_mods_loaded() -> void
+        {
+        }
+
       protected:
         RC_UE4SS_API auto register_tab(StringViewType tab_name, GUI::GUITab::RenderFunctionType) -> void;
         RC_UE4SS_API auto register_keydown_event(Input::Key, const Input::EventCallbackCallable&, uint8_t custom_data = 0) -> void;

--- a/UE4SS/include/UE4SSProgram.hpp
+++ b/UE4SS/include/UE4SSProgram.hpp
@@ -217,6 +217,7 @@ namespace RC
         auto fire_ui_init_for_cpp_mods() -> void;
         auto fire_program_start_for_cpp_mods() -> void;
         auto fire_dll_load_for_cpp_mods(StringViewType dll_name) -> void;
+        auto fire_on_cpp_mods_loaded_for_cpp_mods() -> void;
 
       public:
         auto init() -> void;

--- a/UE4SS/src/Mod/CppMod.cpp
+++ b/UE4SS/src/Mod/CppMod.cpp
@@ -200,6 +200,14 @@ namespace RC
         }
     }
 
+    auto CppMod::fire_on_cpp_mods_loaded() -> void
+    {
+        if (m_mod)
+        {
+            m_mod->on_cpp_mods_loaded();
+        }
+    }
+
     CppMod::~CppMod()
     {
         if (m_main_dll_module)

--- a/UE4SS/src/UE4SSProgram.cpp
+++ b/UE4SS/src/UE4SSProgram.cpp
@@ -1315,6 +1315,17 @@ namespace RC
         }
     }
 
+    auto UE4SSProgram::fire_on_cpp_mods_loaded_for_cpp_mods() -> void
+    {
+        for (const auto& mod : m_mods)
+        {
+            if (auto cpp_mod = dynamic_cast<CppMod*>(mod.get()); cpp_mod)
+            {
+                cpp_mod->fire_on_cpp_mods_loaded();
+            }
+        }
+    }
+
     template <typename ModType>
     auto start_mods() -> std::string
     {
@@ -1509,6 +1520,7 @@ namespace RC
         {
             fire_ui_init_for_cpp_mods();
         }
+        fire_on_cpp_mods_loaded_for_cpp_mods();
     }
 
     auto UE4SSProgram::uninstall_mods() -> void


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

Previously, there wasn't a good way for C++ mods to find other mods by name.
This PR fixes that, and this will likely be the best way to retrieve any other mods full path, if that is something that a mod deems necessary.

This PR also adds `CppUserModBase::on_cpp_mods_loaded`, which fires whenever all C++ mods have been loaded.
Useful for keeping any symbols loaded (via `GetProcAddress`/`dlsym`) up-to-date.