### PR TITLE
fix(BPModLoaderMod): Explicitly use ProcessEvent instead of UEngine::Tick

### DIFF
--- a/assets/Mods/BPModLoaderMod/Scripts/main.lua
+++ b/assets/Mods/BPModLoaderMod/Scripts/main.lua
@@ -298,4 +298,4 @@ ExecuteInGameThread(function()
     if ExistingActor:IsValid() then
         LoadMods(ExistingActor:GetWorld())
     end
-end)
+end, EGameThreadMethod.ProcessEvent)


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

There's some odd bug where under certain circumstances, a BP mod adding a widget to the viewport can cause a crash when UEngine::Tick is used.

The ProcessEvent hook doesn't have this problem, so we will explicitly use it for now until (if ever) we figure out how to fix or otherwise circumvent the bug.

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
