### PR TITLE
fix: SHf add ClassCastFlags

### DIFF
--- a/assets/CustomGameConfigs/Silent Hill F/MemberVariableLayout.ini
+++ b/assets/CustomGameConfigs/Silent Hill F/MemberVariableLayout.ini
@@ -15,6 +15,7 @@ ClassConfigName = 0xD8
 ClassConstructor = 0xA0
 ClassDefaultObject = 0x100
 ClassFlags = 0xC4
+ClassCastFlags = 0xC8
 ClassUnique = 0xB8
 ClassVTableHelperCtorCaller = 0xA8
 ClassWithin = 0xD0
@@ -222,9 +223,9 @@ MetaClass = 0x78
 PropertyClass = 0x70
 
 [UScriptStruct]
-CppStructOps = 0xB8
-StructFlags = 0xB0
-bPrepareCppStructOpsCompleted = 0xB4
+CppStructOps = 0xA8
+StructFlags = 0xA0
+bPrepareCppStructOpsCompleted = 0xA4
 
 [UScriptStruct::ICppStructOps]
 Alignment = 0xC


### PR DESCRIPTION
**Description**
In December, UE4SS introduced methods using ClassCastFlags which was not previously implemented. Existing mods with MemberVariableLayout.ini will not work unless they are updated.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How has this been tested?**
Tested my mod for SHf, previously failed to call KismetSystemLibrary functions


**Additional context**
I am uncertain why my local had changes to UScriptStruct, but it is what all of my users have been using for some time.

