### PR TITLE
fix: JediSurvivor add ClassCastFlags, set ProcessEvent in settings

### DIFF
--- a/assets/CustomGameConfigs/Star Wars Jedi Survivor/MemberVariableLayout.ini
+++ b/assets/CustomGameConfigs/Star Wars Jedi Survivor/MemberVariableLayout.ini
@@ -146,6 +146,7 @@ ClassConfigName = 0xF0
 ClassConstructor = 0xB0
 ClassDefaultObject = 0x120
 ClassFlags = 0xD0
+ClassCastFlags = 0xD8
 ClassGeneratedBy = 0xE8
 ClassUnique = 0xC8
 ClassVTableHelperCtorCaller = 0xB8

--- a/assets/CustomGameConfigs/Star Wars Jedi Survivor/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Star Wars Jedi Survivor/UE4SS-settings.ini
@@ -31,35 +31,44 @@ EnableHotReloadSystem = 0
 ; Default: R
 HotReloadKey = R
 
+; Whether the cache system for AOBs will be used.
+; Default: 1
+UseCache = 1
+
 ; Whether caches will be invalidated if ue4ss.dll has changed
 ; Default: 1
 InvalidateCacheIfDLLDiffers = 1
 
-; The maximum number attempts the scanner will try before erroring out if an aob isn't found
-; Default: 60
-MaxScanAttemptsNormal = 60
-
-; The maximum number attempts the scanner will try for modular games before erroring out if an aob isn't found
-; Default: 2000
-MaxScanAttemptsModular = 2500
+; The number of seconds the scanner will scan for before giving up
+; Default: 30
+SecondsToScanBeforeGivingUp = 30
 
 ; Whether to create UObject listeners in GUObjectArray to create a fast cache for use instead of iterating GUObjectArray.
 ; Setting this to false can help if you're experiencing a crash on startup.
 ; Default: true
-bUseUObjectArrayCache = true
+bUseUObjectArrayCache = false
 
 ; Whether to perform a single AOB scan as soon as possible after the game starts.
 ; Default: 0
 DoEarlyScan = 0
 
+; When the search query in the Live View tab is a hex number, try to find the UObject that contains that memory address.
+; Default: false
+bEnableSeachByMemoryAddress = false
+
 ; The default execution method for ExecuteInGameThread Lua function.
 ; Valid values (case-insensitive): EngineTick, ProcessEvent
+; EngineTick: Execute once per engine tick (once per frame, more predictable timing)
+; ProcessEvent: Execute on next ProcessEvent call (more frequent, lower latency)
 ; Default: EngineTick
-DefaultExecuteInGameThreadMethod = EngineTick
+DefaultExecuteInGameThreadMethod = ProcessEvent
 
 [EngineVersionOverride]
 MajorVersion = 4
 MinorVersion = 26
+; True if the game is built as Debug, Development, or Test.
+; Default: false
+DebugBuild = 
 
 [ObjectDumper]
 ; Whether to force all assets to be loaded before dumping objects
@@ -97,8 +106,8 @@ LoadAllAssetsBeforeGeneratingCXXHeaders = 0
 IgnoreAllCoreEngineModules = 0
 
 ; Whether to skip generating the "Engine" and "CoreUObject" packages
-; Default: 1
-IgnoreEngineAndCoreUObject = 1
+; Default: 0
+IgnoreEngineAndCoreUObject = 0
 
 ; Whether to force all UFUNCTION macros to have "BlueprintCallable"
 ; Note: This will cause some errors in the generated headers that you will need to manually fix
@@ -123,7 +132,7 @@ MakeAllConfigsEngineConfig = 1
 [Debug]
 ; Whether to enable the external UE4SS debug console.
 ConsoleEnabled = 0
-GuiConsoleEnabled = 1
+GuiConsoleEnabled = 0
 GuiConsoleVisible = 0
 
 ; Multiplier for Font Size within the Debug Gui
@@ -135,11 +144,13 @@ GuiConsoleFontScaling = 1
 ; Default: opengl
 GraphicsAPI = opengl
 
-; How many objects to put in each group in the live view.
-; A lower number means more groups but less lag when a group is open.
-; A higher number means less groups but more lag when a group is open.
-; Default: 32768
-LiveViewObjectsPerGroup = 32768
+; The method with which the GUI will be rendered.
+; Valid values (case-insensitive):
+; ExternalThread: A separate thread will be used.
+; EngineTick: The UEngine::Tick function will be used.
+; GameViewportClientTick: The UGameViewportClient::Tick function will be used.
+; Default: ExternalThread
+RenderMode = ExternalThread
 
 [Threads]
 ; The number of threads that the sig scanner will use (not real cpu threads, can be over your physical & hyperthreading max)
@@ -160,7 +171,7 @@ SigScannerMultithreadingModuleSizeThreshold = 16777216
 ; The maximum memory usage (in percentage, see Task Manager %) allowed before asset loading (when LoadAllAssetsBefore* is 1) cannot happen.
 ; Once this percentage is reached, the asset loader will stop loading and whatever operation was in progress (object dump, or cxx generator) will continue.
 ; Default: 85
-MaxMemoryUsageDuringAssetLoading = 85
+MaxMemoryUsageDuringAssetLoading = 80
 
 [Hooks]
 HookProcessInternal = 1
@@ -173,9 +184,20 @@ HookEndPlay  = 1
 HookLocalPlayerExec = 1
 HookAActorTick = 1
 HookEngineTick = 1
+; Method for resolving GameEngine::Tick address
+; Valid values (case-insensitive): Scan, VTable
+; Scan: Use PatternSleuth AOB scan (fallback to VTable if scan fails)
+; VTable: Use vtable lookup (fallback to Scan if vtable lookup fails)
+; Default: Scan
 EngineTickResolveMethod = Scan
 HookGameViewportClientTick = 1
 HookUObjectProcessEvent = 1
 HookProcessConsoleExec = 1
 HookUStructLink = 1
 FExecVTableOffsetInLocalPlayer = 0x28
+
+[CrashDump]
+EnableDumping = 1
+FullMemoryDump = 0
+
+[ExperimentalFeatures]


### PR DESCRIPTION
**Description**
In December, UE4SS introduced methods using ClassCastFlags which was not previously implemented. Existing mods with MemberVariableLayout.ini will not work unless they are updated.

This game also hung on ExecuteInGameThread calls using the current UE4SS GameThread methods.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How has this been tested?**
Tested my mod for Jedi Survivor, previously failed to call KismetSystemLibrary functions and hung on game thread calls.


