### PR TITLE
fix(Lua): LocalUnrealParam and RemoteUnrealParam no longer tries to handle unregistered indexing

### DIFF
--- a/UE4SS/include/LuaType/LuaUObject.hpp
+++ b/UE4SS/include/LuaType/LuaUObject.hpp
@@ -834,15 +834,6 @@ Overloads:
       private:
         auto static setup_metamethods(LuaMadeSimple::Type::BaseObject& base_object) -> void
         {
-            base_object.get_metamethods().create(LuaMadeSimple::Lua::MetaMethod::Index, [](const LuaMadeSimple::Lua& lua) -> int {
-                prepare_to_handle(Operation::Get, lua);
-                return 1;
-            });
-
-            base_object.get_metamethods().create(LuaMadeSimple::Lua::MetaMethod::NewIndex, [](const LuaMadeSimple::Lua& lua) -> int {
-                prepare_to_handle(Operation::Set, lua);
-                return 0;
-            });
         }
 
         auto static setup_member_functions(LuaMadeSimple::Lua::Table& table) -> void

--- a/UE4SS/src/LuaType/LuaUObject.cpp
+++ b/UE4SS/src/LuaType/LuaUObject.cpp
@@ -2253,15 +2253,6 @@ Overloads:
 
     auto RemoteUnrealParam::setup_metamethods(BaseObject& base_object) -> void
     {
-        base_object.get_metamethods().create(LuaMadeSimple::Lua::MetaMethod::Index, [](const LuaMadeSimple::Lua& lua) -> int {
-            prepare_to_handle(Operation::Get, lua);
-            return 1;
-        });
-
-        base_object.get_metamethods().create(LuaMadeSimple::Lua::MetaMethod::NewIndex, [](const LuaMadeSimple::Lua& lua) -> int {
-            prepare_to_handle(Operation::Set, lua);
-            return 0;
-        });
     }
 
     auto RemoteUnrealParam::setup_member_functions(LuaMadeSimple::Lua::Table& table) -> void

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -346,6 +346,8 @@ Improved performance of script hooks created with `RegisterHook`, and
 
 Types with `get` or `Get` functions now have both variants. ([UE4SS #877](https://github.com/UE4SS-RE/RE-UE4SS/pull/877))
 
+Improved error messages when improperly indexing into `LocalUnrealParam`, and `RemoteUnrealParam` without first calling `Get`. ([UE4SS #1154](https://github.com/UE4SS-RE/RE-UE4SS/pull/1154))
+
 #### UEHelpers [UE4SS #650](https://github.com/UE4SS-RE/RE-UE4SS/pull/650) 
 - Increased version to 3
   


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

Previously, it wouldn't distinguish between Get/Set, and any random indexing operation, often triggering Lua pushers, which themselves would generate a very confusing error message.

This commit removes the Index and NewIndex metamethods from these types, which means Lua will give a standard error when improperly indexing into them without first calling `Get`, for example: `attempt to call a RemoteUnrealParam value (method 'GetFullName')`

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

**How has this been tested?**
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration. -->


**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.

**Screenshots**
<!--Add screenshots to help explain your PR, if applicable.-->


**Additional context**
<!-- Add any other context about the pull request here. -->

