### PR TITLE
fix(Lua): UFunction and UClass properly inherit from UStruct

### DIFF
--- a/UE4SS/include/LuaType/LuaUClass.hpp
+++ b/UE4SS/include/LuaType/LuaUClass.hpp
@@ -20,9 +20,6 @@ namespace RC::LuaType
     };
     class UClass : public UObjectBase<Unreal::UClass, UClassName>
     {
-      public:
-        using Super = LuaType::UStruct;
-
       private:
         explicit UClass(Unreal::UClass* object);
 

--- a/UE4SS/include/LuaType/LuaUFunction.hpp
+++ b/UE4SS/include/LuaType/LuaUFunction.hpp
@@ -4,6 +4,7 @@
 
 #include <LuaMadeSimple/LuaMadeSimple.hpp>
 #include <LuaType/LuaUObject.hpp>
+#include <LuaType/LuaUStruct.hpp>
 
 namespace RC::Unreal
 {

--- a/UE4SS/src/LuaType/LuaUClass.cpp
+++ b/UE4SS/src/LuaType/LuaUClass.cpp
@@ -21,7 +21,7 @@ namespace RC::LuaType
         if (lua.is_nil(-1))
         {
             lua.discard_value(-1);
-            LuaType::UObject::construct(lua, lua_object);
+            LuaType::UStruct::construct(lua, lua_object);
             setup_metamethods(lua_object);
             setup_member_functions<LuaMadeSimple::Type::IsFinal::Yes>(table);
             lua.new_metatable<LuaType::UClass>(metatable_name, lua_object.get_metamethods());
@@ -35,7 +35,7 @@ namespace RC::LuaType
 
     auto UClass::construct(const LuaMadeSimple::Lua& lua, BaseObject& construct_to) -> const LuaMadeSimple::Lua::Table
     {
-        LuaMadeSimple::Lua::Table table = UObject::construct(lua, construct_to);
+        LuaMadeSimple::Lua::Table table = UStruct::construct(lua, construct_to);
 
         setup_member_functions<LuaMadeSimple::Type::IsFinal::No>(table);
 
@@ -52,8 +52,6 @@ namespace RC::LuaType
     template <LuaMadeSimple::Type::IsFinal is_final>
     auto UClass::setup_member_functions(const LuaMadeSimple::Lua::Table& table) -> void
     {
-        Super::setup_member_functions<LuaMadeSimple::Type::IsFinal::No>(table);
-
         // CDO = ClassDefaultObject
         table.add_pair("GetCDO", [](const LuaMadeSimple::Lua& lua) -> int {
             const auto& lua_object = lua.get_userdata<UClass>();

--- a/UE4SS/src/LuaType/LuaUFunction.cpp
+++ b/UE4SS/src/LuaType/LuaUFunction.cpp
@@ -42,7 +42,7 @@ namespace RC::LuaType
         if (lua.is_nil(-1))
         {
             lua.discard_value(-1);
-            LuaType::UObject::construct(lua, lua_object);
+            LuaType::UStruct::construct(lua, lua_object);
             setup_metamethods(lua_object);
             setup_member_functions<LuaMadeSimple::Type::IsFinal::Yes>(table);
             lua.new_metatable<LuaType::UFunction>(metatable_name, lua_object.get_metamethods());
@@ -56,7 +56,7 @@ namespace RC::LuaType
 
     auto UFunction::construct(const LuaMadeSimple::Lua& lua, BaseObject& construct_to) -> const LuaMadeSimple::Lua::Table
     {
-        LuaMadeSimple::Lua::Table table = UObject::construct(lua, construct_to);
+        LuaMadeSimple::Lua::Table table = UStruct::construct(lua, construct_to);
 
         setup_member_functions<LuaMadeSimple::Type::IsFinal::No>(table);
 

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -348,6 +348,9 @@ Types with `get` or `Get` functions now have both variants. ([UE4SS #877](https:
 
 Improved error messages when improperly indexing into `LocalUnrealParam`, and `RemoteUnrealParam` without first calling `Get`. ([UE4SS #1154](https://github.com/UE4SS-RE/RE-UE4SS/pull/1154))
 
+Fixed UFunction and UClass properly inheriting from UStruct in Lua. ([UE4SS #1154](https://github.com/UE4SS-RE/RE-UE4SS/pull/1158))
+Corporalwill123
+
 #### UEHelpers [UE4SS #650](https://github.com/UE4SS-RE/RE-UE4SS/pull/650) 
 - Increased version to 3
   

--- a/docs/lua-api/classes/ufunction.md
+++ b/docs/lua-api/classes/ufunction.md
@@ -1,7 +1,7 @@
 # UFunction
 
 ## Inheritance
-[UObject](./uobject.md)
+[UStruct](./ustruct.md)
 
 ## Metamethods
 


### PR DESCRIPTION
**Description**

UFunction was only inheriting from UObject instead of from UStruct, so now it does. UClass is slightly different, since instead of constructing from UStruct, it setup the member functions directly, so I updated it to be more consistent.

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How has this been tested?**

Using this script that is supposed to find any classes or functions that use a given struct and print them to the console.
```lua
function RecursivePropertyFindStruct(property, scriptStruct)
   if (not scriptStruct:IsValid()) then print("ScriptStruct invalid") end
   if (property:IsA(PropertyTypes.ArrayProperty)) then
      return RecursivePropertyFindStruct(property:GetInner(), scriptStruct)
   elseif (property:IsA(PropertyTypes.StructProperty)) then
      if (property:GetStruct():GetAddress() == scriptStruct:GetAddress()) then
         return true
      end
      local found = false
      property:GetStruct():ForEachProperty( function(innerProperty)
         if (RecursivePropertyFindStruct(innerProperty, scriptStruct)) then
            found = true
            return true
         end
      end)
      return found
   end
   return false
end

RegisterKeyBind(Key.O, function()
   ExecuteInGameThread( function()
      local searchingStruct = StaticFindObject("/Path/To.Struct") -- give the path to the struct here
      if (not searchingStruct:IsValid()) then print("Couldn't find struct") return end
      local foundObjects = {}
      ForEachUObject( function (object)
         if (not object:IsValid() or not (object:IsClass() or object:IsA("/Script/CoreUObject.Function"))) then return end
         object:ForEachProperty(function(property)
            if (RecursivePropertyFindStruct(property, searchingStruct)) then
               table.insert(foundObjects,object)
               return true
            end
         end)
      end)
      print("found " .. #foundObjects .. " objects that use " .. searchingStruct:GetFullName())
      for _, object in ipairs(foundObjects) do
         print(object:GetFullName())
      end
   end)
end)
```
**Checklist**
- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.