### PR TITLE
feat(Lua): add StructProperty support to RegisterCustomProperty

### DIFF
--- a/UE4SS/include/UnrealCustom/CustomProperty.hpp
+++ b/UE4SS/include/UnrealCustom/CustomProperty.hpp
@@ -71,7 +71,12 @@ namespace RC::Unreal
         CustomStructProperty(int32_t offset_internal, int32_t element_size);
 
       public:
+        // Used for the C++ API
         auto static construct(int32_t offset_internal, UScriptStruct* script_struct, int32_t element_size) -> std::unique_ptr<CustomProperty>;
+
+        // Used for the Lua API
+        auto static construct(int32_t offset_internal, UClass* belongs_to_class, UClass* inner_class, UScriptStruct* script_struct, int32_t element_size)
+                -> std::unique_ptr<CustomProperty>;
     };
 } // namespace RC::Unreal
 

--- a/UE4SS/src/Mod/LuaMod.cpp
+++ b/UE4SS/src/Mod/LuaMod.cpp
@@ -2041,20 +2041,11 @@ Overloads:
 
                 auto set_is_array_property() -> void
                 {
-                    // Check here if any incompatible booleans have been set, and throw error if so
-                    if (is_struct_property)
-                    {
-                        // TODO: throw error, can't be both array and struct
-                    }
                     is_array_property = true;
                 }
 
                 auto set_is_struct_property() -> void
                 {
-                    if (is_array_property)
-                    {
-                        // TODO: throw error, can't be both array and struct
-                    }
                     is_struct_property = true;
                 }
 

--- a/UE4SS/src/UnrealCustom/CustomProperty.cpp
+++ b/UE4SS/src/UnrealCustom/CustomProperty.cpp
@@ -75,4 +75,15 @@ namespace RC::Unreal
 
         return custom_struct_property;
     }
+
+    auto CustomStructProperty::construct(int32_t offset_internal, UClass* belongs_to_class, UClass* inner_class, UScriptStruct* script_struct, int32_t element_size)
+            -> std::unique_ptr<CustomProperty>
+    {
+        std::unique_ptr<CustomProperty> custom_struct_property = CustomProperty::construct(offset_internal, belongs_to_class, inner_class, element_size);
+
+        // Set the struct type
+        std::bit_cast<FStructProperty*>(custom_struct_property.get())->GetStruct() = script_struct;
+
+        return custom_struct_property;
+    }
 } // namespace RC::Unreal

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -210,6 +210,8 @@ Added support for `UScriptStruct` when using `RegisterCustomProprety` ([UE4SS #1
 
 Added support for handling structs as userdata (Fixed `StructData as userdata is not yet implemented`). ([UE4SS #1169](https://github.com/UE4SS-RE/RE-UE4SS/pull/1169)) - Corporalwill123
 
+Added support for `StructProperty` to `RegisterCustomProperty`, by specifying a `UScriptStruct` name in the `StructProperty` table. ([UE4SS #1190](https://github.com/UE4SS-RE/RE-UE4SS/pull/1190)) - emoose
+
 #### Types.lua [PR #650](https://github.com/UE4SS-RE/RE-UE4SS/pull/650) 
 - Added `NAME_None` definition 
 - Added `EFindName` enum definition 

--- a/docs/lua-api/global-functions/registercustomproperty.md
+++ b/docs/lua-api/global-functions/registercustomproperty.md
@@ -8,7 +8,7 @@ This is an advanced function that's used to add support for non-reflected proper
 
 | # | Type    | Sub Type           | Information |
 |---|---------|--------------------|-------------|
-| 1 | table   | [CustomPropertyInfo](https://github.com/UE4SS/UE4SS/wiki/Table%3A-CustomPropertyInfo) | A table containing all of the required information for registering a custom property |
+| 1 | table   | [CustomPropertyInfo](../table-definitions/custompropertyinfo.md) | A table containing all of the required information for registering a custom property |
 
 ## Example
 

--- a/docs/lua-api/global-functions/registercustomproperty.md
+++ b/docs/lua-api/global-functions/registercustomproperty.md
@@ -12,6 +12,8 @@ This is an advanced function that's used to add support for non-reflected proper
 
 ## Example
 
+### Simple Property
+
 Registers a custom property with the name `MySimpleCustomProperty` that accesses whatever data is at offset `0xF40` in any instance of class `Character` as if it was an `IntProperty`.
 
 It then grabs that value of the first instance of the class `Character` as an example of how the system works.
@@ -19,12 +21,59 @@ It then grabs that value of the first instance of the class `Character` as an ex
 RegisterCustomProperty({
     ["Name"] = "MySimpleCustomProperty",
     ["Type"] = PropertyTypes.IntProperty,
-    ["BelongsToClass"] = "/Script/Engine.Character"
+    ["BelongsToClass"] = "/Script/Engine.Character",
     ["OffsetInternal"] = 0xF40
 })
 
 local CharacterInstance = FindFirstOf("Character")
 if CharacterInstance:IsValid() then
     local MySimplePropertyValue = CharacterInstance.MySimpleCustomProperty
+end
+```
+
+### ArrayProperty
+
+For array properties, you need to specify the inner type using the `ArrayProperty` table:
+
+```lua
+RegisterCustomProperty({
+    ["Name"] = "MyCustomArray",
+    ["Type"] = PropertyTypes.ArrayProperty,
+    ["BelongsToClass"] = "/Script/Engine.Character",
+    ["OffsetInternal"] = 0x100,
+    ["ArrayProperty"] = {
+        ["Type"] = PropertyTypes.IntProperty
+    }
+})
+
+local CharacterInstance = FindFirstOf("Character")
+if CharacterInstance:IsValid() then
+    local ArrayLength = CharacterInstance.MyCustomArray:GetArrayNum()
+    for i = 1, ArrayLength do
+        local Value = CharacterInstance.MyCustomArray[i]
+        print(string.format("Array[%d] = %d", i, Value))
+    end
+end
+```
+
+### StructProperty
+
+For struct properties, you need to specify the struct type by name using the `StructProperty` table. The struct must be a reflected `UScriptStruct` that exists in the game:
+
+```lua
+RegisterCustomProperty({
+    ["Name"] = "MyCustomStruct",
+    ["Type"] = PropertyTypes.StructProperty,
+    ["BelongsToClass"] = "/Script/MyGame.MyClass",
+    ["OffsetInternal"] = 0x28,
+    ["StructProperty"] = {
+        ["Name"] = "/Script/MyGame.MyStructType"
+    }
+})
+
+local MyObject = FindFirstOf("MyClass")
+if MyObject:IsValid() then
+    -- Access struct fields directly
+    local StructField = MyObject.MyCustomStruct.SomeField
 end
 ```

--- a/docs/lua-api/table-definitions/custompropertyinfo.md
+++ b/docs/lua-api/table-definitions/custompropertyinfo.md
@@ -12,6 +12,7 @@ The `CustomPropertyInfo` table contains information about a custom property.
 | BelongsToClass | string           |                    | Full class name without type, that this property belongs to
 | OffsetInternal | integer or table | [OffsetInternalInfo](./offsetinternalinfo.md)| Sub Type only valid if Type is table
 | ArrayProperty  | table            | [ArrayPropertyInfo](./arraypropertyinfo.md)| Only use when 'Type' is PropertyTypes.ArrayProperty
+| StructProperty | table            | [StructPropertyInfo](./structpropertyinfo.md)| Only use when 'Type' is PropertyTypes.StructProperty
 
 ## Simple Example
 Creates a custom property with the name `MySimpleCustomProperty` that accesses whatever data is at offset `0xF40` in any instance of class `Character` as if it was an `IntProperty`.

--- a/docs/lua-api/table-definitions/structpropertyinfo.md
+++ b/docs/lua-api/table-definitions/structpropertyinfo.md
@@ -1,0 +1,17 @@
+# StructPropertyInfo
+
+The `StructPropertyInfo` table contains type information for custom StructProperty properties.
+
+**You must supply data yourself when using this table.**
+
+## Structure
+| Key            | Value Type             | Information      |
+|----------------|------------------------|---------------|
+| Name           | string                 | Full name of `UScriptStruct` to use for the property. |
+
+## Example
+```lua
+local StructPropertyInfo = {
+    ["Name"] = "/Script/MyGame.MyStructType"
+}
+```


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

Extends RegisterCustomProperty so that `PropertyTypes.StructProperty` will lookup a UScriptStruct by name and create a property using it.

Code is based around how ArrayProperty was handled, the name/path for the UScriptStruct is taken from the `Properties.StructProperty.Name` value.

Fortunately there was already a `CustomStructProperty` class, but seems that only had `construct` for the C++ API, so just copied how the `CustomArrayProperty::construct` func for Lua worked for it.

Updated docs for RegisterCustomProperty to mention the usage for this along with the existing ArrayProperty support.

Please let me know if there's anything missing here, or could be improved.

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Is/requires documentation update

**How has this been tested?**
Tested with the following Lua in Code Vein 2:

```
RegisterCustomProperty({
    Name = "SaveData",
    Type = PropertyTypes.StructProperty,
    BelongsToClass = "/Script/Extensions.ClosenessManager",
    OffsetInternal = 0x28,
    StructProperty = {
        Name = "/Script/Extensions.ClosenessSaveData"
    }
})
```

Here `UClosenessManager` was a UObject that had no reflected properties, but the size showed 0x50 bytes of unreflected data.
`FClosenessSaveData` was dumped by the C++ header dump nearby and was exactly 0x50 bytes, testing it in a C++ mod showed that the fields inside matched the data inside UClosenessManager.

That `FClosenessSaveData` is made up of a TMap that points to a struct containing another TMap, so wasn't able to use the existing IntProperty/FloatProperty/etc primitives with RegisterCustomProperty to access it.

With the code above it could be registered and the TMaps were accessible through Lua fine.

**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
