### PR TITLE
feat: OutputDevice build support for Linux

### DIFF
--- a/deps/first/DynamicOutput/include/DynamicOutput/Macros.hpp
+++ b/deps/first/DynamicOutput/include/DynamicOutput/Macros.hpp
@@ -1,6 +1,8 @@
 #ifndef DYNAMIC_OUTPUT_MACROS_HPP
 #define DYNAMIC_OUTPUT_MACROS_HPP
 
+#include <Helpers/String.hpp>
+
 #define ENABLE_OUTPUT_DEVICE_DEBUG_MODE 0
 
 #define ASSERT_OUTPUT_DEVICE_IS_VALID(param_device)                                                                                                            \
@@ -15,5 +17,15 @@
         THROW_INTERNAL_FILE_ERROR("[Output::send] Attempted to send but there were no default devices. Please specify at least one default device or "         \
                                   "construct a Targets object and supply your own devices.")                                                                   \
     }
+
+#ifdef _WIN32
+#define RC_DEVICE_PRINT_FUNC(fmt_var, optional_arg, optional_prefix) \
+wprintf_s(STR("%s%hs%ls\033[0m"), optional_prefix, log_level_to_color(static_cast<Color::Color>(optional_arg)).c_str(), m_formatter(fmt_var).c_str());
+#elif __linux__
+#define RC_DEVICE_PRINT_FUNC(fmt_var, optional_arg, optional_prefix) \
+const auto as_utf8 = to_utf8_string(m_formatter(fmt_var)); \
+const auto color_as_utf8 = to_utf8_string(log_level_to_color(static_cast<Color::Color>(optional_arg))); \
+printf("%s%s%s\033[0m", optional_prefix, color_as_utf8.c_str(), as_utf8.c_str());
+#endif
 
 #endif // DYNAMIC_OUTPUT_MACROS_HPP

--- a/deps/first/DynamicOutput/include/DynamicOutput/Macros.hpp
+++ b/deps/first/DynamicOutput/include/DynamicOutput/Macros.hpp
@@ -20,7 +20,7 @@
 
 #ifdef _WIN32
 #define RC_DEVICE_PRINT_FUNC(fmt_var, optional_arg, optional_prefix) \
-wprintf_s(STR("%s%hs%ls\033[0m"), optional_prefix, log_level_to_color(static_cast<Color::Color>(optional_arg)).c_str(), m_formatter(fmt_var).c_str());
+wprintf_s(STR("%hs%hs%ls\033[0m"), optional_prefix, log_level_to_color(static_cast<Color::Color>(optional_arg)).c_str(), m_formatter(fmt_var).c_str());
 #elif __linux__
 #define RC_DEVICE_PRINT_FUNC(fmt_var, optional_arg, optional_prefix) \
 const auto as_utf8 = to_utf8_string(m_formatter(fmt_var)); \

--- a/deps/first/DynamicOutput/include/DynamicOutput/Output.hpp
+++ b/deps/first/DynamicOutput/include/DynamicOutput/Output.hpp
@@ -33,6 +33,30 @@ namespace RC::Output
 
     auto RC_DYNOUT_API has_internal_error() -> bool;
 
+    inline auto log_level_to_color(Color::Color color) -> std::string
+    {
+        switch (color)
+        {
+        case Color::Default:
+        case Color::NoColor:
+            return "\033[0;0m";
+        case Color::Cyan:
+            return "\033[1;36m";
+        case Color::Yellow:
+            return "\033[1;33m";
+        case Color::Red:
+            return "\033[1;31m";
+        case Color::Green:
+            return "\033[1;32m";
+        case Color::Blue:
+            return "\033[1;94m";
+        case Color::Purple:
+            return "\033[1;35m";
+        }
+
+        return "\033[0;0m";
+    }
+
     template <typename DeviceType>
     auto get_device_internal(OutputDevicesContainerType& device_container) -> DeviceType&
     {
@@ -169,7 +193,7 @@ namespace RC::Output
                 ASSERT_OUTPUT_DEVICE_IS_VALID(device)
                 if (device->has_optional_arg())
                 {
-                    device->receive_with_optional_arg(fmt::vformat(content, fmt_args...), RC_STD_MAKE_FORMAT_ARGS(static_cast<int32_t>(optional_arg)));
+                    device->receive_with_optional_arg(fmt::vformat(content, fmt_args...), static_cast<int32_t>(optional_arg));
                 }
                 else
                 {

--- a/deps/first/DynamicOutput/include/DynamicOutput/TestDevice.hpp
+++ b/deps/first/DynamicOutput/include/DynamicOutput/TestDevice.hpp
@@ -4,6 +4,12 @@
 #include <DynamicOutput/Macros.hpp>
 #include <DynamicOutput/OutputDevice.hpp>
 
+#if _WIN32
+#define RC_TEST_DEVICE_PRINT printf_s
+#elif __linux__
+#define RC_TEST_DEVICE_PRINT printf
+#endif
+
 namespace RC::Output
 {
     class TestDevice : public OutputDevice
@@ -49,23 +55,23 @@ namespace RC::Output
             switch (typed_optional_arg)
             {
             case OptionalArgTest::ValueDefault:
-                printf_s("Optional Arg: ValueDefault - ");
+                RC_TEST_DEVICE_PRINT("Optional Arg: ValueDefault - ");
                 break;
             case OptionalArgTest::ValueOne:
-                printf_s("Optional Arg: ValueOne - ");
+                RC_TEST_DEVICE_PRINT("Optional Arg: ValueOne - ");
                 break;
             case OptionalArgTest::ValueTwo:
-                printf_s("Optional Arg: ValueTwo - ");
+                RC_TEST_DEVICE_PRINT("Optional Arg: ValueTwo - ");
                 break;
             case OptionalArgTest::ValueThree:
-                printf_s("Optional Arg: ValueThree - ");
+                RC_TEST_DEVICE_PRINT("Optional Arg: ValueThree - ");
                 break;
             }
 
 #if ENABLE_OUTPUT_DEVICE_DEBUG_MODE
-            printf_s("TestDevice received: %S", fmt.c_str());
+            RC_DEVICE_PRINT_FUNC(fmt, optional_arg, "TestDevice received: ");
 #else
-            printf_s("%S", FromCharTypePtr<wchar_t>(fmt.data()));
+            RC_DEVICE_PRINT_FUNC(fmt, optional_arg, "");
 #endif
         }
     };

--- a/deps/first/DynamicOutput/src/DebugConsoleDevice.cpp
+++ b/deps/first/DynamicOutput/src/DebugConsoleDevice.cpp
@@ -4,44 +4,23 @@
 #include <DynamicOutput/DebugConsoleDevice.hpp>
 #include <DynamicOutput/Output.hpp>
 
+#ifdef _WIN32
 #define NOMINMAX
 #include <Windows.h>
 #ifdef TEXT
 #undef TEXT
 #endif
+#endif
 
 namespace RC::Output
 {
-    static auto log_level_to_color(Color::Color color) -> std::string
-    {
-        switch (color)
-        {
-        case Color::Default:
-        case Color::NoColor:
-            return "\033[0;0m";
-        case Color::Cyan:
-            return "\033[1;36m";
-        case Color::Yellow:
-            return "\033[1;33m";
-        case Color::Red:
-            return "\033[1;31m";
-        case Color::Green:
-            return "\033[1;32m";
-        case Color::Blue:
-            return "\033[1;94m";
-        case Color::Purple:
-            return "\033[1;35m";
-        }
-
-        return "\033[0;0m";
-    }
-
     auto DebugConsoleDevice::set_windows_console_out_mode_if_needed() const -> void
     {
         if (m_windows_console_mode_set)
         {
             return;
         }
+#ifdef _WIN32
         HANDLE current_console_out_handle = GetStdHandle(STD_OUTPUT_HANDLE);
         if (current_console_out_handle != INVALID_HANDLE_VALUE)
         {
@@ -49,6 +28,7 @@ namespace RC::Output
             GetConsoleMode(current_console_out_handle, &current_console_out_mode);
             SetConsoleMode(current_console_out_handle, current_console_out_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
         }
+#endif
         m_windows_console_mode_set = true;
     }
 
@@ -67,9 +47,9 @@ namespace RC::Output
         set_windows_console_out_mode_if_needed();
 
 #if ENABLE_OUTPUT_DEVICE_DEBUG_MODE
-        wprintf_s(STR("DebugConsoleDevice received: %ls"), m_formatter(fmt).c_str());
+        RC_DEVICE_PRINT_FUNC(fmt, optional_arg, "DebugConsoleDevice received: ")
 #else
-        wprintf_s(STR("%hs%ls\033[0m"), log_level_to_color(static_cast<Color::Color>(optional_arg)).c_str(), m_formatter(fmt).c_str());
+        RC_DEVICE_PRINT_FUNC(fmt, optional_arg, "")
 #endif
     }
 } // namespace RC::Output

--- a/deps/first/File/include/File/FileDef.hpp
+++ b/deps/first/File/include/File/FileDef.hpp
@@ -5,14 +5,18 @@ namespace RC::File
 #ifndef RC_DETECTED_OS
 #ifdef _WIN32
 #define RC_DETECTED_OS _WIN32
+#elif __linux__
+#define RC_DETECTED_OS __linux__
 #else
     static_assert(false, "Could not setup the 'Handle' typedef because a supported OS was not detected.");
 #endif
 #endif
 
-#if RC_DETECTED_OS == _WIN32
 #ifndef RC_OS_FILE_TYPE_INCLUDE_FILE
+#if RC_DETECTED_OS == _WIN32
 #define RC_OS_FILE_TYPE_INCLUDE_FILE <File/FileType/WinFile.hpp>
+#elif RC_DETECTED_OS == __linux__
+#define RC_OS_FILE_TYPE_INCLUDE_FILE <File/FileType/LinuxFile.hpp>
 #else
     static_assert(false, "Could not setup the 'RC_OS_FILE_TYPE_INCLUDE_FILE' macro because a supported OS was not detected.");
 #endif

--- a/deps/first/File/include/File/FileType/LinuxFile.hpp
+++ b/deps/first/File/include/File/FileType/LinuxFile.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef _WIN32
+#ifdef __linux__
 
 #include <filesystem>
 #include <format>
@@ -9,9 +9,13 @@
 #include <File/FileType/FileBase.hpp>
 #include <File/Macros.hpp>
 
+// NOTE: This file is effectively a stub.
+//       The LinuxFile class has not been implemented!
+//       File operations through the Output::* system doesn't work, for example FileDevice and NewFileDevice.
+
 namespace RC::File
 {
-    class WinFile : public FileInterface<WinFile>
+    class LinuxFile : public FileInterface<LinuxFile>
     {
       private:
         using HANDLE = void*;
@@ -45,7 +49,7 @@ namespace RC::File
         bool m_is_file_open{};
 
       public:
-        ~WinFile() override = default;
+        ~LinuxFile() override = default;
 
       private:
         auto static create_all_directories(const std::filesystem::path& file_name_and_path) -> void;
@@ -78,10 +82,10 @@ namespace RC::File
         RC_FILE_API auto get_serialized_item(size_t data_size, bool is_internal_item = false) -> void* override;
         RC_FILE_API auto close_current_file() -> void override;
         RC_FILE_API auto write_string_to_file(StringViewType string_to_write) -> void override;
-        RC_FILE_API auto is_same_as(WinFile& other_file) -> bool override;
+        RC_FILE_API auto is_same_as(LinuxFile& other_file) -> bool override;
         [[nodiscard]] RC_FILE_API auto read_all() const -> StringType override;
         [[nodiscard]] RC_FILE_API auto memory_map() -> std::span<uint8_t> override;
-        [[nodiscard]] RC_FILE_API auto static open_file(const std::filesystem::path& file_name_and_path, const OpenProperties& open_properties) -> WinFile;
+        [[nodiscard]] RC_FILE_API auto static open_file(const std::filesystem::path& file_name_and_path, const OpenProperties& open_properties) -> LinuxFile;
         // File Interface -> END
     };
 
@@ -89,7 +93,7 @@ namespace RC::File
     // Therefore, it's not necessary to do any checks here
     template <ImplementsFileInterface UnderlyingAbstraction>
     class HandleTemplate;
-    using Handle = HandleTemplate<WinFile>;
+    using Handle = HandleTemplate<LinuxFile>;
 } // namespace RC::File
 
-#endif // ifdef _WIN32
+#endif // ifdef __linux__

--- a/deps/first/File/src/FileType/WinFile.cpp
+++ b/deps/first/File/src/FileType/WinFile.cpp
@@ -1,3 +1,4 @@
+#ifdef _WIN32
 #include <fstream>
 
 #include <File/File.hpp>
@@ -623,3 +624,5 @@ namespace RC::File
         return file;
     }
 } // namespace RC::File
+
+#endif // ifdef _WIN32

--- a/deps/first/Helpers/src/SysError.cpp
+++ b/deps/first/Helpers/src/SysError.cpp
@@ -12,6 +12,9 @@
 #include "Helpers/SysError.hpp"
 #include "Helpers/String.hpp"
 
+#include <fmt/core.h>
+#include <fmt/xchar.h>
+
 namespace RC
 {
     SysError::SysError(const int error_code, const std::error_category &category)
@@ -28,7 +31,7 @@ namespace RC
 
     auto SysError::assign(unsigned long error_code) -> void
     {
-        m_error_text.assign(std::format(L"[0x{:x}] {}", error_code, format_error(static_cast<int>(error_code))));
+        m_error_text.assign(fmt::format(STR("[0x{:x}] {}"), error_code, format_error(static_cast<int>(error_code))));
     }
 
 #ifdef _WIN32
@@ -53,7 +56,7 @@ namespace RC
 
     auto SysError::category() const -> StringType
     {
-        return to_wstring(m_error_category->name());
+        return ensure_str(m_error_category->name());
     }
 
     auto SysError::format_error(const int error_code) const -> StringType
@@ -61,12 +64,12 @@ namespace RC
         const std::error_category& error_category = *m_error_category;
         const std::error_code ec(error_code, error_category);
         // remove new line(s) and tabs
-        auto result = std::regex_replace(to_wstring(std::system_error(ec).what()), std::wregex(STR("(\t|\r?\n)")), STR(" "));
+        auto result = std::regex_replace(to_wstring(std::system_error(ec).what()), std::wregex(L"(\t|\r?\n)"), L" ");
         // right trim
         result.erase(std::ranges::find_if(std::ranges::reverse_view(result), [](const CharType c) -> bool {
             return !std::isspace<CharType>(c, std::locale::classic());
         }).base(), result.end());
 
-        return result;
+        return ensure_str(result);
     }
 }

--- a/deps/first/String/include/String/StringType.hpp
+++ b/deps/first/String/include/String/StringType.hpp
@@ -9,7 +9,9 @@
 // This is a debug flag to force the use of u16string for testing purposes
 // char16_t and wchar_t are two different types, so we need to force the use of one of them
 // to ensure we have covered all the cases.
-// #define FORCE_U16
+#ifdef __linux__
+#define FORCE_U16
+#endif
 
 namespace RC
 {


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds some support for DynamicOutput.
I've decided an iterative method of adding Linux support may be more effective than doing it all in one chunk, so I might make more PRs similar to this with small-ish changes for Linux support.

Fixes # (issue) (if applicable)

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Other... Please describe: Build support for Linux

**How has this been tested?**
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration. -->

This has minimal testing.
Specifically, running UE4SS on Windows has been tested and still works, and using DynamicOutput on Linux has been tested and is working except FileDevice and NewFileDevice. Nothing else has been tested.
The File dependency on Linux is not implemented.

It's tested by making a program that utilizes each dependency independently of UE4SS.
CMakeLists.txt, manually change platforms by un/commenting the line near the bottom of the file.
```cmake
cmake_minimum_required(VERSION 3.22)

set(TARGET TestsForUE4SS)
project(${TARGET})

add_executable(${TARGET} "src/main.cpp")
target_include_directories(${TARGET} PUBLIC "include")

# Check for MSVC-compatible compilers (MSVC or clang-cl)
get_filename_component(COMPILER_NAME "${CMAKE_CXX_COMPILER}" NAME)
if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR
        COMPILER_NAME MATCHES "clang-cl" OR
(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC"))
    target_compile_options(${TARGET} PUBLIC /Zi)
endif()

target_compile_definitions(${TARGET} PRIVATE
        RC_ASM_HELPER_BUILD_STATIC
        RC_FILE_BUILD_STATIC
        RC_DYNAMIC_OUTPUT_BUILD_STATIC
        RC_SINGLE_PASS_SIG_SCANNER_BUILD_STATIC
        RC_SINGLE_PASS_SIG_SCANNER_STATIC
        RC_UNREAL_BUILD_STATIC
        RC_INPUT_BUILD_STATIC
        RC_LUA_MADE_SIMPLE_BUILD_STATIC
        RC_FUNCTION_TIMER_BUILD_STATIC
        RC_PARSER_BASE_BUILD_STATIC
        RC_INI_PARSER_BUILD_STATIC
        RC_JSON_BUILD_STATIC
        RC_JSON_PARSER_BUILD_STATIC
        RC_LUA_WRAPPER_GENERATOR_BUILD_STATIC
)

# Windows
#target_compile_definitions(${TARGET} PUBLIC _UNICODE UNICODE UE_GAME UE_BUILD_SHIPPING PLATFORM_WINDOWS PLATFORM_MICROSOFT OVERRIDE_PLATFORM_HEADER_NAME=Windows UBT_COMPILED_PLATFORM=Win64)

# Linux
target_compile_definitions(${TARGET} PUBLIC _UNICODE UNICODE UE_GAME UE_BUILD_SHIPPING PLATFORM_LINUX OVERRIDE_PLATFORM_HEADER_NAME=Clang UBT_COMPILED_PLATFORM=Linux)

target_link_libraries(${TARGET} PUBLIC DynamicOutput)
```

main.cpp:
```c++
#include <DynamicOutput/DynamicOutput.hpp>
#include <Helpers/Time.hpp>

#ifdef _WIN32
#include <Windows.h>
#endif

using namespace RC;

int main()
{
    Output::set_default_devices<Output::DebugConsoleDevice>();
    Output::set_default_log_level<LogLevel::Normal>();

    auto& device = Output::get_device<Output::DebugConsoleDevice>();
    device.set_formatter([](File::StringViewType string) -> File::StringType {
        return fmt::format(STR("[{}] {}"), get_now_as_string(STR("{:%X}")), string);
    });

#ifdef _WIN32
    if (AllocConsole())
    {
        FILE* stdin_filename;
        FILE* stdout_filename;
        FILE* stderr_filename;
        freopen_s(&stdin_filename, "CONIN$", "r", stdin);
        freopen_s(&stdout_filename, "CONOUT$", "w", stdout);
        freopen_s(&stderr_filename, "CONOUT$", "w", stderr);
    }
#endif

    Output::send<LogLevel::Verbose>(STR("HELLO\n"));
    Output::send<LogLevel::Verbose>(STR("Unicode chars 1: åäö ÅÄÖ\n"));
    Output::send<LogLevel::Verbose>(STR("Unicode chars 2: 语言处理\n"));

    return EXIT_SUCCESS;
}
```