### PR TITLE
Fix Static Mesh and Actor Dumper crashing in 5.6 and above games

### DIFF
--- a/UE4SS/src/GUI/Dumpers.cpp
+++ b/UE4SS/src/GUI/Dumpers.cpp
@@ -184,48 +184,42 @@ namespace RC::GUI::Dumpers
                         }
                     };
 
-                    if (Version::IsAtMost(4, 19))
+                    TArray<UObject*> material_interfaces;
+                    if (auto static_materials_property = CastField<FArrayProperty>(mesh->GetPropertyByName((STR("StaticMaterials")))))
                     {
-                        const auto materials =
-                                *mesh->GetValuePtrByPropertyName<TArray<FStaticMaterial_419AndBelow>>(FromCharTypePtr<TCHAR>(STR("StaticMaterials")));
-                        if (materials.GetData())
+                        auto static_materials_inner_property = static_materials_property->GetInner();
+
+                        if (auto static_material_property = CastField<FStructProperty>(static_materials_inner_property))
                         {
-                            actor_buffer.append(STR("Materials=("));
-                        }
-                        for (auto [material, material_index] : materials | views::enumerate)
-                        {
-                            materials_for_each_body(material.MaterialInterface);
-                            if (material_index + 1 < materials.Num())
+                            auto& static_material_struct = static_material_property->GetStruct();
+                            auto material_interface_property = static_material_struct->GetPropertyByNameInChain((STR("MaterialInterface")));
+
+                            FScriptArrayHelper_InContainer array_helper(static_materials_property, mesh);
+                            for (int32 i = 0; i < array_helper.Num(); i++)
                             {
-                                actor_buffer.append(STR(","));
-                            }
-                            else
-                            {
-                                actor_buffer.append(STR(")"));
+                                auto material = *material_interface_property->ContainerPtrToValuePtr<UObject*>(array_helper.GetRawPtr(i));
+                                material_interfaces.Add(material);
                             }
                         }
                     }
-                    else
+
+                    if (material_interfaces.GetData())
                     {
-                        const auto& materials =
-                                *mesh->GetValuePtrByPropertyName<TArray<FStaticMaterial_420AndAbove>>(FromCharTypePtr<TCHAR>(STR("StaticMaterials")));
-                        if (materials.GetData())
+                        actor_buffer.append(STR("Materials=("));
+                    }
+                    for (auto [material, material_index] : material_interfaces | views::enumerate)
+                    {
+                        materials_for_each_body(material);
+                        if (material_index + 1 < material_interfaces.Num())
                         {
-                            actor_buffer.append(STR("Materials=("));
+                            actor_buffer.append(STR(","));
                         }
-                        for (auto [material, material_index] : materials | views::enumerate)
+                        else
                         {
-                            materials_for_each_body(material.MaterialInterface);
-                            if (material_index + 1 < materials.Num())
-                            {
-                                actor_buffer.append(STR(","));
-                            }
-                            else
-                            {
-                                actor_buffer.append(STR(")"));
-                            }
+                            actor_buffer.append(STR(")"));
                         }
                     }
+
                     actor_buffer.append(STR(")"));
 
                     if (static_mesh_component_index + 1 < static_mesh_components.Num())

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -114,6 +114,10 @@ Added individual mod restart/uninstall/start functionality to Lua Debugger ([UE4
 
 Added support for generating `FUtf8String` and `FAnsiString` properties in UHT-compatible headers ([UE4SS #1015](https://github.com/UE4SS-RE/RE-UE4SS/pull/1015))
 
+### Static Mesh Dumper
+
+Fixed Static Mesh Dumper crashing on material interfaces in UE 5.6 and above due to FStaticMaterial layout changes. - Okaetsu
+
 ### Lua API
 
 Added support for `FUtf8String` and `FAnsiString` Unreal string types with string manipulation API ([UE4SS #1015](https://github.com/UE4SS-RE/RE-UE4SS/pull/1015))


### PR DESCRIPTION
**Description**
In 5.6 and above, static mesh dumper and actor dumper would crash on parsing static materials due to `OverlayMaterialInterface` being added to the end of `FStaticMaterial` which would break TArrays containing that struct.

I was initially going to add a new struct for 5.6+, but since we have `FScriptArrayHelper` now, I figured I'd future proof that part of the code by handling the array items via reflection so we don't need to add new structs and elseif blocks for each version change.

I left the old struct definitions as is in case there's still a need for them, but if there isn't then I can remove them in this PR.


Fixes #1236 dumper crashing

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

**How has this been tested?**
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration. -->

I've tested 'Dump all static actor meshes to file' and 'Dump all actors to file' in the following engine versions:
- 4.27 (Stray)
- 5.1 (Palworld)
- 5.6 (Windrose)

The produced .csv files were identical to the ones from before the changes, but without crashing in Windrose.


**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.

