### PR TITLE
build: add support for llvm-ml in cross-compilation toolchains

### DIFF
--- a/cmake/modules/FindLLVMTools.cmake
+++ b/cmake/modules/FindLLVMTools.cmake
@@ -91,6 +91,7 @@ endfunction()
 #   NEED_LLVM_RC - Find llvm-rc
 #   NEED_LLVM_MT - Find llvm-mt
 #   NEED_LLVM_RANLIB - Find llvm-ranlib
+#   NEED_LLVM_ML - Find llvm-ml
 #
 # Sets in parent scope (if requested):
 #   CLANG_EXECUTABLE - Path to clang
@@ -102,6 +103,7 @@ endfunction()
 #   LLVM_RC_EXECUTABLE - Path to llvm-rc
 #   LLVM_MT_EXECUTABLE - Path to llvm-mt
 #   LLVM_RANLIB_EXECUTABLE - Path to llvm-ranlib
+#   LLVM_ML_EXECUTABLE - Path to llvm-ml
 #
 # Example usage:
 #   find_llvm_tools(NEED_CLANG_CL TRUE NEED_LLD TRUE NEED_LLVM_LIB TRUE)
@@ -110,7 +112,7 @@ function(find_llvm_tools)
     cmake_parse_arguments(FIND_LLVM
         ""
         ""
-        "NEED_CLANG;NEED_CLANG_CL;NEED_LLD;NEED_LLVM_LIB;NEED_LLVM_RC;NEED_LLVM_MT;NEED_LLVM_RANLIB"
+        "NEED_CLANG;NEED_CLANG_CL;NEED_LLD;NEED_LLVM_LIB;NEED_LLVM_RC;NEED_LLVM_MT;NEED_LLVM_RANLIB;NEED_LLVM_ML"
         ${ARGN}
     )
     
@@ -157,6 +159,11 @@ function(find_llvm_tools)
         find_llvm_tool(LLVM_RANLIB_EXECUTABLE "llvm-ranlib" "LLVM ranlib" TRUE)
         set(LLVM_RANLIB_EXECUTABLE "${LLVM_RANLIB_EXECUTABLE}" PARENT_SCOPE)
     endif()
+
+    if(FIND_LLVM_NEED_LLVM_ML)
+        find_llvm_tool(LLVM_ML_EXECUTABLE "llvm-ml" "LLVM ML assembler" TRUE)
+        set(LLVM_ML_EXECUTABLE "${LLVM_ML_EXECUTABLE}" PARENT_SCOPE)
+    endif()
 endfunction()
 
 # Convenience wrapper for Windows-targeting toolchains
@@ -168,6 +175,7 @@ function(find_llvm_windows_tools)
         NEED_LLVM_RC TRUE
         NEED_LLVM_MT TRUE
         NEED_LLVM_RANLIB TRUE
+        NEED_LLVM_ML TRUE
     )
     # Forward all variables to parent scope
     set(CLANG_CL_EXECUTABLE "${CLANG_CL_EXECUTABLE}" PARENT_SCOPE)
@@ -176,6 +184,7 @@ function(find_llvm_windows_tools)
     set(LLVM_RC_EXECUTABLE "${LLVM_RC_EXECUTABLE}" PARENT_SCOPE)
     set(LLVM_MT_EXECUTABLE "${LLVM_MT_EXECUTABLE}" PARENT_SCOPE)
     set(LLVM_RANLIB_EXECUTABLE "${LLVM_RANLIB_EXECUTABLE}" PARENT_SCOPE)
+    set(LLVM_ML_EXECUTABLE "${LLVM_ML_EXECUTABLE}" PARENT_SCOPE)
 endfunction()
 
 # Convenience wrapper for GNU-style toolchains

--- a/cmake/toolchains/xwin-clang-cl-toolchain.cmake
+++ b/cmake/toolchains/xwin-clang-cl-toolchain.cmake
@@ -48,6 +48,9 @@ set(CMAKE_RC_COMPILER ${LLVM_RC_EXECUTABLE})
 if(LLVM_MT_EXECUTABLE)
     set(CMAKE_MT ${LLVM_MT_EXECUTABLE})
 endif()
+if(LLVM_ML_EXECUTABLE)
+    set(CMAKE_ASM_MASM_COMPILER ${LLVM_ML_EXECUTABLE})
+endif()
 
 # Get xwin directory from environment or use default relative path
 if(DEFINED ENV{XWIN_DIR})

--- a/cmake/toolchains/xwin-clang-toolchain.cmake
+++ b/cmake/toolchains/xwin-clang-toolchain.cmake
@@ -79,6 +79,13 @@ set(CMAKE_LINKER ${LLD_LINK_EXECUTABLE})
 if(LLVM_RC_EXECUTABLE)
     set(CMAKE_RC_COMPILER ${LLVM_RC_EXECUTABLE})
 endif()
+
+# Set MASM assembler if found
+find_llvm_tool(LLVM_ML_EXECUTABLE "llvm-ml" "LLVM ML assembler" FALSE)
+if(LLVM_ML_EXECUTABLE)
+    set(CMAKE_ASM_MASM_COMPILER ${LLVM_ML_EXECUTABLE})
+endif()
+
 # Set RC flags to use Windows SDK includes
 set(CMAKE_RC_FLAGS "-I ${XWIN_SDK_INCLUDE}/um -I ${XWIN_SDK_INCLUDE}/shared")
 


### PR DESCRIPTION
### What does this PR do?
Adds support for `llvm-ml` in the build system to improve cross-compilation toolchains.

### The Problem
When cross-compiling (especially for Linux or specific toolchains without native MSVC `ml64`), the build system lacked explicit support for the LLVM macro assembler (`llvm-ml`), causing compilation failures or requiring manual build script hacks.

### The Solution
Updated the CMake/build configurations to explicitly support `llvm-ml` as an assembler drop-in, enabling smooth cross-compilation with LLVM-based toolchains.