### PR TITLE
fix: ConsoleEnablerMod sometimes not working

### DIFF
--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -80,6 +80,8 @@ Added `FUObjectItem`, `FUObjectArray`, and `TUObjectArray` to MemberVariableLayo
 - We've also added a special `UEP_TotalSize` entry to every section.
 - It's currently only crucial for `FUObjectItem`, but in the future, we may use this entry for more types.
 
+Fixed the ingame console (Tilde, or F10 key) not working for some games - ([UE4SS #1252](https://github.com/UE4SS-RE/RE-UE4SS/pull/1252))
+
 ### Live View 
 Added search filter: `IncludeClassNames`. ([UE4SS #472](https://github.com/UE4SS-RE/RE-UE4SS/pull/472)) - Buckminsterfullerene
 

--- a/assets/Mods/ConsoleEnablerMod/Scripts/main.lua
+++ b/assets/Mods/ConsoleEnablerMod/Scripts/main.lua
@@ -47,7 +47,7 @@ local function CreateConsole()
     local Engine = UEHelpers.GetEngine()
     if not Engine:IsValid() then print("[ConsoleEnabler] Was unable to find an instance of UEngine\n") return end
 
-    local ConsoleClass = Engine.ConsoleClass ---@type UClass
+    local ConsoleClass = StaticFindObject("/Script/Engine.Console") ---@type UClass
     local GameViewport = Engine.GameViewport
     if (GameViewport:IsValid() and GameViewport.ViewportConsole:IsValid()) then
         -- Console already exists, let's just remap the keys


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

This happens when the game overrides the default console class and uses that class to stop the console from appearing.

Fixes # (issue) (if applicable)

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


**How has this been tested?**
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration. -->

Tested in Subnautica 2.
Without this patch the console won't open.

