### PR TITLE
Fix for inheritance for some Lua types

### DIFF
--- a/UE4SS/include/LuaType/LuaUInterface.hpp
+++ b/UE4SS/include/LuaType/LuaUInterface.hpp
@@ -2,7 +2,7 @@
 
 #include <LuaMadeSimple/LuaObject.hpp>
 #include <LuaType/LuaUObject.hpp>
-#include <LuaType/LuaUStruct.hpp>
+#include <LuaType/LuaUClass.hpp>
 
 namespace RC::Unreal
 {
@@ -21,7 +21,7 @@ namespace RC::LuaType
     class UInterface : public UObjectBase<Unreal::UInterface, UInterfaceName>
     {
       public:
-        using Super = LuaType::UStruct;
+        using Super = LuaType::UClass;
 
       private:
         explicit UInterface(Unreal::UInterface* object);

--- a/UE4SS/include/LuaType/LuaUObject.hpp
+++ b/UE4SS/include/LuaType/LuaUObject.hpp
@@ -129,7 +129,7 @@ namespace RC::LuaType
         }
 
       public:
-        // Constructor for RemoteObjectBase
+        // Constructor for ObjectBase
         auto static construct(const LuaMadeSimple::Lua& lua, Unreal::UObject* unreal_object) -> const LuaMadeSimple::Lua::Table
         {
             SelfType lua_object{unreal_object};
@@ -140,7 +140,7 @@ namespace RC::LuaType
             if (lua.is_nil(-1))
             {
                 lua.discard_value(-1);
-                LuaMadeSimple::Type::RemoteObject<ObjectType>::construct(lua, lua_object);
+                LuaObjectBase<ObjectType>::construct(lua, lua_object);
                 setup_member_functions<LuaMadeSimple::Type::IsFinal::Yes>(table);
                 lua.new_metatable<SelfType>(metatable_name, lua_object.get_metamethods());
             }
@@ -151,10 +151,10 @@ namespace RC::LuaType
             return table;
         }
 
-        // Constructor for objects that inherit from RemoteObjectBase
+        // Constructor for objects that inherit from ObjectBase
         auto static construct(const LuaMadeSimple::Lua& lua, LuaMadeSimple::Type::BaseObject& construct_to) -> const LuaMadeSimple::Lua::Table
         {
-            const LuaMadeSimple::Lua::Table table = LuaMadeSimple::Type::RemoteObject<ObjectType>::construct(lua, construct_to);
+            const LuaMadeSimple::Lua::Table table = LuaObjectBase<ObjectType>::construct(lua, construct_to);
 
             // Setup functions that can be called on this object
             setup_member_functions<LuaMadeSimple::Type::IsFinal::No>(table);
@@ -167,22 +167,36 @@ namespace RC::LuaType
         template <LuaMadeSimple::Type::IsFinal is_final>
         auto static setup_member_functions(const LuaMadeSimple::Lua::Table& table) -> void
         {
-            // Overridden functions from 'Lua::RemoteObject'.
+            // Overridden functions from 'Lua::RemoteObject'/'Lua::LocalObject'.
             table.add_pair("GetAddress", [](const LuaMadeSimple::Lua& lua) -> int {
                 const auto& lua_object = lua.get_userdata<SelfType>();
-                lua.set_integer(reinterpret_cast<uintptr_t>(lua_object.get_remote_cpp_object()));
+                if constexpr (!LuaObjectBase<ObjectType>::IsLocal)
+                {
+                    lua.set_integer(reinterpret_cast<uintptr_t>(lua_object.get_remote_cpp_object()));
+                }
+                else
+                {
+                    lua.set_integer(reinterpret_cast<uintptr_t>(&lua_object.get_local_cpp_object()));
+                }
                 return 1;
             });
 
             table.add_pair("IsValid", [](const LuaMadeSimple::Lua& lua) -> int {
                 const auto& lua_object = lua.get_userdata<SelfType>();
-                if (lua_object.get_remote_cpp_object())
+                if constexpr (!LuaObjectBase<ObjectType>::IsLocal)
                 {
-                    lua.set_bool(true);
+                    if (lua_object.get_remote_cpp_object())
+                    {
+                        lua.set_bool(true);
+                    }
+                    else
+                    {
+                        lua.set_bool(false);
+                    }
                 }
                 else
                 {
-                    lua.set_bool(false);
+                    lua.set_bool(true);
                 }
                 return 1;
             });

--- a/UE4SS/include/LuaType/LuaUScriptStruct.hpp
+++ b/UE4SS/include/LuaType/LuaUScriptStruct.hpp
@@ -12,6 +12,9 @@ namespace RC::Unreal
 namespace RC::LuaType
 {
     // Simple wrapper that contains the UScriptStruct* and the FStructProperty*
+    // IMPORTANT: DO NOT move the 'script_struct' member, or add any new ones above it, or add a vtable to this struct.
+    //            We are relying on 'script_struct' being at offset 0x0 so that it can correctly be treated as a UStruct and UObject.
+    //            This allows calling UObject and UStruct members (i.e. GetFullName, etc.) without further adjustments.
     struct ScriptStructWrapper
     {
         Unreal::UScriptStruct* script_struct{};

--- a/UE4SS/include/LuaType/LuaUScriptStruct.hpp
+++ b/UE4SS/include/LuaType/LuaUScriptStruct.hpp
@@ -27,6 +27,7 @@ namespace RC::LuaType
             return start_of_struct;
         }
     };
+    static_assert(offsetof(ScriptStructWrapper, script_struct) == 0x0);
 
     struct UScriptStructName
     {

--- a/UE4SS/src/LuaType/LuaFOutputDevice.cpp
+++ b/UE4SS/src/LuaType/LuaFOutputDevice.cpp
@@ -34,7 +34,7 @@ namespace RC::LuaType
 
     auto FOutputDevice::construct(const LuaMadeSimple::Lua& lua, BaseObject& construct_to) -> const LuaMadeSimple::Lua::Table
     {
-        LuaMadeSimple::Lua::Table table = LuaMadeSimple::Type::RemoteObject<Unreal::FOutputDevice>::construct(lua, construct_to);
+        LuaMadeSimple::Lua::Table table = SelfType::construct(lua, construct_to);
 
         setup_member_functions<LuaMadeSimple::Type::IsFinal::No>(table);
 

--- a/UE4SS/src/LuaType/LuaFText.cpp
+++ b/UE4SS/src/LuaType/LuaFText.cpp
@@ -19,7 +19,7 @@ namespace RC::LuaType
         if (lua.is_nil(-1))
         {
             lua.discard_value(-1);
-            LuaType::UObject::construct(lua, lua_object);
+            SelfType::construct(lua, lua_object);
             setup_metamethods(lua_object);
             setup_member_functions<LuaMadeSimple::Type::IsFinal::Yes>(table);
             lua.new_metatable<LuaType::FText>(metatable_name, lua_object.get_metamethods());
@@ -33,7 +33,7 @@ namespace RC::LuaType
 
     auto FText::construct(const LuaMadeSimple::Lua& lua, BaseObject& construct_to) -> const LuaMadeSimple::Lua::Table
     {
-        LuaMadeSimple::Lua::Table table = UObject::construct(lua, construct_to);
+        LuaMadeSimple::Lua::Table table = SelfType::construct(lua, construct_to);
 
         setup_member_functions<LuaMadeSimple::Type::IsFinal::No>(table);
 

--- a/UE4SS/src/LuaType/LuaUDataTable.cpp
+++ b/UE4SS/src/LuaType/LuaUDataTable.cpp
@@ -59,13 +59,6 @@ namespace RC::LuaType
     template <LuaMadeSimple::Type::IsFinal is_final>
     auto UDataTable::setup_member_functions(const LuaMadeSimple::Lua::Table& table) -> void
     {
-        table.add_pair("IsValid",
-                       [](const LuaMadeSimple::Lua& lua) -> int {
-                           auto& lua_object = lua.get_userdata<UDataTable>();
-                           lua.set_bool(lua_object.get_remote_cpp_object() != nullptr);
-                           return 1;
-                       });
-
         table.add_pair("GetRowStruct",
                        [](const LuaMadeSimple::Lua& lua) -> int {
                            auto& lua_object = lua.get_userdata<UDataTable>();

--- a/UE4SS/src/LuaType/LuaUEnum.cpp
+++ b/UE4SS/src/LuaType/LuaUEnum.cpp
@@ -51,8 +51,6 @@ namespace RC::LuaType
     template <LuaMadeSimple::Type::IsFinal is_final>
     auto UEnum::setup_member_functions(const LuaMadeSimple::Lua::Table& table) -> void
     {
-        Super::setup_member_functions<LuaMadeSimple::Type::IsFinal::No>(table);
-
         table.add_pair("GetNameByValue", [](const LuaMadeSimple::Lua& lua) -> int {
             std::string error_overload_not_found{R"(
 No overload found for function 'UEnum.GetNameByValue'.

--- a/UE4SS/src/LuaType/LuaUInterface.cpp
+++ b/UE4SS/src/LuaType/LuaUInterface.cpp
@@ -23,7 +23,7 @@ namespace RC::LuaType
         if (lua.is_nil(-1))
         {
             lua.discard_value(-1);
-            LuaType::UObject::construct(lua, lua_object);
+            LuaType::UClass::construct(lua, lua_object);
             setup_metamethods(lua_object);
             setup_member_functions<LuaMadeSimple::Type::IsFinal::Yes>(table);
             lua.new_metatable<LuaType::UInterface>(metatable_name, lua_object.get_metamethods());
@@ -37,7 +37,7 @@ namespace RC::LuaType
 
     auto UInterface::construct(const LuaMadeSimple::Lua& lua, BaseObject& construct_to) -> const LuaMadeSimple::Lua::Table
     {
-        LuaMadeSimple::Lua::Table table = UObject::construct(lua, construct_to);
+        LuaMadeSimple::Lua::Table table = UClass::construct(lua, construct_to);
 
         setup_member_functions<LuaMadeSimple::Type::IsFinal::No>(table);
 
@@ -54,8 +54,6 @@ namespace RC::LuaType
     template <LuaMadeSimple::Type::IsFinal is_final>
     auto UInterface::setup_member_functions(const LuaMadeSimple::Lua::Table& table) -> void
     {
-        Super::setup_member_functions<LuaMadeSimple::Type::IsFinal::No>(table);
-
         if constexpr (is_final == LuaMadeSimple::Type::IsFinal::Yes)
         {
             table.add_pair("type", [](const LuaMadeSimple::Lua& lua) -> int {

--- a/UE4SS/src/LuaType/LuaUScriptStruct.cpp
+++ b/UE4SS/src/LuaType/LuaUScriptStruct.cpp
@@ -97,7 +97,8 @@ namespace RC::LuaType
         table.add_pair("IsValid", [](const LuaMadeSimple::Lua& lua) -> int {
             auto& lua_object = lua.get_userdata<UScriptStruct>();
 
-            if (lua_object.get_local_cpp_object().script_struct)
+            const auto& script_wrapper = lua_object.get_local_cpp_object();
+            if (script_wrapper.script_struct && is_object_in_global_unreal_object_map(script_wrapper.script_struct) && !script_wrapper.script_struct->IsUnreachable())
             {
                 lua.set_bool(true);
             }

--- a/UE4SS/src/LuaType/LuaUScriptStruct.cpp
+++ b/UE4SS/src/LuaType/LuaUScriptStruct.cpp
@@ -69,7 +69,13 @@ namespace RC::LuaType
     template <LuaMadeSimple::Type::IsFinal is_final>
     auto UScriptStruct::setup_member_functions(const LuaMadeSimple::Lua::Table& table) -> void
     {
-        Super::setup_member_functions<LuaMadeSimple::Type::IsFinal::No>(table);
+        // UScriptStruct is special due to the fact that it sometimes represents both data and metadata, and other times just metadata.
+        // The 'setup_member_functions' functions are internal, and shouldn't be called via 'Super'.
+        // This is because this function is called via the 'construct' function, so if we call via 'Super', we will often end up with two calls to this function.
+        // We can't construct the inheritance because this object is a local object, while UObject and UStruct are remote objects.
+        // The solution is to maintain the inheritance manually here.
+        UStruct::setup_member_functions<LuaMadeSimple::Type::IsFinal::No>(table);
+        UObject::setup_member_functions<LuaMadeSimple::Type::IsFinal::No>(table);
 
         table.add_pair("GetBaseAddress", [](const LuaMadeSimple::Lua& lua) -> int {
             // Update: We are no longer storing the base so this function has no use anymore

--- a/UE4SS/src/LuaType/LuaUStruct.cpp
+++ b/UE4SS/src/LuaType/LuaUStruct.cpp
@@ -54,8 +54,6 @@ namespace RC::LuaType
     template <LuaMadeSimple::Type::IsFinal is_final>
     auto UStruct::setup_member_functions(const LuaMadeSimple::Lua::Table& table) -> void
     {
-        Super::setup_member_functions<LuaMadeSimple::Type::IsFinal::No>(table);
-
         table.add_pair("GetSuperStruct", [](const LuaMadeSimple::Lua& lua) -> int {
             const auto& lua_object = lua.get_userdata<UStruct>();
 

--- a/deps/first/LuaMadeSimple/include/LuaMadeSimple/LuaObject.hpp
+++ b/deps/first/LuaMadeSimple/include/LuaMadeSimple/LuaObject.hpp
@@ -62,6 +62,9 @@ namespace RC::LuaMadeSimple::Type
     template <typename ObjectType>
     class LocalObject : public BaseObject
     {
+    public:
+        static constexpr bool IsLocal = true;
+
       private:
         ObjectType m_local_storage;
 
@@ -71,7 +74,17 @@ namespace RC::LuaMadeSimple::Type
         }
 
       public:
+        auto static construct(const LuaMadeSimple::Lua& lua, [[maybe_unused]] BaseObject& construct_to) -> const LuaMadeSimple::Lua::Table
+        {
+            return lua.prepare_new_table();
+        }
+
         auto get_local_cpp_object() -> ObjectType&
+        {
+            return m_local_storage;
+        }
+
+        auto get_local_cpp_object() const -> const ObjectType&
         {
             return m_local_storage;
         }
@@ -81,6 +94,9 @@ namespace RC::LuaMadeSimple::Type
     template <typename ObjectType>
     class RemoteObject : public BaseObject
     {
+    public:
+        static constexpr bool IsLocal = false;
+
       private:
         ObjectType* m_cpp_object;
 


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

There are a few Lua types that are not correctly inherited from their base types.
There are also some classes that incorrectly called `Super::setup_member_functions` which is problematic because that function is already called by the `construct` function, meaning that we end up with two calls to `setup_member_functions`
This has now been fixed.

For future types, prefer to implement inheritance by calling the appropriate `construct` function when possible.

I also decided to document and enforce some hidden behavior with the UScriptStruct inheritance, because it's rather special, and it's important we keep an eye on it so it doesn't break in the future.

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
