### PR TITLE
fix: use-after-free in ensure_str_const string intern pool (dangling string_view keys)

### DIFF
--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -82,6 +82,8 @@ Added `FUObjectItem`, `FUObjectArray`, and `TUObjectArray` to MemberVariableLayo
 
 Fixed the ingame console (Tilde, or F10 key) not working for some games - ([UE4SS #1252](https://github.com/UE4SS-RE/RE-UE4SS/pull/1252))
 
+Fixed random crashes (use-after-free) caused by the string intern pool storing dangling pointers to caller-owned strings, most commonly Lua GC'd strings from UObject member access ([UE4SS #1271](https://github.com/UE4SS-RE/RE-UE4SS/pull/1271))
+
 ### Live View 
 Added search filter: `IncludeClassNames`. ([UE4SS #472](https://github.com/UE4SS-RE/RE-UE4SS/pull/472)) - Buckminsterfullerene
 

--- a/deps/first/Helpers/include/Helpers/String.hpp
+++ b/deps/first/Helpers/include/Helpers/String.hpp
@@ -597,13 +597,25 @@ namespace RC
     }
     auto inline ensure_str_const(std::string_view input) -> const StringType&
     {
-        static std::unordered_map<std::string_view, StringType> uestringpool;
+        // The pool key must OWN its characters: callers pass string_views into
+        // caller-managed memory (e.g. Lua GC'd strings via lua_tostring), so a
+        // string_view key dangles after the caller's buffer dies and every later
+        // bucket compare reads freed memory (EXCEPTION_ACCESS_VIOLATION).
+        struct TransparentStringHash
+        {
+            using is_transparent = void;
+            auto operator()(std::string_view value) const -> size_t
+            {
+                return std::hash<std::string_view>{}(value);
+            }
+        };
+        static std::unordered_map<std::string, StringType, TransparentStringHash, std::equal_to<>> uestringpool;
         static std::shared_mutex uestringpool_lock;
 
         // Allow multiple readers that are stalled when any thread is writing.
         {
             std::shared_lock<std::shared_mutex> read_guard(uestringpool_lock);
-            if (uestringpool.contains(input)) return uestringpool[input];
+            if (auto existing_entry = uestringpool.find(input); existing_entry != uestringpool.end()) return existing_entry->second;
         }
 
         auto temp_input = std::string{input};
@@ -612,7 +624,7 @@ namespace RC
         // Stall the readers to insert a new string.
         {
             std::lock_guard<std::shared_mutex> write_guard(uestringpool_lock);
-            const auto& [emplaced_iter, unused] = uestringpool.emplace(input, std::move(new_str));
+            const auto& [emplaced_iter, unused] = uestringpool.try_emplace(std::move(temp_input), std::move(new_str));
             return emplaced_iter->second;
         }
     }


### PR DESCRIPTION
**Description**

`ensure_str_const` in `deps/first/Helpers/include/Helpers/String.hpp` interns strings in a static `std::unordered_map<std::string_view, StringType>` and stores the **caller's** `string_view` as the map key. The hottest caller passes Lua-owned memory (`LuaUObject.hpp` `prepare_to_handle` → `ensure_str_const(lua.get_string())`, i.e. `lua_tostring`), so once Lua's GC collects that string the pool key dangles permanently; any later lookup that probes the same bucket compares against freed memory → `EXCEPTION_ACCESS_VIOLATION`. Full analysis with the symbolized production crash stack in #1270.

This PR makes the pool own its keys:

- Key type `std::string_view` → owning `std::string`.
- Transparent hash (`is_transparent`) + `std::equal_to<>` so the read path stays a heterogeneous `find(string_view)` — no allocation per lookup on the hot path.
- `emplace(input, ...)` → `try_emplace(std::move(temp_input), ...)` — the stored key is the owning copy rather than the caller's view, and two threads racing past the shared-lock miss stay benign (the losing insert is a no-op).

Fixes #1270

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How has this been tested?**

- The crash was observed live on a production The Isle Evrima (UE 5.6) dedicated server (crash dump `UECC-Windows-927DBA734C4020C1674876B6ADE5A076`; stack in #1270 — `memcpy` ← `xhash` bucket probe ← `String.hpp:606` ← `LuaUObject.hpp` `prepare_to_handle`).
- Rebuilt `UE4SS.dll` with this patch and deployed it to that server on 2026-06-11; no recurrence under the same Lua mod workload that previously triggered it.
- The failure is allocator-timing dependent, so there is no deterministic repro on a stock allocator. With PageHeap (`gflags /p /enable <exe> /full`) or ASan, the unpatched code faults on the first bucket collision after a Lua GC pass; the patched code does not.

**Checklist**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.

**Additional context**

The same hazard exists for any caller passing a transient buffer — Lua strings are just the most common way to hit it, because the signature (`string_view` in, view stored as key) invites it. Owning keys closes the whole class, not just the Lua path.
