### PR TITLE
fix!: rename misspelled bEnableSeachByMemoryAddress variable

### DIFF
--- a/UE4SS/src/SettingsManager.cpp
+++ b/UE4SS/src/SettingsManager.cpp
@@ -87,7 +87,7 @@ namespace RC
         REGISTER_INT64_SETTING(General.SecondsToScanBeforeGivingUp, section_general, SecondsToScanBeforeGivingUp)
         REGISTER_BOOL_SETTING(General.UseUObjectArrayCache, section_general, bUseUObjectArrayCache)
         REGISTER_BOOL_SETTING(General.DoEarlyScan, section_general, DoEarlyScan)
-        REGISTER_BOOL_SETTING(General.SearchByAddress, section_general, bEnableSeachByMemoryAddress)
+        REGISTER_BOOL_SETTING(General.SearchByAddress, section_general, bEnableSearchByMemoryAddress)
         StringType default_exec_method_string{};
         REGISTER_STRING_SETTING(default_exec_method_string, section_general, DefaultExecuteInGameThreadMethod)
         if (String::iequal(default_exec_method_string, STR("ProcessEvent")))

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -1260,3 +1260,4 @@ Changelog from 1.3.4
 New
 
 	* Fixed a bug in the UHT generator that caused some properties to have the "Export" parameter for the UPROPERTY macro instead of "Instanced".
+	* Fixed a typo in bEnableSearchByMemoryAddress variable name and INI configuration keys.

--- a/assets/CustomGameConfigs/Crash Bandicoot 4/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Crash Bandicoot 4/UE4SS-settings.ini
@@ -54,7 +54,7 @@ DoEarlyScan = 0
 
 ; When the search query in the Live View tab is a hex number, try to find the UObject that contains that memory address.
 ; Default: false
-bEnableSeachByMemoryAddress = false
+bEnableSearchByMemoryAddress = false
 
 ; The default execution method for ExecuteInGameThread Lua function.
 ; Valid values (case-insensitive): EngineTick, ProcessEvent

--- a/assets/CustomGameConfigs/Drainsim/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Drainsim/UE4SS-settings.ini
@@ -54,7 +54,7 @@ DoEarlyScan = 0
 
 ; When the search query in the Live View tab is a hex number, try to find the UObject that contains that memory address.
 ; Default: false
-bEnableSeachByMemoryAddress = false
+bEnableSearchByMemoryAddress = false
 
 ; The default execution method for ExecuteInGameThread Lua function.
 ; Valid values (case-insensitive): EngineTick, ProcessEvent

--- a/assets/CustomGameConfigs/Far Far West/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Far Far West/UE4SS-settings.ini
@@ -54,7 +54,7 @@ DoEarlyScan = 0
 
 ; When the search query in the Live View tab is a hex number, try to find the UObject that contains that memory address.
 ; Default: false
-bEnableSeachByMemoryAddress = false
+bEnableSearchByMemoryAddress = false
 
 ; The default execution method for ExecuteInGameThread Lua function.
 ; Valid values (case-insensitive): EngineTick, ProcessEvent

--- a/assets/CustomGameConfigs/Satisfactory/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Satisfactory/UE4SS-settings.ini
@@ -54,7 +54,7 @@ DoEarlyScan = 0
 
 ; When the search query in the Live View tab is a hex number, try to find the UObject that contains that memory address.
 ; Default: false
-bEnableSeachByMemoryAddress = false
+bEnableSearchByMemoryAddress = false
 
 ; The default execution method for ExecuteInGameThread Lua function.
 ; Valid values (case-insensitive): EngineTick, ProcessEvent

--- a/assets/CustomGameConfigs/Star Wars Jedi Survivor/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Star Wars Jedi Survivor/UE4SS-settings.ini
@@ -54,7 +54,7 @@ DoEarlyScan = 0
 
 ; When the search query in the Live View tab is a hex number, try to find the UObject that contains that memory address.
 ; Default: false
-bEnableSeachByMemoryAddress = false
+bEnableSearchByMemoryAddress = false
 
 ; The default execution method for ExecuteInGameThread Lua function.
 ; Valid values (case-insensitive): EngineTick, ProcessEvent

--- a/assets/CustomGameConfigs/StarRupture/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/StarRupture/UE4SS-settings.ini
@@ -54,7 +54,7 @@ DoEarlyScan = 0
 
 ; When the search query in the Live View tab is a hex number, try to find the UObject that contains that memory address.
 ; Default: false
-bEnableSeachByMemoryAddress = false
+bEnableSearchByMemoryAddress = false
 
 ; The default execution method for ExecuteInGameThread Lua function.
 ; Valid values (case-insensitive): EngineTick, ProcessEvent

--- a/assets/CustomGameConfigs/The Outer Worlds 2/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/The Outer Worlds 2/UE4SS-settings.ini
@@ -47,7 +47,7 @@ DoEarlyScan = 0
 
 ; When the search query in the Live View tab is a hex number, try to find the UObject that contains that memory address.
 ; Default: false
-bEnableSeachByMemoryAddress = false
+bEnableSearchByMemoryAddress = false
 
 ; The default execution method for ExecuteInGameThread Lua function.
 ; Valid values (case-insensitive): EngineTick, ProcessEvent

--- a/assets/CustomGameConfigs/The Quarry/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/The Quarry/UE4SS-settings.ini
@@ -54,7 +54,7 @@ DoEarlyScan = 0
 
 ; When the search query in the Live View tab is a hex number, try to find the UObject that contains that memory address.
 ; Default: false
-bEnableSeachByMemoryAddress = false
+bEnableSearchByMemoryAddress = false
 
 ; The default execution method for ExecuteInGameThread Lua function.
 ; Valid values (case-insensitive): EngineTick, ProcessEvent

--- a/assets/CustomGameConfigs/Vein/UE4SS-settings.ini
+++ b/assets/CustomGameConfigs/Vein/UE4SS-settings.ini
@@ -54,7 +54,7 @@ DoEarlyScan = 0
 
 ; When the search query in the Live View tab is a hex number, try to find the UObject that contains that memory address.
 ; Default: false
-bEnableSeachByMemoryAddress = false
+bEnableSearchByMemoryAddress = false
 
 ; The default execution method for ExecuteInGameThread Lua function.
 ; Valid values (case-insensitive): EngineTick, ProcessEvent

--- a/assets/UE4SS-settings.ini
+++ b/assets/UE4SS-settings.ini
@@ -54,7 +54,7 @@ DoEarlyScan = 0
 
 ; When the search query in the Live View tab is a hex number, try to find the UObject that contains that memory address.
 ; Default: false
-bEnableSeachByMemoryAddress = false
+bEnableSearchByMemoryAddress = false
 
 ; The default execution method for ExecuteInGameThread Lua function.
 ; Valid values (case-insensitive): EngineTick, ProcessEvent


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

Corrected a typo in the `bEnableSearchByMemoryAddress` variable name, which was previously misspelled as `bEnableSeachByMemoryAddress`. This change ensures consistency across the C++ source code and all associated configuration template INI files.

<!-- Fixes # (issue) (if applicable) -->

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Breaking change: Renamed variable to fix typo
- [x] Other: Corrected a typo in a configuration variable name.

**How has this been tested?**
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration. -->
Verified by performing a global search for the misspelled variable throughout the repository to ensure all instances were covered. Confirmed that the new variable name is correctly reflected in `SettingsManager.cpp` and all template INI files.

**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.

**Screenshots**
<!--Add screenshots to help explain your PR, if applicable.-->


**Additional context**
<!-- Add any other context about the pull request here. -->
Renamed `bEnableSeachByMemoryAddress` to `bEnableSearchByMemoryAddress` to fix a spelling error. All references in the source code and template INI files have been updated.