### PR TITLE
feat: Add '-DRC_ENABLE_SEH_MACRO_WRAPPERS=ON' to enable SEH_TRY/SEH_CATCH

### DIFF
--- a/UE4SS/include/ExceptionHandling.hpp
+++ b/UE4SS/include/ExceptionHandling.hpp
@@ -15,10 +15,16 @@
         printf_s("Internal Error: %s\n", e.what());                                                                                                            \
     }
 
+#ifndef SEH_DISABLE
+#define SEH_DISABLE 1
+#endif
+
+#if SEH_DISABLE
 // Defining empty TRY/EXCEPT to disable the system.
 // This is because people have reported instability with it enabled.
 #define SEH_TRY(Code) Code
 #define SEH_EXCEPT(...)
+#endif
 
 // These macros should never be used in header files because you are required to include Windows.h.
 #ifdef _WIN32

--- a/cmake/modules/ProjectConfig.cmake
+++ b/cmake/modules/ProjectConfig.cmake
@@ -20,6 +20,13 @@ option(UE4SS_INPUT_ENABLED "Enable the input system" ON)
 option(ENABLE_IDE_SOURCE_VISIBILITY "Enable IDE visibility for source files" ON)
 option(UE4SS_SUPPRESS_THIRD_PARTY_WARNINGS "Suppress warnings from third-party libraries" ON)
 option(UE4SS_VERSION_CHECK "Enable compiler version checking" ON)
+option(RC_ENABLE_SEH_MACRO_WRAPPERS "Enable the SEH_TRY/SEH_EXCEPT macros, used for logging exceptions" OFF)
+
+if (RC_ENABLE_SEH_MACRO_WRAPPERS)
+    set(RC_ENABLE_SEH_MACROS_DEFINITION "SEH_DISABLE=0")
+else ()
+    set(RC_ENABLE_SEH_MACROS_DEFINITION "")
+endif ()
 
 # Profiler configuration
 # Default to None - users can opt-in to Tracy or Superluminal if needed
@@ -30,9 +37,9 @@ set_property(CACHE RC_PROFILER_FLAVOR PROPERTY STRINGS Tracy Superluminal None)
 set(UE4SS_PROXY_PATH "" CACHE FILEPATH "Path to DLL for proxy generation (empty = use default dwmapi.dll)")
 
 # Target type definitions (UE4-style)
-set(UE4SS_Game_DEFINITIONS UE_GAME)
-set(UE4SS_CasePreserving_DEFINITIONS ${UE4SS_Game_DEFINITIONS} WITH_CASE_PRESERVING_NAME)
-set(UE4SS_LessEqual421_DEFINITIONS ${UE4SS_Game_DEFINITIONS} FNAME_ALIGN8 LESSEQUAL421)
+set(UE4SS_Game_DEFINITIONS ${RC_ENABLE_SEH_MACROS_DEFINITION} UE_GAME)
+set(UE4SS_CasePreserving_DEFINITIONS ${UE4SS_Game_DEFINITIONS} ${RC_ENABLE_SEH_MACROS_DEFINITION} WITH_CASE_PRESERVING_NAME)
+set(UE4SS_LessEqual421_DEFINITIONS ${UE4SS_Game_DEFINITIONS} ${RC_ENABLE_SEH_MACROS_DEFINITION} FNAME_ALIGN8 LESSEQUAL421)
 
 # Target type flags (can be customized per target)
 set(UE4SS_Game_FLAGS "")


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

These macros were forcefully disabled because some end-users were having problems with them. This commit adds a CMake option that re-enables them, which is useful for developers.

These macros are currently only used when calling the FName constructor, and FName::ToString.
It notifies via a message to the log file whenever either of these calls causes a crash of the game.

Like this:
```log
[2026-06-14 23:18:25.9443080] Error: Crashed calling FName::ToString.
```