### PR TITLE
fix: Crash due to incorrectly popping Lua stack (regression)

### DIFF
--- a/UE4SS/src/Mod/LuaMod.cpp
+++ b/UE4SS/src/Mod/LuaMod.cpp
@@ -3798,12 +3798,20 @@ Overloads:
                     LuaType::auto_construct_object(*exec.lua, exec.constructed_object);
                     exec.lua->call_function(1, 1);
 
-                    bool cancel = exec.lua->is_bool(-1) && exec.lua->get_bool(-1);
-                    lua_pop(exec.lua->get_lua_state(), 1); // Pop the return value
-                    if (cancel)
+                    if (exec.lua->is_bool(-1))
                     {
-                        thread_refs_to_unref.emplace_back(exec.lua->get_lua_state(), exec.lua_callback_thread_ref);
-                        callbacks_to_remove.insert(exec.callback_id);
+                        // get_bool pops the value from the stack, so we shouldn't call lua_pop explicitly.
+                        bool cancel = exec.lua->get_bool(-1);
+                        if (cancel)
+                        {
+                            thread_refs_to_unref.emplace_back(exec.lua->get_lua_state(), exec.lua_callback_thread_ref);
+                            callbacks_to_remove.insert(exec.callback_id);
+                        }
+                    }
+                    else
+                    {
+                        // No bool means we didn't call get_bool, which means the value wasn't popped from the stack, therefore we must explicitly call lua_pop.
+                        lua_pop(exec.lua->get_lua_state(), 1);
                     }
                 });
             }


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes a regression introduced in #1269

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

**How has this been tested?**
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration. -->

In Palworld, this code causes a crash without this PR:
```lua
NotifyOnNewObject("/Game/Pal/Blueprint/MapObject/Object/LevelObject/BP_LevelObject_TowerFastTravelPoint.BP_LevelObject_TowerFastTravelPoint_C", function()
    return true
end)
```