### PR TITLE
fix: Returning self when a field doesn't exist

### DIFF
--- a/UE4SS/src/LuaType/LuaUObject.cpp
+++ b/UE4SS/src/LuaType/LuaUObject.cpp
@@ -2168,7 +2168,7 @@ Overloads:
             else
             {
                 // Construct an empty object to allow for safe chaining with a validity check at the end
-                LuaType::UObject::construct(lua, nullptr);
+                lua.set_nil();
             }
 
             return;

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -349,6 +349,9 @@ Large performance increase when `Apply filters when not searching` is enabled ([
 ### UHT Dumper 
 
 ### Lua API 
+
+`nil` is now returned if a field or function doesn't exist in an object ([UE4SS #1292](https://github.com/UE4SS-RE/RE-UE4SS/pull/1292))
+
 `print` now behaves like vanilla Lua (can now accept zero, one, or multiple arguments of any type) ([UE4SS #423](https://github.com/UE4SS-RE/RE-UE4SS/pull/423)) - Lyrth 
 
 The callback of `NotifyOnNewObject` can now optionally return `true` to unregister itself ([UE4SS #432](https://github.com/UE4SS-RE/RE-UE4SS/pull/432)) - Lyrth 

--- a/deps/first/LuaMadeSimple/src/LuaMadeSimple.cpp
+++ b/deps/first/LuaMadeSimple/src/LuaMadeSimple.cpp
@@ -536,6 +536,7 @@ namespace RC::LuaMadeSimple
 
         // Create the '__index' metamethod
         // This one will always exist but the user supplied callable might not
+        // This is necessary otherwise attached variables and functions won't be found
         metatable.add_pair("__index", [](const LuaMadeSimple::Lua& lua) -> int {
             if (lua.is_userdata(-2))
             {
@@ -569,7 +570,14 @@ namespace RC::LuaMadeSimple
 
                     if (user_callables.index.has_value())
                     {
+                        // Let user callback push the final value.
                         user_callables.index.value()(lua);
+                    }
+                    else
+                    {
+                        // No user callback means value wasn't found.
+                        // Let's return nil to stay consistent with how Lua normally works.
+                        lua.set_nil();
                     }
                 }
             }


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

For example, `FText("Test").aaa` would return a reference of the same FText that tried to access `aaa` instead of nil

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.