### PR TITLE
fix:  Crash when throwing Lua errors when there's no error Lua handler

### DIFF
--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -502,6 +502,8 @@ Fixed callbacks being executed in the wrong thread. ([UE4SS #1170](https://githu
 
 Fixed UFunction and UClass properly inheriting from UStruct in Lua. ([UE4SS #1158](https://github.com/UE4SS-RE/RE-UE4SS/pull/1158)) - Corporalwill123
 
+Fixed crash when calling certain functions that take callbacks. ([UE4SS #1299](https://github.com/UE4SS-RE/RE-UE4SS/pull/1299))
+
 ### C++ API 
 Fixed a crash caused by a race condition enabled by C++ mods using `UE4SS_ENABLE_IMGUI` in their constructor ([UE4SS #481](https://github.com/UE4SS-RE/RE-UE4SS/pull/481)) 
 

--- a/deps/first/LuaMadeSimple/src/LuaMadeSimple.cpp
+++ b/deps/first/LuaMadeSimple/src/LuaMadeSimple.cpp
@@ -5,6 +5,7 @@
 
 #include <LuaMadeSimple/LuaMadeSimple.hpp>
 #include <LuaMadeSimple/LuaObject.hpp>
+#include <lstate.h>
 
 #include <Helpers/String.hpp>
 
@@ -1063,7 +1064,16 @@ namespace RC::LuaMadeSimple
         auto final_message = handle_error(lua_state, error_message);
 
         lua_state_errors.emplace(lua_state, final_message);
-        luaL_error(lua_state, final_message.c_str());
+        // Do C++ throw if there aren't any Lua handlers, it means this function may have been called outside a protected Lua function.
+        // This normally happens while setting up a callback into Lua, often via get_function_ref.
+        if (!lua_state->errorJmp && !lua_state->l_G->mainthread->errorJmp)
+        {
+            throw std::runtime_error{final_message};
+        }
+        else
+        {
+            luaL_error(lua_state, final_message.c_str());
+        }
     }
 
     auto new_state() -> Lua&


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

We have a habit of calling `lua.throw_error` for anything Lua related, but the problem is that there's sometimes no Lua error handler because the error happens before the pcall occurs.
We can just do a regular C++ throw if there's no Lua error handler.

See point 2 in this comment for an unrelated issue: https://github.com/UE4SS-RE/RE-UE4SS/issues/1180#issuecomment-4686894303

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

**How has this been tested?**
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration. -->

Put a bunch of `lua.throw` statements in locations where calls to `get_function_ref` occur and verify that doesn't crash.

**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.

