### PR TITLE
feat: Add support for using mod name as the main dll name for C++ mods

### DIFF
--- a/UE4SS/include/Mod/CppMod.hpp
+++ b/UE4SS/include/Mod/CppMod.hpp
@@ -23,7 +23,7 @@ namespace RC
         typedef void (*uninstall_type)(CppUserModBase*);
 
       private:
-        StringType m_dll_filename;
+        StringType m_dll_filename{};
         std::filesystem::path m_dlls_path;
 
         Unreal::Windows::HMODULE m_main_dll_module = NULL;

--- a/UE4SS/include/Mod/CppMod.hpp
+++ b/UE4SS/include/Mod/CppMod.hpp
@@ -23,6 +23,7 @@ namespace RC
         typedef void (*uninstall_type)(CppUserModBase*);
 
       private:
+        StringType m_dll_filename;
         std::filesystem::path m_dlls_path;
 
         Unreal::Windows::HMODULE m_main_dll_module = NULL;

--- a/UE4SS/src/Mod/CppMod.cpp
+++ b/UE4SS/src/Mod/CppMod.cpp
@@ -22,6 +22,21 @@ namespace RC
         }
 
         auto dll_path = m_dlls_path / STR("main.dll");
+        if (!std::filesystem::exists(dll_path))
+        {
+            dll_path = m_dlls_path / fmt::format(STR("{}.dll"), mod_name);
+
+            if (!std::filesystem::exists(dll_path))
+            {
+                Output::send<LogLevel::Warning>(STR("Failed to load C++ mod {}, dlls folder must contain either main.dll or {}\n"),
+                                                m_mod_name, ensure_str(dll_path.filename()));
+                set_installable(false);
+                return;
+            }
+        }
+
+        m_dll_filename = ensure_str(dll_path.filename());
+
         // Add mods dlls directory to search path for dynamic/shared linked libraries in mods
         m_dlls_path_cookie = AddDllDirectory(m_dlls_path.c_str());
         m_main_dll_module = LoadLibraryExW(dll_path.c_str(), NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
@@ -61,7 +76,7 @@ namespace RC
             if (!Output::has_internal_error())
             {
                 Output::send<LogLevel::Warning>(STR("Failed to load dll <{}> for mod {}, because: {}\n"),
-                                                ensure_str((m_dlls_path / STR("main.dll"))),
+                                                ensure_str((m_dlls_path / m_dll_filename)),
                                                 m_mod_name,
                                                 ensure_str(e.what()));
             }

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -252,6 +252,8 @@ Added support for handling structs as userdata (Fixed `StructData as userdata is
 
 ### C++ API 
 
+Added support for using mod name as the dll name for C++ mods. - Okaetsu
+
 Added `UDataTable` class to C++ API. ([UE4SS #997](https://github.com/UE4SS-RE/RE-UE4SS/pull/997))
 - Full DataTable row access with `FindRow<T>()`, `GetAllRows<T>()`, and `ForEachRow<T>()`
 - Row manipulation with `AddRow()`, `RemoveRow()`, and `EmptyTable()`

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -252,7 +252,7 @@ Added support for handling structs as userdata (Fixed `StructData as userdata is
 
 ### C++ API 
 
-Added support for using mod name as the dll name for C++ mods. - Okaetsu
+Added support for using mod name as the main dll name for C++ mods. ([UE4SS #1313](https://github.com/UE4SS-RE/RE-UE4SS/pull/1313)) - Okaetsu
 
 Added `UDataTable` class to C++ API. ([UE4SS #997](https://github.com/UE4SS-RE/RE-UE4SS/pull/997))
 - Full DataTable row access with `FindRow<T>()`, `GetAllRows<T>()`, and `ForEachRow<T>()`

--- a/docs/guides/installing-a-c++-mod.md
+++ b/docs/guides/installing-a-c++-mod.md
@@ -9,6 +9,8 @@
     - Create a folder structure in `Mods` that looks like `MyAwesomeMod\dlls`. 
     - Move `MyAwesomeMod.dll` inside the `dlls` folder and rename it to `main.dll`.
 
+> NOTE: `MyAwesomeMod.dll` will also work and UE4SS will use `MyAwesomeMod.dll` if `main.dll` isn't present.
+
 The result should look like:
 ```
 Mods\


### PR DESCRIPTION
**Description**
Allows C++ mods to use the mod name for their main dll, for example if the mod is called `MyAwesomeMod` then you can use `MyAwesomeMod.dll` as the dll name.

This is a fallback, so it'll default to looking for `main.dll` first like before and then `MyAwesomeMod.dll` if `main.dll` wasn't found.

This change makes it slightly easier to work with C++ mods that want to link to another C++ mod where both mods rely on UE4SS, however load order is still something that needs to be accounted for which means the dependency mod must be loaded first before the other mods that depend on it.

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Is/requires documentation update

**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
