### PR TITLE
Add await_debugger function and documentation on how to debug C++ mods

### DIFF
--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -303,6 +303,8 @@ Added improved string and path conversion utilities with proper UTF-8 support ([
 - Added `utf8_to_wpath()` to convert UTF-8 paths to Windows wide strings
 - **BREAKING:** `to_charT_string_path()` now returns UTF-8 encoded strings for char type instead of locale-dependent encoding
 
+Added `RC::await_debugger` in `Helpers/Debug.hpp`. ([UE4SS #1314](https://github.com/UE4SS-RE/RE-UE4SS/pull/1314))
+
 ### BPModLoader 
 
 ### Experimental 

--- a/deps/first/Helpers/CMakeLists.txt
+++ b/deps/first/Helpers/CMakeLists.txt
@@ -8,6 +8,7 @@ set(${TARGET}_Sources
         "${CMAKE_CURRENT_SOURCE_DIR}/src/Casting.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/SysError.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/Time.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/Debug.cpp"
         )
 
 string(REGEX REPLACE "(.)([A-Z])" "\\1_\\2" MODULE_NAME ${TARGET})

--- a/deps/first/Helpers/include/Helpers/Debug.hpp
+++ b/deps/first/Helpers/include/Helpers/Debug.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace RC
+{
+    /**
+     * @brief Waits for a debugger on the current thread. Currently, windows only.
+     * @details Invokes `IsDebuggerPresent` in a loop. You should call this before any breakpoints you set. Note that this makes no stability guarantees;
+     * Unreal is multithreaded, so there could be issues if you hold the game thread for too long. In most cases, you'll at least be able to step through
+     * the code you want to debug. Setting your IDE to automatically attach itself to the game process can alleviate/eliminate these issues.
+     * @note This function is not actually deprecated; it's marked as such to yell at you for calling it in order to make it harder to accidentally use it
+     * in a release/public build.
+     */
+    [[deprecated("await_debugger called! This should only be used for development.")]]
+    auto await_debugger() -> void;
+}

--- a/deps/first/Helpers/src/Debug.cpp
+++ b/deps/first/Helpers/src/Debug.cpp
@@ -1,0 +1,22 @@
+#include <Helpers/Debug.hpp>
+
+#if defined(WIN32) || defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <thread>
+#include <chrono>
+
+auto RC::await_debugger() -> void
+{
+    while (!IsDebuggerPresent())
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+}
+
+#else
+
+#warning "await_debugger not supported on non-Windows platforms!"
+auto RC::await_debugger() -> void {}
+
+#endif

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -121,6 +121,7 @@
   - [Installing a C++ Mod](./guides/installing-a-c++-mod.md)
   - [GUI tabs with a C++ Mod](./guides/creating-gui-tabs-with-c++-mod.md)
   - [Accessing UE properties with a C++ mod](./guides/accessing-ue-properties-c++.md)
+  - [Debugging a C++ Mod](./guides/debugging-a-c++-mod.md)
 
 ## Guides
 

--- a/docs/guides/debugging-a-c++-mod.md
+++ b/docs/guides/debugging-a-c++-mod.md
@@ -1,0 +1,22 @@
+# Debugging a C++ Mod
+
+Logging can only get you so far. Sometimes, you may want to set a breakpoint and inspect the callstack and variables directly. This guide will show you how.
+
+Note that this guide is also a completely valid way to debug UE4SS itself.
+
+## Prerequisites
+This guide assumes you already know how to use a debugger. If you don't, check your IDE's guides; here's a few:
+* [Visual Studio](https://learn.microsoft.com/en-us/visualstudio/debugger/debugger-feature-tour?view=visualstudio)
+* [CLion](https://www.jetbrains.com/help/clion/debugging-code.html#useful-debugger-shortcuts)
+* [VS Code](https://code.visualstudio.com/docs/cpp/cpp-debug)
+
+## The Process
+1. Add `#include <Helpers/Debug.hpp>` near the top of the file you want to debug.
+2. At some point before your breakpoint is hit, call `RC::await_debugger()`. This will stop execution on the current thread until a debugger is connected. 
+3. Attach your debugger to the game's process. Refer to your IDE's guides on how exactly to do this, though this option is usually under a `Run` or `Debug` menu. The executable you want to debug is usually the one that's next to the `ue4ss` folder in your game directory.
+   * Alternatively, set your IDE's debugger to automatically attach itself to an executable when it launches.
+4. The breakpoint will be hit!
+
+## Important Caveats
+* There are no stability guarantees. Unreal is multithreaded, so there could be issues if you hold the game thread for too long. In most cases, you'll at least be able to step through the code you want to debug. Setting your IDE to automatically attach itself to the game process can alleviate/eliminate these issues.
+* `RC::await_debugger()` is marked as deprecated, so the compiler will scream at you for using it. This is intentional; this should never be called in a release/public build of your mod or UE4SS. *It's not actually deprecated.*


### PR DESCRIPTION
**Description**
Adds a function under `Helpers/Debug.hpp` to wait for a debugger to connect, and updates documentation on how to debug a C++ mod. Utilizes `IsDebuggerPresent` in a debounced loop from the Windows API, which is the most stable option for UE4SS' unique environment (other methods for setting a breakpoint or waiting for a debugger tends to crash).

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

**How has this been tested?**
Used personally for a while; extremely trivial and not used by default anywhere. 

**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.

