### PR TITLE
Revert "fix: Returning self when a field doesn't exist"

### DIFF
--- a/UE4SS/src/LuaType/LuaUObject.cpp
+++ b/UE4SS/src/LuaType/LuaUObject.cpp
@@ -2168,7 +2168,7 @@ Overloads:
             else
             {
                 // Construct an empty object to allow for safe chaining with a validity check at the end
-                lua.set_nil();
+                LuaType::UObject::construct(lua, nullptr);
             }
 
             return;

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -355,9 +355,6 @@ Large performance increase when `Apply filters when not searching` is enabled ([
 ### UHT Dumper 
 
 ### Lua API 
-
-`nil` is now returned if a field or function doesn't exist in an object ([UE4SS #1292](https://github.com/UE4SS-RE/RE-UE4SS/pull/1292))
-
 `print` now behaves like vanilla Lua (can now accept zero, one, or multiple arguments of any type) ([UE4SS #423](https://github.com/UE4SS-RE/RE-UE4SS/pull/423)) - Lyrth 
 
 The callback of `NotifyOnNewObject` can now optionally return `true` to unregister itself ([UE4SS #432](https://github.com/UE4SS-RE/RE-UE4SS/pull/432)) - Lyrth 

--- a/deps/first/LuaMadeSimple/src/LuaMadeSimple.cpp
+++ b/deps/first/LuaMadeSimple/src/LuaMadeSimple.cpp
@@ -537,7 +537,6 @@ namespace RC::LuaMadeSimple
 
         // Create the '__index' metamethod
         // This one will always exist but the user supplied callable might not
-        // This is necessary otherwise attached variables and functions won't be found
         metatable.add_pair("__index", [](const LuaMadeSimple::Lua& lua) -> int {
             if (lua.is_userdata(-2))
             {
@@ -571,14 +570,7 @@ namespace RC::LuaMadeSimple
 
                     if (user_callables.index.has_value())
                     {
-                        // Let user callback push the final value.
                         user_callables.index.value()(lua);
-                    }
-                    else
-                    {
-                        // No user callback means value wasn't found.
-                        // Let's return nil to stay consistent with how Lua normally works.
-                        lua.set_nil();
                     }
                 }
             }


### PR DESCRIPTION
Reverts UE4SS-RE/RE-UE4SS#1292

It turns out to be a breaking change.
We'll create another fix, probably a function like `IsValidField` or something like that which will return `false` if the property or function doesn't exist.
Usage:
```lua
-- Function
local PostBeginPlay = Context.PostBeginPlay
if PostBeginPlay:IsValidField() then
    PostBeginPlay()
end

-- Property
local PlayerController = FindFirstOf("PlayerController")
local aaa = PlayerController.aaa
if not aaa:IsValidField() then
    print("Not valid\n")
end
```