### PR TITLE
feat: Add 'IsValidField'

### DIFF
--- a/UE4SS/include/LuaType/LuaUObject.hpp
+++ b/UE4SS/include/LuaType/LuaUObject.hpp
@@ -454,7 +454,10 @@ namespace RC::LuaType
         // Constructor for UObject
         auto static construct(const LuaMadeSimple::Lua& lua, DerivedType* unreal_object) -> const LuaMadeSimple::Lua::Table
         {
-            add_to_global_unreal_objects_map(unreal_object);
+            if (unreal_object != LuaMadeSimple::Type::special_invalid_ptr())
+            {
+                add_to_global_unreal_objects_map(unreal_object);
+            }
 
             SelfType lua_object{unreal_object};
 
@@ -753,8 +756,8 @@ Overloads:
 
             table.add_pair("IsValid", [](const LuaMadeSimple::Lua& lua) -> int {
                 const auto& lua_object = lua.get_userdata<SelfType>();
-                if (lua_object.get_remote_cpp_object() && is_object_in_global_unreal_object_map(lua_object.get_remote_cpp_object()) &&
-                    !lua_object.get_remote_cpp_object()->IsUnreachable())
+                if (lua_object.get_remote_cpp_object() && lua_object.get_remote_cpp_object() != LuaMadeSimple::Type::special_invalid_ptr() &&
+                    is_object_in_global_unreal_object_map(lua_object.get_remote_cpp_object()) && !lua_object.get_remote_cpp_object()->IsUnreachable())
                 {
                     lua.set_bool(true);
                 }

--- a/UE4SS/src/LuaType/LuaUObject.cpp
+++ b/UE4SS/src/LuaType/LuaUObject.cpp
@@ -2167,8 +2167,9 @@ Overloads:
             }
             else
             {
-                // Construct an empty object to allow for safe chaining with a validity check at the end
-                LuaType::UObject::construct(lua, nullptr);
+                // Construct an empty object, this is for compatibility reasons because people may have written code that takes for granted that
+                // all objects are userdata even invalid fields and functions being accessed from a valid UObject.
+                LuaMadeSimple::Type::RemoteObject<Unreal::UObject>::construct(lua, static_cast<Unreal::UObject*>(LuaMadeSimple::Type::special_invalid_ptr()));
             }
 
             return;

--- a/deps/first/LuaMadeSimple/include/LuaMadeSimple/LuaObject.hpp
+++ b/deps/first/LuaMadeSimple/include/LuaMadeSimple/LuaObject.hpp
@@ -26,6 +26,14 @@ namespace RC::LuaMadeSimple::Type
         LuaMadeSimple::Lua::MetaMethods metamethods;
     };
 
+    // Can be used to track special states within the pointer value if you know the pointer is otherwise nullptr.
+    // 'IsValid' for RemoteObject will return false even when the internal pointer is set to this value.
+    // It's used to enable 'IsValidField' to return true even when 'IsValid' returns false, which can be useful for reflection systems.
+    static constexpr auto special_invalid_ptr()
+    {
+        return reinterpret_cast<void*>(std::numeric_limits<uintptr_t>::max() - 0x1000);
+    }
+
     class RC_LMS_API BaseObject
     {
       private:
@@ -112,9 +120,9 @@ namespace RC::LuaMadeSimple::Type
         // This function cannot be used if you want to inherit from RemoteObject
         auto static construct(const LuaMadeSimple::Lua& lua, ObjectType* object_ptr) -> const LuaMadeSimple::Lua::Table
         {
-            RemoteObject<ObjectType> lua_object{object_ptr};
-
             auto metatable_name = "TrivialObject";
+
+            RemoteObject<ObjectType> lua_object{metatable_name, object_ptr};
 
             LuaMadeSimple::Lua::Table table = lua.get_metatable(metatable_name);
             if (lua.is_nil(-1))
@@ -168,14 +176,13 @@ namespace RC::LuaMadeSimple::Type
                 }
 
                 const RemoteObject& lua_object = lua.get_userdata<RemoteObject>();
-                if (lua_object.get_remote_cpp_object())
-                {
-                    lua.set_bool(true);
-                }
-                else
-                {
-                    lua.set_bool(false);
-                }
+                lua.set_bool(lua_object.m_cpp_object && lua_object.m_cpp_object != special_invalid_ptr());
+                return 1;
+            });
+
+            table.add_pair("IsValidField", [](const LuaMadeSimple::Lua& lua) -> int {
+                auto& lua_object = lua.get_userdata<RemoteObject>();
+                lua.set_bool(lua_object.m_cpp_object != special_invalid_ptr());
                 return 1;
             });
 

--- a/deps/first/LuaMadeSimple/src/LuaMadeSimple.cpp
+++ b/deps/first/LuaMadeSimple/src/LuaMadeSimple.cpp
@@ -537,6 +537,7 @@ namespace RC::LuaMadeSimple
 
         // Create the '__index' metamethod
         // This one will always exist but the user supplied callable might not
+        // This is necessary otherwise attached variables and functions won't be found
         metatable.add_pair("__index", [](const LuaMadeSimple::Lua& lua) -> int {
             if (lua.is_userdata(-2))
             {
@@ -570,7 +571,14 @@ namespace RC::LuaMadeSimple
 
                     if (user_callables.index.has_value())
                     {
+                        // Let user callback push the final value.
                         user_callables.index.value()(lua);
+                    }
+                    else
+                    {
+                        // No user callback means value wasn't found.
+                        // Let's return nil to stay consistent with how Lua normally works.
+                        lua.set_nil();
                     }
                 }
             }


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

Adds 'IsValidField' to RemoteObject, including UObject.
It returns `true` if the field (i.e. property or function) exists in the UObject regardless if `IsValid` would return false because of a nullptr.

See test section for example of usage.

Fixes #1284 

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

**How has this been tested?**
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration. -->

Run this code when GameModeBase exists.
For me in Palworld, that's at the main menu.

```lua
RegisterKeyBind(Key.K, {ModifierKey.CONTROL}, function()
    local GameMode = FindFirstOf("GameModeBase")
    if GameMode:IsValid() then
        print(string.format("GameMode: %s\n", GameMode:GetFullName()))
    else
        print("GameMode not valid\n")
        return
    end

    if GameMode.aaa:IsValidField() then
        print("aaa:IsValidField(): YES\n")
    else
        print("aaa:IsValidField(): NO\n")
    end
    if GameMode.aaa:IsValid() then
        print("aaa:IsValid(): YES\n")
    else
        print("aaa:IsValid(): NO\n")
    end

    if GameMode.GameState:IsValidField() then
        print("GameState:IsValidField(): YES\n")
    else
        print("GameState:IsValidField(): NO\n")
    end
    if GameMode.GameState:IsValid() then
        print("GameState:IsValid(): YES\n")
    else
        print("GameState:IsValid(): NO\n")
    end
    GameMode.GameState = nil
    if GameMode.GameState:IsValidField() then
        print("GameState:IsValidField(): YES\n")
    else
        print("GameState:IsValidField(): NO\n")
    end
    if GameMode.GameState:IsValid() then
        print("GameState:IsValid(): YES\n")
    else
        print("GameState:IsValid(): NO\n")
    end
end)
```

Expected outcome:
```
aaa:IsReflected(): NO
aaa:IsValid(): NO
GameState:IsReflected(): YES
GameState:IsValid(): YES
GameState:IsReflected(): YES
GameState:IsValid(): NO
```

You can create a universal function that can handle LocalObject as well, if you want that for some reason:
```lua
local function IsValidField(Object, Field)
    if type(Field) ~= "string" then return false end
    if Object[Field].IsValidField then
        return Object[Field]:IsValidField()
    else
        return Object[Field]
    end
end
```