### PR TITLE
Change constexpr to inline in special_invalid_ptr

### DIFF
--- a/deps/first/LuaMadeSimple/include/LuaMadeSimple/LuaObject.hpp
+++ b/deps/first/LuaMadeSimple/include/LuaMadeSimple/LuaObject.hpp
@@ -29,7 +29,7 @@ namespace RC::LuaMadeSimple::Type
     // Can be used to track special states within the pointer value if you know the pointer is otherwise nullptr.
     // 'IsValid' for RemoteObject will return false even when the internal pointer is set to this value.
     // It's used to enable 'IsValidField' to return true even when 'IsValid' returns false, which can be useful for reflection systems.
-    static constexpr auto special_invalid_ptr()
+    static inline auto special_invalid_ptr()
     {
         return reinterpret_cast<void*>(std::numeric_limits<uintptr_t>::max() - 0x1000);
     }


### PR DESCRIPTION
**Description**
Newer MSVC versions (14.44+) are stricter and reject using reinterpret_cast inside the constexpr function special_invalid_ptr. Since this function is only ever used at runtime anyway, removing the constexpr specifier fixes the following build error:
`error C3615: constexpr function 'special_invalid_ptr' cannot result in a constant expression`

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How has this been tested?**
Built UE4SS from source and a C++ mod against this header with MSVC 14.44+