### PR TITLE
fix(LuaMod): keep the shared hook thread anchored for the mod's lifetime

### DIFF
--- a/UE4SS/src/Mod/LuaMod.cpp
+++ b/UE4SS/src/Mod/LuaMod.cpp
@@ -756,11 +756,12 @@ namespace RC
         {
             // First use - create new thread and anchor it in the registry
             mod->m_hook_lua = &mod->lua().new_thread();
-            int thread_ref = luaL_ref(mod->lua().get_lua_state(), LUA_REGISTRYINDEX);
-            return thread_ref;
+            luaL_ref(mod->lua().get_lua_state(), LUA_REGISTRYINDEX);
         }
 
-        // Thread already exists and is already anchored
+        // The thread is shared by every hook of the mod, so it stays anchored for the mod's
+        // lifetime. Giving the anchor's ref away would let one callback unref it on teardown
+        // and GC a state the other hooks still use.
         return LUA_REFNIL;
     }
 


### PR DESCRIPTION
First half of #1345.

`ensure_hook_thread_exists` hands the registry ref of the mod's **shared** hook thread to whichever caller creates it first:

```cpp
mod->m_hook_lua = &mod->lua().new_thread();
int thread_ref = luaL_ref(mod->lua().get_lua_state(), LUA_REGISTRYINDEX);
return thread_ref;
```

That caller keeps it as its own `lua_thread_ref` and unrefs it on teardown (LuaMod.cpp:254, and :6528 where a NotifyOnNewObject callback returning true "releases the thread_ref to GC"). The thread is shared, so that drops the only anchor: Lua collects the state while `m_hook_lua` still points at it and is never reset, and every other hook of the mod keeps running on freed memory.

This anchors the thread once for the mod's lifetime and always returns LUA_REFNIL. `luaL_unref` ignores negative refs, so the teardown call sites keep working untouched.

Found on a Palworld dedicated server (Linux, via tc-imba's port) but the code is shared, so Windows should be affected the same way. Running with this for a while now, mods that register hooks and tear callbacks down are stable.

The other half of #1345 (Lua running concurrently from the async and game threads) is a design question, so I left it out of this PR.