### PR TITLE
fix: Misbehaving wofstream causing UTF-16 characters to not be outputted properly

### DIFF
--- a/UE4SS/src/SDKGenerator/UEHeaderGenerator.cpp
+++ b/UE4SS/src/SDKGenerator/UEHeaderGenerator.cpp
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <format>
-#include <fstream>
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
@@ -2045,7 +2044,7 @@ namespace RC::UEGenerator
 
         bool previous_character_was_hex = false;
         const CharType* ptr = string.c_str();
-        
+
         while (CharType ch = *ptr++)
         {
             switch (ch)
@@ -4245,14 +4244,8 @@ namespace RC::UEGenerator
         // TODO might be slow, maybe move it out into the header generator?
         std::filesystem::create_directories(this->m_full_file_path.parent_path());
 
-        std::basic_ofstream<CharType> file_output_stream;
-        file_output_stream.open(m_full_file_path);
-        if (!file_output_stream.is_open())
-        {
-            throw std::invalid_argument("Failed to open the header file");
-        }
-        file_output_stream << generate_file_contents();
-        file_output_stream.close();
+        auto file = File::open(m_full_file_path, File::OpenFor::Writing, File::OverwriteExistingFile::Yes, File::CreateIfNonExistent::Yes);
+        file.write_string_to_file(generate_file_contents());
         return true;
     }
 

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -459,6 +459,8 @@ Fixed filters incorrectly being applied when not searching ([UE4SS #1089](https:
 ### UHT Dumper 
 Fix SetupAttachment implementations randomly changing order ([UE4SS #606](https://github.com/UE4SS-RE/RE-UE4SS/pull/606)) - Buckminsterfullerene 
 
+Fix non-ascii characters in outputted .cpp files ([UE4SS #1378](https://github.com/UE4SS-RE/RE-UE4SS/pull/1378))  
+
 ### Lua API 
 Fixed FString use after free ([UE4SS #425](https://github.com/UE4SS-RE/RE-UE4SS/pull/425)) - localcc 
 


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

We'll use our own File abstraction instead which isn't misbehaving.

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

**How has this been tested?**
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration. -->

Open the live view, find a CDO with a `TEXT` property, edit the value to something that's not ascii, like this for example: `Вещи` and then use the UHT dumper and see whether there's a cpp file generated that abruptly ends with `TEXT("`


**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.