### PR TITLE
Automatic stack traces for errors

### DIFF
--- a/UE4SS/CMakeLists.txt
+++ b/UE4SS/CMakeLists.txt
@@ -115,6 +115,7 @@ target_compile_definitions(UE4SS PRIVATE
     RC_JSON_PARSER_BUILD_STATIC
     RC_LUA_WRAPPER_GENERATOR_BUILD_STATIC
     RC_HELPERS_BUILD_STATIC
+    RC_CALL_STACK_DEBUG_BUILD_STATIC
 )
 
 # ---------------------------------------------------------------------------

--- a/UE4SS/CMakeLists.txt
+++ b/UE4SS/CMakeLists.txt
@@ -127,6 +127,7 @@ target_compile_definitions(UE4SS PRIVATE
     RC_JSON_PARSER_BUILD_STATIC
     RC_LUA_WRAPPER_GENERATOR_BUILD_STATIC
     RC_HELPERS_BUILD_STATIC
+    RC_CALL_STACK_DEBUG_BUILD_STATIC
 )
 
 # ---------------------------------------------------------------------------

--- a/UE4SS/src/GUI/ConsoleOutputDevice.cpp
+++ b/UE4SS/src/GUI/ConsoleOutputDevice.cpp
@@ -38,7 +38,7 @@ namespace RC::Output
 #if RC_STACKTRACE_ENABLED
         if (static_cast<LogLevel::LogLevel>(optional_arg) == LogLevel::Error)
         {
-            const auto trace_string = to_string(CallStackDebug::generate_call_stack());
+            const auto trace_string = to_string(CallStackDebug::get_call_stack());
             std::stringstream stack_stream{trace_string};
             for (std::string line; std::getline(stack_stream, line);)
             {

--- a/UE4SS/src/GUI/ConsoleOutputDevice.cpp
+++ b/UE4SS/src/GUI/ConsoleOutputDevice.cpp
@@ -4,16 +4,7 @@
 
 #include <GUI/ConsoleOutputDevice.hpp>
 #include <UE4SSProgram.hpp>
-
-#if __cpp_lib_stacktrace >= RC_REQ_STACKTRACE_MIN_VER
-#include <stacktrace>
-#endif
-
-#if _WIN32
-#define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
-#include <Windows.h>
-#endif
+#include <CallStackDebug/CallStackDebug.hpp>
 
 namespace RC::Output
 {
@@ -44,15 +35,10 @@ namespace RC::Output
         {
             UE4SSProgram::get_program().get_debugging_ui().get_console().add_line(line, color);
         }
-#if __cpp_lib_stacktrace >= RC_REQ_STACKTRACE_MIN_VER
+#if RC_STACKTRACE_ENABLED
         if (static_cast<LogLevel::LogLevel>(optional_arg) == LogLevel::Error)
         {
-            if (auto module = GetModuleHandleW(L"ntdll.dll"); module && GetProcAddress(module, "wine_get_version"))
-            {
-                UE4SSProgram::get_program().get_debugging_ui().get_console().add_line("Wine detected, stack trace might be incorrect!", Color::Yellow);
-            }
-            const auto trace = std::stacktrace::current();
-            const auto trace_string = std::to_string(trace);
+            const auto trace_string = to_string(CallStackDebug::generate_call_stack());
             std::stringstream stack_stream{trace_string};
             for (std::string line; std::getline(stack_stream, line);)
             {

--- a/UE4SS/src/GUI/ConsoleOutputDevice.cpp
+++ b/UE4SS/src/GUI/ConsoleOutputDevice.cpp
@@ -5,6 +5,16 @@
 #include <GUI/ConsoleOutputDevice.hpp>
 #include <UE4SSProgram.hpp>
 
+#if __cpp_lib_stacktrace >= RC_REQ_STACKTRACE_MIN_VER
+#include <stacktrace>
+#endif
+
+#if _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <Windows.h>
+#endif
+
 namespace RC::Output
 {
     auto ConsoleDevice::has_optional_arg() const -> bool
@@ -34,6 +44,22 @@ namespace RC::Output
         {
             UE4SSProgram::get_program().get_debugging_ui().get_console().add_line(line, color);
         }
+#if __cpp_lib_stacktrace >= RC_REQ_STACKTRACE_MIN_VER
+        if (static_cast<LogLevel::LogLevel>(optional_arg) == LogLevel::Error)
+        {
+            if (auto module = GetModuleHandleW(L"ntdll.dll"); module && GetProcAddress(module, "wine_get_version"))
+            {
+                UE4SSProgram::get_program().get_debugging_ui().get_console().add_line("Wine detected, stack trace might be incorrect!", Color::Yellow);
+            }
+            const auto trace = std::stacktrace::current();
+            const auto trace_string = std::to_string(trace);
+            std::stringstream stack_stream{trace_string};
+            for (std::string line; std::getline(stack_stream, line);)
+            {
+                UE4SSProgram::get_program().get_debugging_ui().get_console().add_line(line, Color::Red);
+            }
+        }
+#endif
 #endif
     }
 } // namespace RC::Output

--- a/deps/first/CMakeLists.txt
+++ b/deps/first/CMakeLists.txt
@@ -18,6 +18,7 @@ add_subdirectory("ScopedTimer")
 add_subdirectory("SinglePassSigScanner")
 add_subdirectory("Unreal")
 add_subdirectory("Profiler")
+add_subdirectory("CallStackDebug")
 
 # Add our Rust components for IDE visibility
 if(DEFINED ENABLE_IDE_SOURCE_VISIBILITY AND ENABLE_IDE_SOURCE_VISIBILITY)

--- a/deps/first/CallStackDebug/CMakeLists.txt
+++ b/deps/first/CallStackDebug/CMakeLists.txt
@@ -9,6 +9,8 @@ set(${TARGET}_Sources
         "${CMAKE_CURRENT_SOURCE_DIR}/src/CallStackDebug.cpp"
         )
 
+string(REGEX REPLACE "(.)([A-Z])" "\\1_\\2" MODULE_NAME ${TARGET})
+string(TOUPPER ${MODULE_NAME} MODULE_NAME)
 
 if (UE4SS_ASM_HELPER_BUILD_SHARED)
     message("Project: ${TARGET} (SHARED)")
@@ -29,8 +31,6 @@ target_compile_definitions(${TARGET} PRIVATE
 if (NOT ${UE4SS_${TARGET}_BUILD_SHARED})
     target_compile_definitions(${TARGET} PRIVATE
             RC_FILE_BUILD_STATIC
-            RC_DYNAMIC_OUTPUT_BUILD_STATIC
-            RC_SINGLE_PASS_SIG_SCANNER_BUILD_STATIC
             RC_HELPERS_BUILD_STATIC
     )
 endif ()

--- a/deps/first/CallStackDebug/CMakeLists.txt
+++ b/deps/first/CallStackDebug/CMakeLists.txt
@@ -1,20 +1,16 @@
 cmake_minimum_required(VERSION 3.22)
 
-set(TARGET DynamicOutput)
+set(TARGET CallStackDebug)
 project(${TARGET})
 
 option(UE4SS_${TARGET}_BUILD_SHARED "Build as a shared lib" OFF)
 
 set(${TARGET}_Sources
-        "${CMAKE_CURRENT_SOURCE_DIR}/src/DebugConsoleDevice.cpp"
-        "${CMAKE_CURRENT_SOURCE_DIR}/src/Output.cpp"
-        "${CMAKE_CURRENT_SOURCE_DIR}/src/OutputDevice.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/CallStackDebug.cpp"
         )
 
-string(REGEX REPLACE "(.)([A-Z])" "\\1_\\2" MODULE_NAME ${TARGET})
-string(TOUPPER ${MODULE_NAME} MODULE_NAME)
 
-if (UE4SS_${TARGET}_BUILD_SHARED)
+if (UE4SS_ASM_HELPER_BUILD_SHARED)
     message("Project: ${TARGET} (SHARED)")
     add_library(${TARGET} SHARED ${${TARGET}_Sources})
 else ()
@@ -30,9 +26,18 @@ target_compile_definitions(${TARGET} PRIVATE
         $<$<NOT:$<BOOL:${UE4SS_${TARGET}_BUILD_SHARED}>>:
             RC_${MODULE_NAME}_BUILD_STATIC>)
 
+if (NOT ${UE4SS_${TARGET}_BUILD_SHARED})
+    target_compile_definitions(${TARGET} PRIVATE
+            RC_FILE_BUILD_STATIC
+            RC_DYNAMIC_OUTPUT_BUILD_STATIC
+            RC_SINGLE_PASS_SIG_SCANNER_BUILD_STATIC
+            RC_HELPERS_BUILD_STATIC
+    )
+endif ()
+
 target_include_directories(${TARGET} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-target_link_libraries(${TARGET} PUBLIC File CallStackDebug)
+target_link_libraries(${TARGET} PUBLIC File Helpers)
 
 # Make headers visible in the IDE
 # Uses make_headers_visible() from cmake/modules/IDEVisibility.cmake

--- a/deps/first/CallStackDebug/LICENSE
+++ b/deps/first/CallStackDebug/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Narknon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/deps/first/CallStackDebug/include/CallStackDebug/CallStackDebug.hpp
+++ b/deps/first/CallStackDebug/include/CallStackDebug/CallStackDebug.hpp
@@ -14,4 +14,4 @@
 namespace RC::CallStackDebug
 {
     auto RC_CALL_STACK_DEBUG_API generate_call_stack() -> StringType;
-} // namespace RC::PDB
+} // namespace RC::CallStackDebug

--- a/deps/first/CallStackDebug/include/CallStackDebug/CallStackDebug.hpp
+++ b/deps/first/CallStackDebug/include/CallStackDebug/CallStackDebug.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <CallStackDebug/Common.hpp>
+#include <String/StringType.hpp>
+
+#ifndef RC_REQ_STACKTRACE_MIN_VER
+#define RC_REQ_STACKTRACE_MIN_VER 202011L
+#endif
+
+#ifndef RC_STACKTRACE_ENABLED
+#define RC_STACKTRACE_ENABLED __cpp_lib_stacktrace >= RC_REQ_STACKTRACE_MIN_VER
+#endif
+
+namespace RC::CallStackDebug
+{
+    auto RC_CALL_STACK_DEBUG_API generate_call_stack() -> StringType;
+} // namespace RC::PDB

--- a/deps/first/CallStackDebug/include/CallStackDebug/CallStackDebug.hpp
+++ b/deps/first/CallStackDebug/include/CallStackDebug/CallStackDebug.hpp
@@ -13,5 +13,6 @@
 
 namespace RC::CallStackDebug
 {
-    auto RC_CALL_STACK_DEBUG_API generate_call_stack() -> StringType;
+    auto RC_CALL_STACK_DEBUG_API generate_new_call_stack() -> void;
+    auto RC_CALL_STACK_DEBUG_API get_call_stack() -> StringType;
 } // namespace RC::CallStackDebug

--- a/deps/first/CallStackDebug/include/CallStackDebug/CallStackDebug.hpp
+++ b/deps/first/CallStackDebug/include/CallStackDebug/CallStackDebug.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include <CallStackDebug/Common.hpp>
 #include <String/StringType.hpp>
 
@@ -13,6 +15,21 @@
 
 namespace RC::CallStackDebug
 {
-    auto RC_CALL_STACK_DEBUG_API generate_new_call_stack() -> void;
+    using ModuleNameAndOffsetPair = std::pair<StringType, size_t>;
+    using CallStackWithoutSymbols = std::vector<ModuleNameAndOffsetPair>;
+
+    // Generates a new call stack.
+    // Leave the CallStackWithoutSymbols param empty to use the current stack context.
+    auto RC_CALL_STACK_DEBUG_API generate_new_call_stack(const CallStackWithoutSymbols& = {}) -> void;
+
+    // Get the latest call stack trace.
+    // Remember to generate a trace before calling this function.
     auto RC_CALL_STACK_DEBUG_API get_call_stack() -> StringType;
+
+    // Returns a call stack without symbols attached, useful when debugging symbols are unavailable.
+    // A use-case would be to serialize module + RIP pairs for symbolication later when debugging symbols are available.
+    auto RC_CALL_STACK_DEBUG_API get_unsymbolized_call_stack() -> CallStackWithoutSymbols;
+
+    // Turns module + RIP pairs into a symbolized call stack.
+    auto RC_CALL_STACK_DEBUG_API symbolicate_call_stack(const CallStackWithoutSymbols&) -> StringType;
 } // namespace RC::CallStackDebug

--- a/deps/first/CallStackDebug/include/CallStackDebug/Common.hpp
+++ b/deps/first/CallStackDebug/include/CallStackDebug/Common.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#ifndef RC_CALL_STACK_DEBUG__EXPORTS
-#ifndef RC_CALL_STACK_DEBUG__BUILD_STATIC
+#ifndef RC_CALL_STACK_DEBUG_EXPORTS
+#ifndef RC_CALL_STACK_DEBUG_BUILD_STATIC
 #ifndef RC_CALL_STACK_DEBUG_API
 #define RC_CALL_STACK_DEBUG_API __declspec(dllimport)
 #endif

--- a/deps/first/CallStackDebug/include/CallStackDebug/Common.hpp
+++ b/deps/first/CallStackDebug/include/CallStackDebug/Common.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#ifndef RC_CALL_STACK_DEBUG__EXPORTS
+#ifndef RC_CALL_STACK_DEBUG__BUILD_STATIC
+#ifndef RC_CALL_STACK_DEBUG_API
+#define RC_CALL_STACK_DEBUG_API __declspec(dllimport)
+#endif
+#else
+#ifndef RC_CALL_STACK_DEBUG_API
+#define RC_CALL_STACK_DEBUG_API
+#endif
+#endif
+#else
+#ifndef RC_CALL_STACK_DEBUG_API
+#define RC_CALL_STACK_DEBUG_API __declspec(dllexport)
+#endif
+#endif

--- a/deps/first/CallStackDebug/src/CallStackDebug.cpp
+++ b/deps/first/CallStackDebug/src/CallStackDebug.cpp
@@ -18,9 +18,11 @@
 
 namespace RC::CallStackDebug
 {
-    auto generate_call_stack() -> StringType
+    thread_local StringType s_call_stack_cache{};
+
+    auto generate_new_call_stack() -> void
     {
-        StringType call_stack_string{};
+        s_call_stack_cache.clear();
         const auto trace = std::stacktrace::current();
         // Skipping entry 0 because that's this function, and we're assuming the user is not interested in this code.
         for (size_t i = 1; i < trace.size(); ++i)
@@ -33,13 +35,15 @@ namespace RC::CallStackDebug
                 HANDLE debug_handle{};
                 if (!DuplicateHandle(current_process, current_process, current_process, &debug_handle, 0, false, DUPLICATE_SAME_ACCESS))
                 {
-                    return fmt::format(STR("Error when generating call stack: DuplicateHandle returned error: 0x{:X}\n"), GetLastError());
+                    s_call_stack_cache = fmt::format(STR("Error when generating call stack: DuplicateHandle returned error: 0x{:X}\n"), GetLastError());
+                    return;
                 }
                 if (!SymInitialize(debug_handle, nullptr, true))
                 {
-                    return fmt::format(STR("Error when generating call stack: SymInitialize returned error: 0x{:X}\n"), GetLastError());
+                    s_call_stack_cache = fmt::format(STR("Error when generating call stack: SymInitialize returned error: 0x{:X}\n"), GetLastError());
+                    return;
                 }
-                call_stack_string.append(fmt::format(STR("[{}] "), i - 1));
+                s_call_stack_cache.append(fmt::format(STR("[{}] "), i - 1));
                 char buffer[sizeof(SYMBOL_INFO) + MAX_SYM_NAME * sizeof(TCHAR)];
                 auto symbol_info = reinterpret_cast<PSYMBOL_INFO>(buffer);
                 symbol_info->SizeOfStruct = sizeof(SYMBOL_INFO);
@@ -48,22 +52,30 @@ namespace RC::CallStackDebug
                 if (SymFromAddr(debug_handle, original_address, &sym_from_addr_displacement, symbol_info))
                 {
                     const auto name_ascii_view = symbol_info->Name;
-                    call_stack_string.append(ensure_str(name_ascii_view));
+                    s_call_stack_cache.append(ensure_str(name_ascii_view));
                     IMAGEHLP_LINE64 line{};
                     line.SizeOfStruct = sizeof(IMAGEHLP_LINE64);
                     DWORD sym_get_line_from_addr64_displacement{};
                     if (SymGetLineFromAddr64(debug_handle, original_address, &sym_get_line_from_addr64_displacement, &line))
                     {
-                        call_stack_string.append(fmt::format(STR(" in '{}' @ L{}"), ensure_str(line.FileName), line.LineNumber));
+                        s_call_stack_cache.append(fmt::format(STR(" in '{}' @ L{}"), ensure_str(line.FileName), line.LineNumber));
                     }
                 }
                 else
                 {
-                    call_stack_string.append(STR("Unknown"));
+                    s_call_stack_cache.append(STR("Unknown"));
                 }
-                call_stack_string.append(STR("\n"));
+                s_call_stack_cache.append(STR("\n"));
             }
         }
-        return call_stack_string;
+    }
+
+    auto get_call_stack() -> StringType
+    {
+        if (s_call_stack_cache.empty())
+        {
+            generate_new_call_stack();
+        }
+        return s_call_stack_cache;
     }
 } // namespace RC::PDB

--- a/deps/first/CallStackDebug/src/CallStackDebug.cpp
+++ b/deps/first/CallStackDebug/src/CallStackDebug.cpp
@@ -20,8 +20,34 @@ namespace RC::CallStackDebug
 {
     thread_local StringType s_call_stack_cache{};
 
+    template <typename Callable>
+    struct Cleanup
+    {
+        Callable cleanup_callable{};
+        ~Cleanup()
+        {
+            cleanup_callable();
+        }
+    };
+
     auto generate_new_call_stack() -> void
     {
+        SymSetOptions(SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS | SYMOPT_LOAD_LINES);
+        const HANDLE current_process = GetCurrentProcess();
+        HANDLE debug_handle{};
+        if (!DuplicateHandle(current_process, current_process, current_process, &debug_handle, 0, false, DUPLICATE_SAME_ACCESS))
+        {
+            s_call_stack_cache = fmt::format(STR("Error when generating call stack: DuplicateHandle returned error: 0x{:X}\n"), GetLastError());
+            return;
+        }
+        if (!SymInitialize(debug_handle, nullptr, true))
+        {
+            s_call_stack_cache = fmt::format(STR("Error when generating call stack: SymInitialize returned error: 0x{:X}\n"), GetLastError());
+            return;
+        }
+        auto cleanup = Cleanup([&]() {
+            SymCleanup(debug_handle);
+        });
         s_call_stack_cache.clear();
         const auto trace = std::stacktrace::current();
         // Skipping entry 0 because that's this function, and we're assuming the user is not interested in this code.
@@ -30,19 +56,6 @@ namespace RC::CallStackDebug
             const auto& current_frame = trace[i];
             const auto original_address = reinterpret_cast<uintptr_t>(current_frame.native_handle());
             {
-                SymSetOptions(SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS | SYMOPT_LOAD_LINES);
-                const HANDLE current_process = GetCurrentProcess();
-                HANDLE debug_handle{};
-                if (!DuplicateHandle(current_process, current_process, current_process, &debug_handle, 0, false, DUPLICATE_SAME_ACCESS))
-                {
-                    s_call_stack_cache = fmt::format(STR("Error when generating call stack: DuplicateHandle returned error: 0x{:X}\n"), GetLastError());
-                    return;
-                }
-                if (!SymInitialize(debug_handle, nullptr, true))
-                {
-                    s_call_stack_cache = fmt::format(STR("Error when generating call stack: SymInitialize returned error: 0x{:X}\n"), GetLastError());
-                    return;
-                }
                 s_call_stack_cache.append(fmt::format(STR("[{}] "), i - 1));
                 char buffer[sizeof(SYMBOL_INFO) + MAX_SYM_NAME * sizeof(TCHAR)];
                 auto symbol_info = reinterpret_cast<PSYMBOL_INFO>(buffer);

--- a/deps/first/CallStackDebug/src/CallStackDebug.cpp
+++ b/deps/first/CallStackDebug/src/CallStackDebug.cpp
@@ -1,0 +1,69 @@
+#include <CallStackDebug/CallStackDebug.hpp>
+#include <Helpers/String.hpp>
+#include <fmt/core.h>
+#include <fmt/xchar.h>
+
+#if RC_STACKTRACE_ENABLED
+#include <stacktrace>
+#endif
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <Windows.h>
+#include <DbgHelp.h>
+#else
+#error "CallStackDebug is only supported on Windows"
+#endif
+
+namespace RC::CallStackDebug
+{
+    auto generate_call_stack() -> StringType
+    {
+        StringType call_stack_string{};
+        const auto trace = std::stacktrace::current();
+        // Skipping entry 0 because that's this function, and we're assuming the user is not interested in this code.
+        for (size_t i = 1; i < trace.size(); ++i)
+        {
+            const auto& current_frame = trace[i];
+            const auto original_address = reinterpret_cast<uintptr_t>(current_frame.native_handle());
+            {
+                SymSetOptions(SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS | SYMOPT_LOAD_LINES);
+                const HANDLE current_process = GetCurrentProcess();
+                HANDLE debug_handle{};
+                if (!DuplicateHandle(current_process, current_process, current_process, &debug_handle, 0, false, DUPLICATE_SAME_ACCESS))
+                {
+                    return fmt::format(STR("Error when generating call stack: DuplicateHandle returned error: 0x{:X}\n"), GetLastError());
+                }
+                if (!SymInitialize(debug_handle, nullptr, true))
+                {
+                    return fmt::format(STR("Error when generating call stack: SymInitialize returned error: 0x{:X}\n"), GetLastError());
+                }
+                call_stack_string.append(fmt::format(STR("[{}] "), i - 1));
+                char buffer[sizeof(SYMBOL_INFO) + MAX_SYM_NAME * sizeof(TCHAR)];
+                auto symbol_info = reinterpret_cast<PSYMBOL_INFO>(buffer);
+                symbol_info->SizeOfStruct = sizeof(SYMBOL_INFO);
+                symbol_info->MaxNameLen = MAX_SYM_NAME;
+                DWORD64 sym_from_addr_displacement{};
+                if (SymFromAddr(debug_handle, original_address, &sym_from_addr_displacement, symbol_info))
+                {
+                    const auto name_ascii_view = symbol_info->Name;
+                    call_stack_string.append(ensure_str(name_ascii_view));
+                    IMAGEHLP_LINE64 line{};
+                    line.SizeOfStruct = sizeof(IMAGEHLP_LINE64);
+                    DWORD sym_get_line_from_addr64_displacement{};
+                    if (SymGetLineFromAddr64(debug_handle, original_address, &sym_get_line_from_addr64_displacement, &line))
+                    {
+                        call_stack_string.append(fmt::format(STR(" in '{}' @ L{}"), ensure_str(line.FileName), line.LineNumber));
+                    }
+                }
+                else
+                {
+                    call_stack_string.append(STR("Unknown"));
+                }
+                call_stack_string.append(STR("\n"));
+            }
+        }
+        return call_stack_string;
+    }
+} // namespace RC::PDB

--- a/deps/first/CallStackDebug/src/CallStackDebug.cpp
+++ b/deps/first/CallStackDebug/src/CallStackDebug.cpp
@@ -6,12 +6,15 @@
 #if RC_STACKTRACE_ENABLED
 #include <stacktrace>
 #endif
+#include <ranges>
+#include <functional>
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #include <Windows.h>
 #include <DbgHelp.h>
+#include <Psapi.h>
 #else
 #error "CallStackDebug is only supported on Windows"
 #endif
@@ -30,31 +33,79 @@ namespace RC::CallStackDebug
         }
     };
 
-    auto generate_new_call_stack() -> void
+    static constexpr auto s_module_unknown = std::pair<uintptr_t, StringType>{std::numeric_limits<uintptr_t>::max(), {}};
+    static constexpr auto s_module_unknown_by_name = std::numeric_limits<uintptr_t>::max();
+
+    // Returns module base address and name that the given address belongs to.
+    static auto get_module_from_address(void* in_address) -> std::pair<uintptr_t, StringType>
     {
-        SymSetOptions(SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS | SYMOPT_LOAD_LINES);
-        const HANDLE current_process = GetCurrentProcess();
-        HANDLE debug_handle{};
-        if (!DuplicateHandle(current_process, current_process, current_process, &debug_handle, 0, false, DUPLICATE_SAME_ACCESS))
+        const auto address = reinterpret_cast<uintptr_t>(in_address);
+        HMODULE modules[1024]{};
+        DWORD bytes_required{};
+        if (K32EnumProcessModules(GetCurrentProcess(), modules, sizeof(modules), &bytes_required) == 0)
         {
-            s_call_stack_cache = fmt::format(STR("Error when generating call stack: DuplicateHandle returned error: 0x{:X}\n"), GetLastError());
-            return;
+            return s_module_unknown;
         }
-        if (!SymInitialize(debug_handle, nullptr, true))
+
+        for (size_t i = 0; i < bytes_required / sizeof(HMODULE); ++i)
         {
-            s_call_stack_cache = fmt::format(STR("Error when generating call stack: SymInitialize returned error: 0x{:X}\n"), GetLastError());
-            return;
+            MODULEINFO info{};
+            K32GetModuleInformation(GetCurrentProcess(), modules[i], &info, sizeof(MODULEINFO));
+            const auto base = reinterpret_cast<uintptr_t>(info.lpBaseOfDll);
+            if (address >= base && address <= base + info.SizeOfImage)
+            {
+                char module_raw_name[MAX_PATH];
+                if (K32GetModuleBaseNameA(GetCurrentProcess(), modules[i], module_raw_name, sizeof(module_raw_name) / sizeof(char)) == 0)
+                {
+                    continue;
+                }
+                const auto module_name = ensure_str(module_raw_name);
+                return {base, module_name};
+            }
         }
-        auto cleanup = Cleanup([&]() {
-            SymCleanup(debug_handle);
-        });
-        s_call_stack_cache.clear();
-        const auto trace = std::stacktrace::current();
+
+        return s_module_unknown;
+    }
+
+    // Returns the base address of a module by name.
+    static auto get_module_base_from_name(StringViewType name) -> uintptr_t
+    {
+        HMODULE modules[1024]{};
+        DWORD bytes_required{};
+        if (K32EnumProcessModules(GetCurrentProcess(), modules, sizeof(modules), &bytes_required) == 0)
+        {
+            return s_module_unknown_by_name;
+        }
+
+        for (size_t i = 0; i < bytes_required / sizeof(HMODULE); ++i)
+        {
+            char module_raw_name[MAX_PATH];
+            if (K32GetModuleBaseNameA(GetCurrentProcess(), modules[i], module_raw_name, sizeof(module_raw_name) / sizeof(char)) == 0)
+            {
+                continue;
+            }
+            const auto module_name = ensure_str(module_raw_name);
+            if (name != module_name)
+            {
+                continue;
+            }
+
+            MODULEINFO info{};
+            K32GetModuleInformation(GetCurrentProcess(), modules[i], &info, sizeof(MODULEINFO));
+            const auto base = reinterpret_cast<uintptr_t>(info.lpBaseOfDll);
+            return base;
+        }
+
+        return s_module_unknown_by_name;
+    }
+
+    static auto iterate_stack_trace(HANDLE debug_handle, auto&& trace, auto frame_resolver) -> void
+    {
         // Skipping entry 0 because that's this function, and we're assuming the user is not interested in this code.
         for (size_t i = 1; i < trace.size(); ++i)
         {
             const auto& current_frame = trace[i];
-            const auto original_address = reinterpret_cast<uintptr_t>(current_frame.native_handle());
+            const uintptr_t original_address = frame_resolver(current_frame);
             {
                 s_call_stack_cache.append(fmt::format(STR("[{}] "), i - 1));
                 char buffer[sizeof(SYMBOL_INFO) + MAX_SYM_NAME * sizeof(TCHAR)];
@@ -83,12 +134,66 @@ namespace RC::CallStackDebug
         }
     }
 
+    auto generate_new_call_stack(const CallStackWithoutSymbols& call_stack) -> void
+    {
+        SymSetOptions(SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS | SYMOPT_LOAD_LINES);
+        const HANDLE current_process = GetCurrentProcess();
+        HANDLE debug_handle{};
+        if (!DuplicateHandle(current_process, current_process, current_process, &debug_handle, 0, false, DUPLICATE_SAME_ACCESS))
+        {
+            s_call_stack_cache = fmt::format(STR("Error when generating call stack: DuplicateHandle returned error: 0x{:X}\n"), GetLastError());
+            return;
+        }
+        if (!SymInitialize(debug_handle, nullptr, true))
+        {
+            s_call_stack_cache = fmt::format(STR("Error when generating call stack: SymInitialize returned error: 0x{:X}\n"), GetLastError());
+            return;
+        }
+        auto cleanup = Cleanup([&]() {
+            SymCleanup(debug_handle);
+        });
+        s_call_stack_cache.clear();
+        if (!call_stack.empty())
+        {
+            iterate_stack_trace(debug_handle, call_stack, [](const ModuleNameAndOffsetPair& pair) {
+                return get_module_base_from_name(pair.first) + pair.second;
+            });
+        }
+        else
+        {
+            const auto trace = std::stacktrace::current();
+            iterate_stack_trace(debug_handle, trace, [](const std::stacktrace_entry& entry) {
+                return reinterpret_cast<uintptr_t>(entry.native_handle());
+            });
+        }
+    }
+
     auto get_call_stack() -> StringType
     {
         if (s_call_stack_cache.empty())
         {
             generate_new_call_stack();
         }
+        return s_call_stack_cache;
+    }
+
+
+    auto get_unsymbolized_call_stack() -> CallStackWithoutSymbols
+    {
+        CallStackWithoutSymbols call_stack{};
+        const auto trace = std::stacktrace::current();
+        for (const auto& entry : trace)
+        {
+            const auto [module_base, module_name] = get_module_from_address(entry.native_handle());
+            const auto module_offset = reinterpret_cast<uintptr_t>(entry.native_handle()) - module_base;
+            call_stack.emplace_back(module_name, module_offset);
+        }
+        return call_stack;
+    }
+
+    auto symbolicate_call_stack(const CallStackWithoutSymbols& call_stack) -> StringType
+    {
+        generate_new_call_stack(call_stack);
         return s_call_stack_cache;
     }
 } // namespace RC::PDB

--- a/deps/first/DynamicOutput/CMakeLists.txt
+++ b/deps/first/DynamicOutput/CMakeLists.txt
@@ -30,6 +30,13 @@ target_compile_definitions(${TARGET} PRIVATE
         $<$<NOT:$<BOOL:${UE4SS_${TARGET}_BUILD_SHARED}>>:
             RC_${MODULE_NAME}_BUILD_STATIC>)
 
+if (NOT ${UE4SS_${TARGET}_BUILD_SHARED})
+    target_compile_definitions(${TARGET} PRIVATE
+            RC_FILE_BUILD_STATIC
+            RC_CALL_STACK_DEBUG_BUILD_STATIC
+    )
+endif ()
+
 target_include_directories(${TARGET} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 target_link_libraries(${TARGET} PUBLIC File CallStackDebug)

--- a/deps/first/DynamicOutput/include/DynamicOutput/FileDevice.hpp
+++ b/deps/first/DynamicOutput/include/DynamicOutput/FileDevice.hpp
@@ -94,7 +94,7 @@ namespace RC::Output
 #if RC_STACKTRACE_ENABLED
         if (static_cast<LogLevel::LogLevel>(optional_arg) == LogLevel::Error)
         {
-            const auto trace_string = CallStackDebug::generate_call_stack();
+            const auto trace_string = CallStackDebug::get_call_stack();
             const auto log_str = fmt::format(STR("{}\n"), trace_string);
             m_file.write_string_to_file(log_str);
         }

--- a/deps/first/DynamicOutput/include/DynamicOutput/FileDevice.hpp
+++ b/deps/first/DynamicOutput/include/DynamicOutput/FileDevice.hpp
@@ -8,12 +8,9 @@
 #include <DynamicOutput/Macros.hpp>
 #include <DynamicOutput/OutputDevice.hpp>
 #include <File/File.hpp>
+#include <CallStackDebug/CallStackDebug.hpp>
 #include <fmt/core.h>
 #include <fmt/xchar.h>
-
-#if __cpp_lib_stacktrace >= RC_REQ_STACKTRACE_MIN_VER
-#include <stacktrace>
-#endif
 
 namespace RC::Output
 {
@@ -94,17 +91,11 @@ namespace RC::Output
 
         m_file.write_string_to_file(m_formatter(fmt));
 
-#if __cpp_lib_stacktrace >= RC_REQ_STACKTRACE_MIN_VER
+#if RC_STACKTRACE_ENABLED
         if (static_cast<LogLevel::LogLevel>(optional_arg) == LogLevel::Error)
         {
-            // TODO: Move into a .cpp file so that we can ue GetModuleHandleW to detect Wine.
-            //if (auto module = GetModuleHandleW(L"ntdll.dll"); module && GetProcAddress(module, "wine_get_version"))
-            //{
-            //    m_file.write_string_to_file(STR("Wine detected, stack trace might be incorrect!\n"));
-            //}
-            const auto trace = std::stacktrace::current();
-            const auto trace_string = std::to_string(trace);
-            const auto log_str = fmt::format(STR("{}\n"), ensure_str(trace_string));
+            const auto trace_string = CallStackDebug::generate_call_stack();
+            const auto log_str = fmt::format(STR("{}\n"), trace_string);
             m_file.write_string_to_file(log_str);
         }
 #endif

--- a/deps/first/DynamicOutput/include/DynamicOutput/FileDevice.hpp
+++ b/deps/first/DynamicOutput/include/DynamicOutput/FileDevice.hpp
@@ -8,6 +8,12 @@
 #include <DynamicOutput/Macros.hpp>
 #include <DynamicOutput/OutputDevice.hpp>
 #include <File/File.hpp>
+#include <fmt/core.h>
+#include <fmt/xchar.h>
+
+#if __cpp_lib_stacktrace >= RC_REQ_STACKTRACE_MIN_VER
+#include <stacktrace>
+#endif
 
 namespace RC::Output
 {
@@ -69,9 +75,40 @@ namespace RC::Output
 
   public:
     // OutputDevice Interface -> START
+    auto has_optional_arg() const -> bool override
+    {
+        return true;
+    }
     // Due to the design of the Output system the opening of the file is done in receive instead of in the constructor
     // It's opened only once and stays open until the Output object (not the device) leaves scope
     // The destructor is responsible for closing the file
+    auto receive_with_optional_arg(File::StringViewType fmt, [[maybe_unused]] int32_t optional_arg) const -> void
+    {
+        if (!m_is_device_ready)
+        {
+            start_device();
+        }
+
+        // Do file output stuff here
+        // File should already be open & be ready for writing (happens in constructor)
+
+        m_file.write_string_to_file(m_formatter(fmt));
+
+#if __cpp_lib_stacktrace >= RC_REQ_STACKTRACE_MIN_VER
+        if (static_cast<LogLevel::LogLevel>(optional_arg) == LogLevel::Error)
+        {
+            // TODO: Move into a .cpp file so that we can ue GetModuleHandleW to detect Wine.
+            //if (auto module = GetModuleHandleW(L"ntdll.dll"); module && GetProcAddress(module, "wine_get_version"))
+            //{
+            //    m_file.write_string_to_file(STR("Wine detected, stack trace might be incorrect!\n"));
+            //}
+            const auto trace = std::stacktrace::current();
+            const auto trace_string = std::to_string(trace);
+            const auto log_str = fmt::format(STR("{}\n"), ensure_str(trace_string));
+            m_file.write_string_to_file(log_str);
+        }
+#endif
+    }
     auto receive(File::StringViewType fmt) const -> void override
     {
         if (!m_is_device_ready)

--- a/deps/first/DynamicOutput/include/DynamicOutput/Output.hpp
+++ b/deps/first/DynamicOutput/include/DynamicOutput/Output.hpp
@@ -17,6 +17,7 @@
 #include <DynamicOutput/Macros.hpp>
 #include <DynamicOutput/OutputDevice.hpp>
 #include <File/InternalFile.hpp>
+#include <CallStackDebug/CallStackDebug.hpp>
 
 #if RC_IS_ANSI == 1
 #define RC_STD_MAKE_FORMAT_ARGS fmt::make_format_args
@@ -232,6 +233,11 @@ namespace RC::Output
                 THROW_INTERNAL_FILE_ERROR("[Output::send] Attempted to send but there were no opened devices.");
             }
 
+            if (static_cast<LogLevel::LogLevel>(optional_arg) == LogLevel::Error)
+            {
+                CallStackDebug::generate_new_call_stack();
+            }
+
             for (const auto& device : m_opened_devices)
             {
                 ASSERT_OUTPUT_DEVICE_IS_VALID(device)
@@ -252,6 +258,11 @@ namespace RC::Output
             if (m_opened_devices.empty())
             {
                 THROW_INTERNAL_FILE_ERROR("[Output::send] Attempted to send but there were no opened devices.");
+            }
+
+            if (static_cast<LogLevel::LogLevel>(optional_arg) == LogLevel::Error)
+            {
+                CallStackDebug::generate_new_call_stack();
             }
 
             for (const auto& device : m_opened_devices)
@@ -363,6 +374,10 @@ namespace RC::Output
     template <int32_t optional_arg, typename... FmtArgs>
     auto send(File::StringViewType content, FmtArgs... fmt_args) -> void
     {
+        if (static_cast<LogLevel::LogLevel>(optional_arg) == LogLevel::Error)
+        {
+            CallStackDebug::generate_new_call_stack();
+        }
         for (const auto& device : DefaultTargets::get_default_devices_ref())
         {
             ASSERT_DEFAULT_OUTPUT_DEVICE_IS_VALID(device)
@@ -381,6 +396,10 @@ namespace RC::Output
     template <int32_t optional_arg>
     auto send(File::StringViewType content) -> void
     {
+        if (static_cast<LogLevel::LogLevel>(optional_arg) == LogLevel::Error)
+        {
+            CallStackDebug::generate_new_call_stack();
+        }
         for (const auto& device : DefaultTargets::get_default_devices_ref())
         {
             ASSERT_DEFAULT_OUTPUT_DEVICE_IS_VALID(device)

--- a/deps/first/DynamicOutput/include/DynamicOutput/OutputDevice.hpp
+++ b/deps/first/DynamicOutput/include/DynamicOutput/OutputDevice.hpp
@@ -5,8 +5,6 @@
 #include <DynamicOutput/Macros.hpp>
 #include <File/Macros.hpp>
 
-#define RC_REQ_STACKTRACE_MIN_VER 202011L
-
 namespace RC
 {
     // Namespaced enums are used here to make them scoped

--- a/deps/first/DynamicOutput/include/DynamicOutput/OutputDevice.hpp
+++ b/deps/first/DynamicOutput/include/DynamicOutput/OutputDevice.hpp
@@ -5,6 +5,8 @@
 #include <DynamicOutput/Macros.hpp>
 #include <File/Macros.hpp>
 
+#define RC_REQ_STACKTRACE_MIN_VER 202011L
+
 namespace RC
 {
     // Namespaced enums are used here to make them scoped

--- a/deps/first/DynamicOutput/src/DebugConsoleDevice.cpp
+++ b/deps/first/DynamicOutput/src/DebugConsoleDevice.cpp
@@ -4,6 +4,10 @@
 #include <DynamicOutput/DebugConsoleDevice.hpp>
 #include <DynamicOutput/Output.hpp>
 
+#if __cpp_lib_stacktrace >= RC_REQ_STACKTRACE_MIN_VER
+#include <stacktrace>
+#endif
+
 #ifdef _WIN32
 #define NOMINMAX
 #include <Windows.h>
@@ -50,6 +54,18 @@ namespace RC::Output
         RC_DEVICE_PRINT_FUNC(fmt, optional_arg, "DebugConsoleDevice received: ")
 #else
         RC_DEVICE_PRINT_FUNC(fmt, optional_arg, "")
+#if __cpp_lib_stacktrace >= RC_REQ_STACKTRACE_MIN_VER
+        if (static_cast<LogLevel::LogLevel>(optional_arg) == LogLevel::Error)
+        {
+            if (auto module = GetModuleHandleW(L"ntdll.dll"); module && GetProcAddress(module, "wine_get_version"))
+            {
+                RC_DEVICE_PRINT_FUNC(STR("Wine detected, stack trace might be incorrect!"), Color::Yellow, "")
+            }
+            const auto trace = std::stacktrace::current();
+            const auto trace_string = std::to_string(trace);
+            RC_DEVICE_PRINT_FUNC(ensure_str(trace_string), Color::Red, "")
+        }
+#endif
 #endif
     }
 } // namespace RC::Output

--- a/deps/first/DynamicOutput/src/DebugConsoleDevice.cpp
+++ b/deps/first/DynamicOutput/src/DebugConsoleDevice.cpp
@@ -54,7 +54,7 @@ namespace RC::Output
 #if RC_STACKTRACE_ENABLED
         if (static_cast<LogLevel::LogLevel>(optional_arg) == LogLevel::Error)
         {
-            const auto trace_string = CallStackDebug::generate_call_stack();
+            const auto trace_string = CallStackDebug::get_call_stack();
             RC_DEVICE_PRINT_FUNC(trace_string, Color::Red, "")
         }
 #endif

--- a/deps/first/DynamicOutput/src/DebugConsoleDevice.cpp
+++ b/deps/first/DynamicOutput/src/DebugConsoleDevice.cpp
@@ -3,10 +3,7 @@
 
 #include <DynamicOutput/DebugConsoleDevice.hpp>
 #include <DynamicOutput/Output.hpp>
-
-#if __cpp_lib_stacktrace >= RC_REQ_STACKTRACE_MIN_VER
-#include <stacktrace>
-#endif
+#include <CallStackDebug/CallStackDebug.hpp>
 
 #ifdef _WIN32
 #define NOMINMAX
@@ -54,16 +51,11 @@ namespace RC::Output
         RC_DEVICE_PRINT_FUNC(fmt, optional_arg, "DebugConsoleDevice received: ")
 #else
         RC_DEVICE_PRINT_FUNC(fmt, optional_arg, "")
-#if __cpp_lib_stacktrace >= RC_REQ_STACKTRACE_MIN_VER
+#if RC_STACKTRACE_ENABLED
         if (static_cast<LogLevel::LogLevel>(optional_arg) == LogLevel::Error)
         {
-            if (auto module = GetModuleHandleW(L"ntdll.dll"); module && GetProcAddress(module, "wine_get_version"))
-            {
-                RC_DEVICE_PRINT_FUNC(STR("Wine detected, stack trace might be incorrect!"), Color::Yellow, "")
-            }
-            const auto trace = std::stacktrace::current();
-            const auto trace_string = std::to_string(trace);
-            RC_DEVICE_PRINT_FUNC(ensure_str(trace_string), Color::Red, "")
+            const auto trace_string = CallStackDebug::generate_call_stack();
+            RC_DEVICE_PRINT_FUNC(trace_string, Color::Red, "")
         }
 #endif
 #endif

--- a/deps/first/Input/CMakeLists.txt
+++ b/deps/first/Input/CMakeLists.txt
@@ -37,6 +37,7 @@ target_compile_definitions(${TARGET} PRIVATE
 if (NOT ${UE4SS_${TARGET}_BUILD_SHARED})
     target_compile_definitions(${TARGET} PRIVATE
             RC_DYNAMIC_OUTPUT_BUILD_STATIC
+            RC_CALL_STACK_DEBUG_BUILD_STATIC
     )
 endif ()
 


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds stack traces to all calls to `Output::send<LogLevel::Error>`, regardless of where this call comes from.
It works even for Lua errors because they invoke with LogLevel::Error, so that means you get a view into the C++ call stack.

In the future I hope to have this working for exceptions before unwinding happens.
I also want to use this to complement the `.dmp` files when a crash happens because more often than not when debugging `.dmp` files, you just need the call stack and it can be complicated to debug `.dmp` files.

If a symbol isn't found, for example if the .pdb file is missing, will have entries show up as `Unknown`.
Users should be advised to download the zDev release corresponding to the git hash in their UE4SS.log file and unzip the pdb file from there next to UE4SS.dll in order to get stack traces.

Sample error output:
```
Error executing script: ...eam-re-ue4ss\assets\Mods\BPModLoaderMod\Scripts\main.lua:489: Test?
stack traceback:
	[C]: in function 'error'
	...eam-re-ue4ss\assets\Mods\BPModLoaderMod\Scripts\main.lua:489: in function 'a'
	...eam-re-ue4ss\assets\Mods\BPModLoaderMod\Scripts\main.lua:490: in function 'b'
	...eam-re-ue4ss\assets\Mods\BPModLoaderMod\Scripts\main.lua:491: in function 'd'
	...eam-re-ue4ss\assets\Mods\BPModLoaderMod\Scripts\main.lua:492: in function 'e'
	...eam-re-ue4ss\assets\Mods\BPModLoaderMod\Scripts\main.lua:493: in main chunk
[0] RC::Output::send<4,std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> > > in '/stuff/repos/oss_ue4ss/cxx_mods/RE-UE4SS/deps/first/DynamicOutput/include/DynamicOutput/Output.hpp' @ L379
[1] RC::LuaMod::load_and_execute_script in '/stuff/repos/oss_ue4ss/cxx_mods/RE-UE4SS/UE4SS/src/Mod/LuaMod.cpp' @ L5951
[2] RC::LuaMod::start_mod in '/stuff/repos/oss_ue4ss/cxx_mods/RE-UE4SS/UE4SS/src/Mod/LuaMod.cpp' @ L5990
[3] RC::start_mods<RC::LuaMod> in '/stuff/repos/oss_ue4ss/cxx_mods/RE-UE4SS/UE4SS/src/UE4SSProgram.cpp' @ L1972
[4] RC::UE4SSProgram::start_lua_mods in '/stuff/repos/oss_ue4ss/cxx_mods/RE-UE4SS/UE4SS/src/UE4SSProgram.cpp' @ L2042
[5] RC::UE4SSProgram::on_program_start::<lambda_9>::operator() in '/stuff/repos/oss_ue4ss/cxx_mods/RE-UE4SS/UE4SS/src/UE4SSProgram.cpp' @ L1463
[6] RC::TRY<`lambda at /stuff/repos/oss_ue4ss/cxx_mods/RE-UE4SS/UE4SS/src/UE4SSProgram.cpp:1420:13'> in '/stuff/repos/oss_ue4ss/cxx_mods/RE-UE4SS/UE4SS/include/ExceptionHandling.hpp' @ L86
[7] RC::UE4SSProgram::on_program_start in '/stuff/repos/oss_ue4ss/cxx_mods/RE-UE4SS/UE4SS/src/UE4SSProgram.cpp' @ L1466
[8] RC::UE4SSProgram::update in '/stuff/repos/oss_ue4ss/cxx_mods/RE-UE4SS/UE4SS/src/UE4SSProgram.cpp' @ L1487
[9] std::invoke<void (RC::UE4SSProgram::*)(),RC::UE4SSProgram *> in '/home/martin/xwin/crt/include/type_traits' @ L1686
[10] std::thread::_Invoke<std::tuple<void (RC::UE4SSProgram::*)(),RC::UE4SSProgram *>,0,1> in '/home/martin/xwin/crt/include/thread' @ L60
[11] Unknown
[12] Unknown
[13] Unknown
```

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

**How has this been tested?**
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce. Please also list any relevant details for your test configuration. -->

A Lua mod with a call to `error`.

