### PR TITLE
Fixes for UVTD

### DIFF
--- a/UVTD/include/UVTD/Config.hpp
+++ b/UVTD/include/UVTD/Config.hpp
@@ -73,6 +73,13 @@ namespace RC::UVTD
         
         std::unordered_set<File::StringType> valid_udt_names;
         std::vector<File::StringType> uprefix_to_fprefix;
+
+        // Maps a PDB class name onto the name it should be emitted as. Used where the engine renamed
+        // a class outright rather than just swapping its prefix, e.g. UAssetClassProperty became
+        // USoftClassProperty in 4.18 with an identical layout. Emitting the old class under the new
+        // name keeps a single set of member offsets covering every engine version, so consumers never
+        // have to branch on which name the running engine happens to use.
+        std::unordered_map<File::StringType, File::StringType> class_rename_map;
         
         // Enhanced member rename map - outer key is class name, inner key is member name
         std::unordered_map<File::StringType, std::unordered_map<File::StringType, MemberRenameInfo>> member_rename_map;

--- a/UVTD/include/UVTD/ConfigUtil.hpp
+++ b/UVTD/include/UVTD/ConfigUtil.hpp
@@ -54,7 +54,12 @@ namespace RC::UVTD
         }
 
         // UPrefix to FPrefix access
-        inline const std::vector<File::StringType>& GetUPrefixToFPrefix() 
+        inline const std::unordered_map<File::StringType, File::StringType>& GetClassRenameMap()
+        {
+            return UVTDConfig::Get().class_rename_map;
+        }
+
+        inline const std::vector<File::StringType>& GetUPrefixToFPrefix()
         {
             return UVTDConfig::Get().uprefix_to_fprefix;
         }

--- a/UVTD/include/UVTD/Helpers.hpp
+++ b/UVTD/include/UVTD/Helpers.hpp
@@ -55,4 +55,10 @@ namespace RC::UVTD
 
     // Workaround that lets us have a unified 'TUObjectArray' struct regardless if the engine version uses a chunked or non-chunked variant of TUObjectArray.
     auto unify_uobject_array_if_needed(StringType& out_variable_type) -> bool;
+
+    // Every PDB contains all UObject-array container variants, but only one is live per engine
+    // version (TStaticIndirectArray <= 4.10, FFixedUObjectArray 4.11 to 4.19, chunked 4.20+).
+    // Dumping an inactive variant would overwrite the unified TUObjectArray section with the
+    // wrong layout, with last-record-wins deciding arbitrarily.
+    auto is_inactive_uobject_array_variant(const File::StringType& class_name, const PDBNameInfo& pdb_info) -> bool;
 } // namespace RC::UVTD

--- a/UVTD/include/UVTD/Helpers.hpp
+++ b/UVTD/include/UVTD/Helpers.hpp
@@ -48,6 +48,11 @@ namespace RC::UVTD
     auto to_string_type(const char* c_str) -> File::StringType;
     auto change_prefix(File::StringType input, bool is_425_plus) -> std::optional<File::StringType>;
 
+    // Normalizes a type name so that equivalent spellings across engine versions compare equal:
+    // TSizedDefaultAllocator<32> == FDefaultAllocator, TObjectPtr<T> == T* inside containers,
+    // and template whitespace differences. Used for type-change detection and getter dedup.
+    auto normalize_type_for_comparison(const File::StringType& type) -> File::StringType;
+
     // Workaround that lets us have a unified 'TUObjectArray' struct regardless if the engine version uses a chunked or non-chunked variant of TUObjectArray.
     auto unify_uobject_array_if_needed(StringType& out_variable_type) -> bool;
 } // namespace RC::UVTD

--- a/UVTD/include/UVTD/PDBNameInfo.hpp
+++ b/UVTD/include/UVTD/PDBNameInfo.hpp
@@ -66,27 +66,41 @@ namespace RC::UVTD
                 return std::nullopt;
             }
 
-            // Parse minor version (second part)
+            // Parse minor version (second part). A suffix glued onto the digits
+            // (e.g. "5_04abiotic") is split off and treated as a regular suffix.
             if (parts[1].empty()) return std::nullopt;
+            size_t minor_digit_count = 0;
+            while (minor_digit_count < parts[1].size() && parts[1][minor_digit_count] >= '0' && parts[1][minor_digit_count] <= '9')
+            {
+                minor_digit_count++;
+            }
+            if (minor_digit_count == 0) return std::nullopt;
+
+            File::StringType minor_digits = parts[1].substr(0, minor_digit_count);
+            File::StringType glued_suffix = parts[1].substr(minor_digit_count);
             try
             {
-                info.minor_version = std::stoi(to_string(parts[1]));
+                info.minor_version = std::stoi(to_string(minor_digits));
             }
             catch (...)
             {
                 return std::nullopt;
             }
 
-            // Base version is Major_Minor
-            info.base_version = std::format(STR("{}_{}"), parts[0], parts[1]);
+            // Base version is Major_Minor, digits only
+            info.base_version = std::format(STR("{}_{}"), parts[0], minor_digits);
 
             // Generate version_no_separator (for class names like UnrealVirtual427)
             info.version_no_separator = std::format(STR("{}{}"),
                 info.major_version,
                 info.minor_version < 10 ? std::format(STR("0{}"), info.minor_version) : std::format(STR("{}"), info.minor_version));
 
-            // Collect suffixes (parts 2+ are suffixes, max 2)
+            // Collect suffixes (anything glued to the minor version, then parts 2+, max 2)
             info.suffix_count = 0;
+            if (!glued_suffix.empty())
+            {
+                info.suffixes[info.suffix_count++] = glued_suffix;
+            }
             for (size_t i = 2; i < parts.size() && info.suffix_count < 2; ++i)
             {
                 if (!parts[i].empty())

--- a/UVTD/include/UVTD/Symbols.hpp
+++ b/UVTD/include/UVTD/Symbols.hpp
@@ -162,6 +162,9 @@ namespace RC::UVTD
     struct MethodBody
     {
         File::StringType name;
+        // Plain (unmangled) base name. Emitted as an extra VTableLayoutMap entry when it is
+        // unambiguous within the class, so old call sites and user inis keep working.
+        File::StringType alias;
         MethodSignature signature;
         uint32_t offset;
         bool is_overload;

--- a/UVTD/include/UVTD/Symbols.hpp
+++ b/UVTD/include/UVTD/Symbols.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <format>
+#include <functional>
 #include <map>
 #include <unordered_map>
 #include <vector>
@@ -211,7 +212,11 @@ namespace RC::UVTD
     public:
         std::unordered_map<File::StringType, EnumEntry> enum_entries;
         std::unordered_map<File::StringType, Class> class_entries;
+        // Cache keys are raw TPI type indices, which are only meaningful within a single PDB.
+        // type_size_cache_source tracks which PDB the cache belongs to so it can be invalidated
+        // when a different PDB is opened; entries must never survive across PDBs.
         static inline std::unordered_map<uint32_t, uint32_t> type_size_cache;
+        static inline std::filesystem::path type_size_cache_source;
 
 
         Symbols() = delete;
@@ -242,6 +247,11 @@ namespace RC::UVTD
         auto static read_numeric(const uint8_t*& data) -> uint64_t;
         auto static get_numeric_leaf_size(const uint8_t* data) -> uint32_t;
         auto static get_field_record_size(const PDB::CodeView::TPI::FieldList* field) -> uint32_t;
+        // Walks every sub-record of an LF_FIELDLIST at true record boundaries,
+        // skipping alignment padding and following LF_INDEX continuation lists
+        auto static for_each_field(const PDB::TPIStream& tpi_stream,
+                                   const PDB::CodeView::TPI::Record* field_list_record,
+                                   const std::function<void(const PDB::CodeView::TPI::FieldList*)>& callback) -> void;
         auto static get_type_size_impl(const PDB::TPIStream& tpi_stream, uint32_t record_index, bool is_64bit = true) -> uint32_t;
         auto static get_type_size(const PDB::TPIStream& tpi_stream, uint32_t record_index, bool is_64bit = true) -> uint32_t;
         auto static get_method_name(const PDB::CodeView::TPI::FieldList* method_record) -> File::StringType;

--- a/UVTD/include/UVTD/Symbols.hpp
+++ b/UVTD/include/UVTD/Symbols.hpp
@@ -216,10 +216,13 @@ namespace RC::UVTD
         std::unordered_map<File::StringType, EnumEntry> enum_entries;
         std::unordered_map<File::StringType, Class> class_entries;
         // Cache keys are raw TPI type indices, which are only meaningful within a single PDB.
-        // type_size_cache_source tracks which PDB the cache belongs to so it can be invalidated
+        // type_size_cache_source tracks which PDB the caches belong to so they can be invalidated
         // when a different PDB is opened; entries must never survive across PDBs.
         static inline std::unordered_map<uint32_t, uint32_t> type_size_cache;
         static inline std::filesystem::path type_size_cache_source;
+
+        // Clears every cache keyed by PDB-local data (type sizes, complete-type name index)
+        auto static clear_per_pdb_caches() -> void;
 
 
         Symbols() = delete;

--- a/UVTD/src/Config.cpp
+++ b/UVTD/src/Config.cpp
@@ -326,6 +326,33 @@ namespace RC::UVTD
                 Output::send(STR("uprefix_to_fprefix.json not found\n"));
             }
             
+            // Load class_rename_map.json
+            std::filesystem::path class_rename_path = config_dir / "class_rename_map.json";
+            if (std::filesystem::exists(class_rename_path))
+            {
+                std::ifstream file(class_rename_path);
+                std::string json_str((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+
+                auto result = glz::read_json<std::unordered_map<std::string, std::string>>(json_str);
+                if (result.has_value())
+                {
+                    class_rename_map.clear();
+                    for (const auto& [from, to] : result.value())
+                    {
+                        class_rename_map.emplace(to_wstring(from), to_wstring(to));
+                    }
+                    Output::send(STR("Loaded {} class renames\n"), class_rename_map.size());
+                }
+                else
+                {
+                    Output::send(STR("Failed to parse class_rename_map.json\n"));
+                }
+            }
+            else
+            {
+                Output::send(STR("class_rename_map.json not found\n"));
+            }
+
             // Load member_rename_map.json
             std::filesystem::path rename_path = config_dir / "member_rename_map.json";
             if (std::filesystem::exists(rename_path))

--- a/UVTD/src/Helpers.cpp
+++ b/UVTD/src/Helpers.cpp
@@ -41,6 +41,27 @@ namespace RC::UVTD
         return input;
     }
 
+    auto is_inactive_uobject_array_variant(const File::StringType& class_name, const PDBNameInfo& pdb_info) -> bool
+    {
+        static constexpr StringViewType chunked = STR("FChunkedFixedUObjectArray");
+        static constexpr StringViewType non_chunked = STR("FFixedUObjectArray");
+        static constexpr StringViewType indirect_410_and_earlier = STR("TStaticIndirectArrayThreadSafeRead<UObjectBase,8388608,16384>");
+
+        if (class_name == chunked)
+        {
+            return !pdb_info.is_at_least(4, 20);
+        }
+        if (class_name == non_chunked)
+        {
+            return pdb_info.is_at_least(4, 20) || !pdb_info.is_at_least(4, 11);
+        }
+        if (class_name == indirect_410_and_earlier)
+        {
+            return pdb_info.is_at_least(4, 11);
+        }
+        return false;
+    }
+
     auto normalize_type_for_comparison(const File::StringType& type) -> File::StringType
     {
         File::StringType normalized = type;

--- a/UVTD/src/Helpers.cpp
+++ b/UVTD/src/Helpers.cpp
@@ -27,6 +27,15 @@ namespace RC::UVTD
 
     auto change_prefix(File::StringType input, bool is_425_plus) -> std::optional<File::StringType>
     {
+        // An outright class rename wins over the prefix swap: the old and new classes have the same
+        // layout, so emitting the old one under the new name gives every engine version a single set
+        // of member offsets. Only pre-rename PDBs contain these names, so this never fires on a build
+        // that already uses the new one.
+        if (auto it = ConfigUtil::GetClassRenameMap().find(input); it != ConfigUtil::GetClassRenameMap().end())
+        {
+            return it->second;
+        }
+
         // Use ConfigUtil instead of hardcoded list
         for (const auto& prefixed : ConfigUtil::GetUPrefixToFPrefix())
         {

--- a/UVTD/src/Helpers.cpp
+++ b/UVTD/src/Helpers.cpp
@@ -45,7 +45,8 @@ namespace RC::UVTD
     {
         static constexpr StringViewType chunked = STR("FChunkedFixedUObjectArray");
         static constexpr StringViewType non_chunked = STR("FFixedUObjectArray");
-        static constexpr StringViewType indirect_410_and_earlier = STR("TStaticIndirectArrayThreadSafeRead<UObjectBase,8388608,16384>");
+        static constexpr StringViewType indirect_408_to_410 = STR("TStaticIndirectArrayThreadSafeRead<UObjectBase,8388608,16384>");
+        static constexpr StringViewType tarray_407_and_earlier = STR("TArray<UObjectBase *,FDefaultAllocator>");
 
         if (class_name == chunked)
         {
@@ -55,9 +56,13 @@ namespace RC::UVTD
         {
             return pdb_info.is_at_least(4, 20) || !pdb_info.is_at_least(4, 11);
         }
-        if (class_name == indirect_410_and_earlier)
+        if (class_name == indirect_408_to_410)
         {
-            return pdb_info.is_at_least(4, 11);
+            return pdb_info.is_at_least(4, 11) || !pdb_info.is_at_least(4, 8);
+        }
+        if (class_name == tarray_407_and_earlier)
+        {
+            return pdb_info.is_at_least(4, 8);
         }
         return false;
     }
@@ -130,6 +135,12 @@ namespace RC::UVTD
         static constexpr StringViewType fixed_uobject_array_string = STR("FFixedUObjectArray");
         static constexpr StringViewType chunked_fixed_uobject_array_string = STR("FChunkedFixedUObjectArray");
         static constexpr StringViewType non_chunked_410_and_earlier = STR("TStaticIndirectArrayThreadSafeRead<UObjectBase,8388608,16384>");
+        static constexpr StringViewType tarray_407_and_earlier = STR("TArray<UObjectBase *,FDefaultAllocator>");
+        if (auto tarray_pos = out_variable_type.find(tarray_407_and_earlier); tarray_pos != out_variable_type.npos)
+        {
+            out_variable_type.replace(tarray_pos, tarray_407_and_earlier.length(), STR("TUObjectArray"));
+            return true;
+        }
         if (auto fixed_uobject_array_pos = out_variable_type.find(fixed_uobject_array_string); fixed_uobject_array_pos != out_variable_type.npos)
         {
             out_variable_type.replace(fixed_uobject_array_pos, fixed_uobject_array_string.length(), STR("TUObjectArray"));

--- a/UVTD/src/Helpers.cpp
+++ b/UVTD/src/Helpers.cpp
@@ -41,6 +41,69 @@ namespace RC::UVTD
         return input;
     }
 
+    auto normalize_type_for_comparison(const File::StringType& type) -> File::StringType
+    {
+        File::StringType normalized = type;
+
+        // TSizedDefaultAllocator<32> replaced FDefaultAllocator but is the same thing
+        size_t pos = 0;
+        while ((pos = normalized.find(STR("TSizedDefaultAllocator<32>"), pos)) != File::StringType::npos)
+        {
+            normalized.replace(pos, 26, STR("FDefaultAllocator"));
+        }
+
+        // Remove spaces before '>' (e.g. "TArray<T >" vs "TArray<T>")
+        pos = 0;
+        while ((pos = normalized.find(STR(" >"), pos)) != File::StringType::npos)
+        {
+            normalized.erase(pos, 1);
+        }
+
+        while (!normalized.empty() && normalized.back() == ' ')
+        {
+            normalized.pop_back();
+        }
+
+        // Inside containers, TObjectPtr<T> is layout-equivalent to T*
+        if (normalized.starts_with(STR("TArray<")) ||
+            normalized.starts_with(STR("TSet<")) ||
+            normalized.starts_with(STR("TMap<")))
+        {
+            size_t tobj_pos = 0;
+            while ((tobj_pos = normalized.find(STR("TObjectPtr<"), tobj_pos)) != File::StringType::npos)
+            {
+                size_t start = tobj_pos + 11;
+                int depth = 1;
+                size_t end = start;
+                while (end < normalized.size() && depth > 0)
+                {
+                    if (normalized[end] == '<') depth++;
+                    else if (normalized[end] == '>') depth--;
+                    if (depth > 0) end++;
+                }
+
+                if (depth == 0)
+                {
+                    File::StringType inner_type = normalized.substr(start, end - start);
+                    normalized.replace(tobj_pos, end - tobj_pos + 1, inner_type + STR("*"));
+                }
+                else
+                {
+                    tobj_pos++;
+                }
+            }
+        }
+
+        // Normalize pointer spacing: "T *" -> "T*"
+        pos = 0;
+        while ((pos = normalized.find(STR(" *"), pos)) != File::StringType::npos)
+        {
+            normalized.erase(pos, 1);
+        }
+
+        return normalized;
+    }
+
     auto unify_uobject_array_if_needed(StringType& out_variable_type) -> bool
     {
         static constexpr StringViewType fixed_uobject_array_string = STR("FFixedUObjectArray");

--- a/UVTD/src/MemberVarsDumper.cpp
+++ b/UVTD/src/MemberVarsDumper.cpp
@@ -118,7 +118,7 @@ namespace RC::UVTD
                 const auto name_info = names.find(class_name_final);
                 if (name_info == names.end()) continue;
 
-                process_class(tpi_stream, type_record, class_name, name_info->second);
+                process_class(tpi_stream, type_record, class_name_final, name_info->second);
             }
         }
         return;

--- a/UVTD/src/MemberVarsDumper.cpp
+++ b/UVTD/src/MemberVarsDumper.cpp
@@ -109,6 +109,8 @@ namespace RC::UVTD
                 if (type_record->data.LF_CLASS.property.fwdref) continue;
 
                 const File::StringType class_name = Symbols::get_leaf_name(type_record->data.LF_CLASS.data, type_record->data.LF_CLASS.lfEasy.kind);
+                if (is_inactive_uobject_array_variant(class_name, symbols.get_pdb_name_info())) continue;
+
                 auto class_name_final = class_name;
                 unify_uobject_array_if_needed(class_name_final);
                 if (!names.contains(class_name_final)) continue;

--- a/UVTD/src/MemberVarsDumper.cpp
+++ b/UVTD/src/MemberVarsDumper.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <format>
 #include <unordered_map>
 
@@ -212,17 +213,24 @@ namespace RC::UVTD
             // Track variables we've already processed to avoid duplicates
             std::unordered_set<File::StringType> processed_variables;
 
+            // Padding calculation requires offset order; PDB declaration order usually matches
+            // but is not guaranteed, so sort explicitly
+            auto sorted_variables = class_entry.variables;
+            std::stable_sort(sorted_variables.begin(), sorted_variables.end(), [](const MemberVariable& a, const MemberVariable& b) {
+                return a.offset < b.offset;
+            });
+
             // Iterate through sorted variables with formatted type info
-            for (size_t i = 0; i < class_entry.variables.size(); ++i)
+            for (size_t i = 0; i < sorted_variables.size(); ++i)
             {
-                const auto& variable = class_entry.variables[i];
+                const auto& variable = sorted_variables[i];
 
                 // Calculate padding to next member
                 uint32_t padding = 0;
-                if (i + 1 < class_entry.variables.size())
+                if (i + 1 < sorted_variables.size())
                 {
                     uint32_t current_end = variable.offset + variable.size;
-                    uint32_t next_start = class_entry.variables[i + 1].offset;
+                    uint32_t next_start = sorted_variables[i + 1].offset;
                     if (next_start > current_end)
                     {
                         padding = next_start - current_end;

--- a/UVTD/src/MemberVarsDumper.cpp
+++ b/UVTD/src/MemberVarsDumper.cpp
@@ -27,16 +27,12 @@ namespace RC::UVTD
 
         auto fields = tpi_stream.GetTypeRecord(class_record->data.LF_CLASS.field);
 
-        auto list_size = fields->header.size - sizeof(uint16_t);
-        for (size_t i = 0; i < list_size; i++)
-        {
-            auto field_record = (PDB::CodeView::TPI::FieldList*)((uint8_t*)&fields->data.LF_FIELD.list + i);
-
+        Symbols::for_each_field(tpi_stream, fields, [&](const PDB::CodeView::TPI::FieldList* field_record) {
             if (field_record->kind == PDB::CodeView::TPI::TypeRecordKind::LF_MEMBER)
             {
                 process_member(tpi_stream, field_record, class_entry);
             }
-        }
+        });
     }
 
     auto MemberVarsDumper::process_member(const PDB::TPIStream& tpi_stream, const PDB::CodeView::TPI::FieldList* field_record, Class& class_entry) -> void
@@ -65,24 +61,29 @@ namespace RC::UVTD
         // Extract bitfield information if applicable
         auto bitfield_info = Symbols::get_bitfield_info(tpi_stream, field_record->data.LF_MEMBER.index);
 
+        // The offset is a variable-length numeric leaf, not a plain uint16
+        const uint8_t* offset_data = reinterpret_cast<const uint8_t*>(field_record->data.LF_MEMBER.offset);
+        uint32_t member_offset = static_cast<uint32_t>(Symbols::read_numeric(offset_data));
+
+        uint32_t member_size = Symbols::get_type_size(tpi_stream, field_record->data.LF_MEMBER.index, symbols.is_x64());
+
         if (existing != class_entry.variables.end())
         {
             // Update existing variable
             existing->type = type_name;
-            existing->offset = *(uint16_t*)field_record->data.LF_MEMBER.offset;
+            existing->offset = member_offset;
+            existing->type_index = field_record->data.LF_MEMBER.index;
+            existing->size = member_size;
             existing->is_bitfield = bitfield_info.is_bitfield;
             existing->bit_position = bitfield_info.bit_position;
             existing->bit_length = bitfield_info.bit_length;
         }
         else
         {
-            // Calculate the size of this member
-            uint32_t member_size = Symbols::get_type_size(tpi_stream, field_record->data.LF_MEMBER.index, symbols.is_x64());
-
             MemberVariable variable;
             variable.type = type_name;
             variable.name = member_name;
-            variable.offset = *(uint16_t*)field_record->data.LF_MEMBER.offset;
+            variable.offset = member_offset;
             variable.type_index = field_record->data.LF_MEMBER.index;
             variable.size = member_size;
             variable.is_bitfield = bitfield_info.is_bitfield;

--- a/UVTD/src/MemberVarsWrapperGenerator.cpp
+++ b/UVTD/src/MemberVarsWrapperGenerator.cpp
@@ -35,82 +35,8 @@ namespace RC::UVTD
         return type.find(STR("::*)(")) != File::StringType::npos;
     }
 
-    // Normalize a type for comparison purposes
-    // This handles equivalent types that should be considered the same:
-    // - FDefaultAllocator == TSizedDefaultAllocator<32>
-    // - T* in TArray/TSet/TMap == TObjectPtr<T> in TArray/TSet/TMap
-    // - Whitespace differences (e.g., "TArray<T >" vs "TArray<T>")
-    static auto normalize_type_for_comparison(const File::StringType& type) -> File::StringType
-    {
-        File::StringType normalized = type;
-
-        // Normalize allocator types: TSizedDefaultAllocator<32> -> FDefaultAllocator
-        // These are equivalent in UE (TSizedDefaultAllocator<32> was introduced later but is the same)
-        size_t pos = 0;
-        while ((pos = normalized.find(STR("TSizedDefaultAllocator<32>"), pos)) != File::StringType::npos)
-        {
-            normalized.replace(pos, 26, STR("FDefaultAllocator"));
-            // Don't increment pos - the replacement is shorter, so we're already past it
-        }
-
-        // Normalize whitespace: remove spaces before > (e.g., "TArray<T >" -> "TArray<T>")
-        pos = 0;
-        while ((pos = normalized.find(STR(" >"), pos)) != File::StringType::npos)
-        {
-            normalized.erase(pos, 1);
-            // Don't increment - we removed a char, check same position again
-        }
-
-        // Also normalize " >" at the very end
-        while (!normalized.empty() && normalized.back() == ' ')
-        {
-            normalized.pop_back();
-        }
-
-        // For container types (TArray, TSet, TMap), normalize TObjectPtr<T> to T*
-        // This allows us to treat TArray<AActor*> and TArray<TObjectPtr<AActor>> as equivalent
-        if (normalized.starts_with(STR("TArray<")) ||
-            normalized.starts_with(STR("TSet<")) ||
-            normalized.starts_with(STR("TMap<")))
-        {
-            // Find TObjectPtr<X> and replace with X*
-            size_t tobj_pos = 0;
-            while ((tobj_pos = normalized.find(STR("TObjectPtr<"), tobj_pos)) != File::StringType::npos)
-            {
-                // Find the matching closing >
-                size_t start = tobj_pos + 11; // after "TObjectPtr<"
-                int depth = 1;
-                size_t end = start;
-                while (end < normalized.size() && depth > 0)
-                {
-                    if (normalized[end] == '<') depth++;
-                    else if (normalized[end] == '>') depth--;
-                    if (depth > 0) end++;
-                }
-
-                if (depth == 0)
-                {
-                    // Extract the inner type
-                    File::StringType inner_type = normalized.substr(start, end - start);
-                    // Replace TObjectPtr<X> with X*
-                    normalized.replace(tobj_pos, end - tobj_pos + 1, inner_type + STR("*"));
-                }
-                else
-                {
-                    tobj_pos++; // Move past to avoid infinite loop
-                }
-            }
-        }
-
-        // Normalize pointer spacing: "T *" -> "T*"
-        pos = 0;
-        while ((pos = normalized.find(STR(" *"), pos)) != File::StringType::npos)
-        {
-            normalized.erase(pos, 1);
-        }
-
-        return normalized;
-    }
+    // Type normalization lives in Helpers (normalize_type_for_comparison), shared with
+    // TypeContainer's type-change detection.
 
     // Check if a type should be skipped because a better version exists
     // Returns true if this type should be skipped

--- a/UVTD/src/MemberVarsWrapperGenerator.cpp
+++ b/UVTD/src/MemberVarsWrapperGenerator.cpp
@@ -35,6 +35,30 @@ namespace RC::UVTD
         return type.find(STR("::*)(")) != File::StringType::npos;
     }
 
+    // Check if a type is a C-style array (ends with [N])
+    // These need special handling because "Type[N]&" is invalid syntax
+    // Must use typedef: using ArrType = Type[N]; ArrType& GetX();
+    static auto is_c_array_type(const File::StringType& type) -> bool
+    {
+        // Look for pattern ending with [number]
+        if (type.empty() || type.back() != STR(']'))
+            return false;
+
+        // Find the matching opening bracket
+        auto bracket_pos = type.rfind(STR('['));
+        if (bracket_pos == File::StringType::npos)
+            return false;
+
+        // Check that there's something between the brackets (the array size)
+        return bracket_pos + 1 < type.length() - 1;
+    }
+
+    // Check if a type needs a typedef for proper reference return syntax
+    static auto needs_typedef_for_reference(const File::StringType& type) -> bool
+    {
+        return is_pointer_to_member_function(type) || is_c_array_type(type);
+    }
+
     // Type normalization lives in Helpers (normalize_type_for_comparison), shared with
     // TypeContainer's type-change detection.
 
@@ -423,7 +447,7 @@ namespace RC::UVTD
                             File::StringType versioned_getter_name = final_variable_name + getter_suffix;
 
                             // Check if this is a pointer-to-member-function type which needs special handling
-                            if (is_pointer_to_member_function(version_type_name))
+                            if (needs_typedef_for_reference(version_type_name))
                             {
                                 // Generate typedef with unique name for this versioned getter
                                 File::StringType typedef_name = versioned_getter_name + STR("_Type");
@@ -516,7 +540,7 @@ namespace RC::UVTD
                         // Check if this is a pointer-to-member-function type which needs special handling
                         // These types have complex syntax for reference return types: ReturnType (ClassName::*&)(Args...)
                         // We handle this by generating a typedef
-                        if (is_pointer_to_member_function(final_type_name))
+                        if (needs_typedef_for_reference(final_type_name))
                         {
                             File::StringType typedef_name = final_variable_name + STR("_Type");
                             header_wrapper_dumper.send(STR("    using {} = {};\n"), typedef_name, final_type_name);
@@ -536,7 +560,7 @@ namespace RC::UVTD
                 // Handle classes with inheritance relationship (only for non-versioned, non-bitfield getters)
                 if (inheritance_info.has_value() && !variable.has_type_changes() && !variable.is_bitfield)
                 {
-                    bool is_pmf_inherit = is_pointer_to_member_function(final_type_name);
+                    bool is_pmf_inherit = needs_typedef_for_reference(final_type_name);
                     File::StringType typedef_name_inherit = final_variable_name + STR("_Type");
 
                     wrapper_src_dumper.send(STR("{\n"));
@@ -583,7 +607,15 @@ namespace RC::UVTD
                     wrapper_src_dumper.send(STR("        }\n"));
                     wrapper_src_dumper.send(STR("        return offset_it->second;\n"));
                     wrapper_src_dumper.send(STR("    }();\n"));
-                    wrapper_src_dumper.send(STR("    return *Helper::Casting::ptr_cast<{}*>(this, offset);\n"), final_type_name);
+                    // Use typedef for cast when type needs special handling (arrays, pointer-to-member-function)
+                    if (is_pmf_inherit)
+                    {
+                        wrapper_src_dumper.send(STR("    return *Helper::Casting::ptr_cast<{}*>(this, offset);\n"), typedef_name_inherit);
+                    }
+                    else
+                    {
+                        wrapper_src_dumper.send(STR("    return *Helper::Casting::ptr_cast<{}*>(this, offset);\n"), final_type_name);
+                    }
                     wrapper_src_dumper.send(STR("}\n"));
 
                     // Now do the same for the const version - use typedef for pointer-to-member-function types
@@ -639,13 +671,21 @@ namespace RC::UVTD
                     wrapper_src_dumper.send(STR("        }\n"));
                     wrapper_src_dumper.send(STR("        return offset_it->second;\n"));
                     wrapper_src_dumper.send(STR("    }();\n"));
-                    wrapper_src_dumper.send(STR("    return *Helper::Casting::ptr_cast<{}*>(this, offset);\n"), add_const_if_needed(final_type_name));
+                    // Use typedef for cast when type needs special handling
+                    if (is_pmf_inherit)
+                    {
+                        wrapper_src_dumper.send(STR("    return *Helper::Casting::ptr_cast<const {}*>(this, offset);\n"), typedef_name_inherit);
+                    }
+                    else
+                    {
+                        wrapper_src_dumper.send(STR("    return *Helper::Casting::ptr_cast<{}*>(this, offset);\n"), add_const_if_needed(final_type_name));
+                    }
                     wrapper_src_dumper.send(STR("}\n\n"));
                 }
                 else if (!variable.has_type_changes() && !variable.is_bitfield)
                 {
                     // Standard handling for classes without special inheritance, type changes, or bitfields
-                    bool is_pmf = is_pointer_to_member_function(final_type_name);
+                    bool is_pmf = needs_typedef_for_reference(final_type_name);
                     File::StringType typedef_name = final_variable_name + STR("_Type");
 
                     wrapper_src_dumper.send(STR("{\n"));
@@ -658,7 +698,15 @@ namespace RC::UVTD
                                             final_variable_name);
                     wrapper_src_dumper.send(STR("        return offset_it->second;\n"));
                     wrapper_src_dumper.send(STR("    }();\n"));
-                    wrapper_src_dumper.send(STR("    return *Helper::Casting::ptr_cast<{}*>(this, offset);\n"), final_type_name);
+                    // Use typedef for cast when type needs special handling (arrays, pointer-to-member-function)
+                    if (is_pmf)
+                    {
+                        wrapper_src_dumper.send(STR("    return *Helper::Casting::ptr_cast<{}*>(this, offset);\n"), typedef_name);
+                    }
+                    else
+                    {
+                        wrapper_src_dumper.send(STR("    return *Helper::Casting::ptr_cast<{}*>(this, offset);\n"), final_type_name);
+                    }
                     wrapper_src_dumper.send(STR("}\n"));
 
                     // Const getter - use typedef for pointer-to-member-function types
@@ -680,7 +728,15 @@ namespace RC::UVTD
                                             final_variable_name);
                     wrapper_src_dumper.send(STR("        return offset_it->second;\n"));
                     wrapper_src_dumper.send(STR("    }();\n"));
-                    wrapper_src_dumper.send(STR("    return *Helper::Casting::ptr_cast<{}*>(this, offset);\n"), add_const_if_needed(final_type_name));
+                    // Use typedef for cast when type needs special handling
+                    if (is_pmf)
+                    {
+                        wrapper_src_dumper.send(STR("    return *Helper::Casting::ptr_cast<const {}*>(this, offset);\n"), typedef_name);
+                    }
+                    else
+                    {
+                        wrapper_src_dumper.send(STR("    return *Helper::Casting::ptr_cast<{}*>(this, offset);\n"), add_const_if_needed(final_type_name));
+                    }
                     wrapper_src_dumper.send(STR("}\n\n"));
                 }
                 // Note: if variable.has_type_changes() is true, getters were already generated above

--- a/UVTD/src/Symbols.cpp
+++ b/UVTD/src/Symbols.cpp
@@ -42,14 +42,6 @@ inline bool is_valid_pointer_range(const uint8_t* current, const uint8_t* end, s
     return current && end && current + required_size <= end && required_size <= Constants::MAX_STRING_LENGTH;
 }
 
-inline bool is_padding_record(uint16_t kind_value) {
-    return kind_value >= Constants::PADDING_MARKER && kind_value < 0xF10;
-}
-
-inline uint32_t get_padding_size(uint16_t kind_value) {
-    return kind_value & Constants::PADDING_SIZE_MASK;
-}
-
 // ============= Safe String Operations =============
 inline uint32_t safe_strlen(const char* str, size_t max_len = Constants::MAX_STRING_LENGTH) {
     if (!str) return 0;
@@ -191,7 +183,7 @@ inline NumericValue read_numeric_safe(const uint8_t* data, const uint8_t* data_e
     {
         if (type_size_cache_source != this->pdb_file_path)
         {
-            type_size_cache.clear();
+            clear_per_pdb_caches();
             type_size_cache_source = this->pdb_file_path;
         }
 
@@ -694,64 +686,65 @@ inline uint32_t get_pointer_size(PDB::CodeView::TPI::TypeIndexKind type, bool is
     return is_64bit ? 8 : 4;
 }
 
+    // Name -> complete (non-fwdref) class/struct record index for the current PDB.
+    // Built once per PDB on first use; invalidated together with type_size_cache.
+    static std::unordered_map<std::string, uint32_t> s_complete_type_index;
+    static bool s_complete_type_index_built = false;
+
+    auto Symbols::clear_per_pdb_caches() -> void
+    {
+        type_size_cache.clear();
+        s_complete_type_index.clear();
+        s_complete_type_index_built = false;
+    }
+
+    static auto get_class_record_name(const PDB::CodeView::TPI::Record* record) -> const char*
+    {
+        const uint8_t* data = reinterpret_cast<const uint8_t*>(record->data.LF_CLASS.data);
+        Symbols::read_numeric(data); // skip the size numeric leaf, advances data
+        return reinterpret_cast<const char*>(data);
+    }
+
     static auto find_complete_type_definition(const PDB::TPIStream& tpi_stream, uint32_t forward_decl_index) -> uint32_t
 {
     const PDB::CodeView::TPI::Record* forward_record = tpi_stream.GetTypeRecord(forward_decl_index);
     if (!forward_record) return forward_decl_index;
-    
+
     // Only search for class/struct types
     if (forward_record->header.kind != PDB::CodeView::TPI::TypeRecordKind::LF_CLASS &&
         forward_record->header.kind != PDB::CodeView::TPI::TypeRecordKind::LF_STRUCTURE) {
         return forward_decl_index;
     }
-    
+
     // If it's not a forward declaration, return as-is
     if (!forward_record->data.LF_CLASS.property.fwdref) {
         return forward_decl_index;
     }
-    
-    // Get the name of the forward declaration
-    const uint8_t* data = reinterpret_cast<const uint8_t*>(forward_record->data.LF_CLASS.data);
-    
-    // Skip the numeric leaf (size, which is 0 for forward decl)
-    const uint8_t* temp_data = data;
-    Symbols::read_numeric(temp_data);  // This advances temp_data
-    
-    // Now temp_data points to the name
-    std::string forward_name(reinterpret_cast<const char*>(temp_data));
-    
-    // Search through all type records
-    uint32_t first_index = tpi_stream.GetFirstTypeIndex();
-    uint32_t last_index = tpi_stream.GetLastTypeIndex();
-    
-    for (uint32_t i = first_index; i <= last_index; ++i) {
-        // Skip the forward declaration itself
-        if (i == forward_decl_index) continue;
-        
-        const PDB::CodeView::TPI::Record* candidate = tpi_stream.GetTypeRecord(i);
-        if (!candidate) continue;
-        
-        // Must be the same kind (class or struct)
-        if (candidate->header.kind != forward_record->header.kind) continue;
-        
-        // Check if this is NOT a forward declaration
-        if (candidate->data.LF_CLASS.property.fwdref) continue;
-        
-        // Get the candidate's name
-        const uint8_t* candidate_data = reinterpret_cast<const uint8_t*>(candidate->data.LF_CLASS.data);
-        
-        // Skip the size numeric leaf
-        const uint8_t* temp_candidate_data = candidate_data;
-        Symbols::read_numeric(temp_candidate_data);
-        
-        // Compare names
-        std::string candidate_name(reinterpret_cast<const char*>(temp_candidate_data));
-        if (candidate_name == forward_name) {
-            // Found the complete definition!
-            return i;
+
+    if (!s_complete_type_index_built)
+    {
+        s_complete_type_index_built = true;
+
+        const uint32_t first_index = tpi_stream.GetFirstTypeIndex();
+        const uint32_t last_index = tpi_stream.GetLastTypeIndex();
+        for (uint32_t i = first_index; i <= last_index; ++i)
+        {
+            const PDB::CodeView::TPI::Record* candidate = tpi_stream.GetTypeRecord(i);
+            if (!candidate) continue;
+            if (candidate->header.kind != PDB::CodeView::TPI::TypeRecordKind::LF_CLASS &&
+                candidate->header.kind != PDB::CodeView::TPI::TypeRecordKind::LF_STRUCTURE) continue;
+            if (candidate->data.LF_CLASS.property.fwdref) continue;
+
+            // First complete definition wins, matching the previous linear-scan behavior
+            s_complete_type_index.try_emplace(get_class_record_name(candidate), i);
         }
     }
-    
+
+    if (auto it = s_complete_type_index.find(get_class_record_name(forward_record)); it != s_complete_type_index.end())
+    {
+        return it->second;
+    }
+
     // No complete definition found, return the original
     return forward_decl_index;
 }
@@ -1091,9 +1084,8 @@ auto Symbols::get_type_size_impl(const PDB::TPIStream& tpi_stream, uint32_t reco
         case PDB::CodeView::TPI::TypeIndexKind::T_PUINT4:
             return STR("uint32*");
         default:
-            __debugbreak();
+            Output::send(STR("Warning: unknown built-in type index 0x{:X}\n"), record_index);
             return STR("<UNKNOWN TYPE>");
-            break;
         }
     }
 
@@ -1267,7 +1259,9 @@ auto Symbols::get_type_size_impl(const PDB::TPIStream& tpi_stream, uint32_t reco
         }
     }
     default:
-        __debugbreak();
+        Output::send(STR("Warning: unhandled type record kind 0x{:X} for type index 0x{:X}\n"),
+                     static_cast<uint32_t>(record->header.kind),
+                     record_index);
         return STR("<UNKNOWN TYPE>");
     }
 }

--- a/UVTD/src/Symbols.cpp
+++ b/UVTD/src/Symbols.cpp
@@ -73,6 +73,13 @@ inline bool is_virtual_method(uint16_t mprop) {
            mprop == static_cast<uint16_t>(PDB::CodeView::TPI::MethodProperty::Virtual);
 }
 
+// Only introducing virtuals carry a vtable offset in LF_ONEMETHOD/METHOD records.
+// Plain 'Virtual' (an override) does not, so it must not be counted when sizing records.
+inline bool method_has_vtable_offset(uint16_t mprop) {
+    return mprop == static_cast<uint16_t>(PDB::CodeView::TPI::MethodProperty::Intro) ||
+           mprop == static_cast<uint16_t>(PDB::CodeView::TPI::MethodProperty::PureIntro);
+}
+
 inline bool is_static_method(uint16_t mprop) {
     return mprop == static_cast<uint16_t>(PDB::CodeView::TPI::MethodProperty::Static);
 }
@@ -182,6 +189,12 @@ inline NumericValue read_numeric_safe(const uint8_t* data, const uint8_t* data_e
         : pdb_file_path(pdb_file_path), pdb_file_handle(std::move(File::open(pdb_file_path))), pdb_file_map(std::move(pdb_file_handle.memory_map())),
           pdb_file(pdb_file_map.data())
     {
+        if (type_size_cache_source != this->pdb_file_path)
+        {
+            type_size_cache.clear();
+            type_size_cache_source = this->pdb_file_path;
+        }
+
         // Parse PDB name using standardized format: Major_Minor[-Suffix1][-Suffix2]
         auto pdb_stem = this->pdb_file_path.filename().stem().wstring();
         auto name_info = PDBNameInfo::parse(pdb_stem);
@@ -465,20 +478,40 @@ auto Symbols::get_field_record_size(const PDB::CodeView::TPI::FieldList* field) 
         case PDB::CodeView::TPI::TypeRecordKind::LF_ONEMETHOD:
         {
             const auto& record = field->data.LF_ONEMETHOD;
-            const size_t fixed_size = reinterpret_cast<const uint8_t*>(&record.vbaseoff) - 
+            const size_t fixed_size = reinterpret_cast<const uint8_t*>(&record.vbaseoff) -
                                      reinterpret_cast<const uint8_t*>(&record);
-            
-            // Check if method is virtual (has vtable offset)
-            const uint32_t vtable_offset_size = is_virtual_method(record.attributes.mprop) ? 
+
+            const uint32_t vtable_offset_size = method_has_vtable_offset(record.attributes.mprop) ?
                                                 Constants::VTABLE_OFFSET_SIZE : 0;
-            
+
             // Name follows the optional vtable offset
             const uint8_t* name_ptr = reinterpret_cast<const uint8_t*>(record.vbaseoff) + vtable_offset_size;
             const uint32_t name_len = safe_strlen(reinterpret_cast<const char*>(name_ptr));
-            
+
             if (name_len == 0) return Constants::INVALID_RECORD_SIZE;
-            
+
             return static_cast<uint32_t>(fixed_size) + vtable_offset_size + name_len;
+        }
+
+        case PDB::CodeView::TPI::TypeRecordKind::LF_VBCLASS:
+        case PDB::CodeView::TPI::TypeRecordKind::LF_IVBCLASS:
+        {
+            // Layout after kind: attributes(2), btype(4), vbtype(4), then two numeric leaves (vbpoff, vbind)
+            const uint8_t* data = reinterpret_cast<const uint8_t*>(&field->data);
+            const size_t fixed_size = sizeof(uint16_t) + sizeof(uint32_t) + sizeof(uint32_t);
+
+            const uint8_t* first_leaf = data + fixed_size;
+            const uint32_t first_leaf_size = get_numeric_leaf_size(first_leaf) + Constants::NUMERIC_LEAF_PREFIX_SIZE;
+            const uint8_t* second_leaf = first_leaf + first_leaf_size;
+            const uint32_t second_leaf_size = get_numeric_leaf_size(second_leaf) + Constants::NUMERIC_LEAF_PREFIX_SIZE;
+
+            return static_cast<uint32_t>(fixed_size) + first_leaf_size + second_leaf_size;
+        }
+
+        case PDB::CodeView::TPI::TypeRecordKind::LF_INDEX:
+        {
+            // Layout after kind: pad0(2), continuation type index(4)
+            return sizeof(uint16_t) + sizeof(uint32_t);
         }
         
         case PDB::CodeView::TPI::TypeRecordKind::LF_MEMBER:
@@ -517,7 +550,55 @@ auto Symbols::get_field_record_size(const PDB::CodeView::TPI::FieldList* field) 
     }
 }
 
-auto Symbols::get_class_inheritance_model(const PDB::TPIStream& tpi_stream, uint32_t class_type_index) 
+auto Symbols::for_each_field(const PDB::TPIStream& tpi_stream,
+                             const PDB::CodeView::TPI::Record* field_list_record,
+                             const std::function<void(const PDB::CodeView::TPI::FieldList*)>& callback) -> void
+{
+    if (!field_list_record || field_list_record->header.kind != PDB::CodeView::TPI::TypeRecordKind::LF_FIELDLIST)
+    {
+        return;
+    }
+
+    const uint8_t* list_data = reinterpret_cast<const uint8_t*>(&field_list_record->data.LF_FIELD.list);
+    const uint8_t* list_end = list_data + field_list_record->header.size - Constants::PDB_TYPE_RECORD_HEADER_SIZE;
+
+    while (list_data < list_end)
+    {
+        // Sub-records are 4-byte aligned; LF_PAD bytes (0xF0 | count) fill the gap
+        if (*list_data >= 0xF0)
+        {
+            const uint32_t padding = *list_data & 0x0F;
+            if (padding == 0 || list_data + padding > list_end) break;
+            list_data += padding;
+            continue;
+        }
+
+        if (list_data + sizeof(uint16_t) > list_end) break;
+
+        const auto* field = reinterpret_cast<const PDB::CodeView::TPI::FieldList*>(list_data);
+
+        // A split field list ends with LF_INDEX pointing at the continuation list
+        if (field->kind == PDB::CodeView::TPI::TypeRecordKind::LF_INDEX)
+        {
+            const uint32_t continuation_index = *reinterpret_cast<const uint32_t*>(list_data + sizeof(uint16_t) + sizeof(uint16_t));
+            for_each_field(tpi_stream, tpi_stream.GetTypeRecord(continuation_index), callback);
+            return;
+        }
+
+        const uint32_t record_size = get_field_record_size(field);
+        if (record_size == Constants::INVALID_RECORD_SIZE)
+        {
+            Output::send(STR("Warning: unknown field record kind 0x{:X}, stopping field list walk early\n"), static_cast<uint32_t>(field->kind));
+            break;
+        }
+
+        callback(field);
+
+        list_data += sizeof(field->kind) + record_size;
+    }
+}
+
+auto Symbols::get_class_inheritance_model(const PDB::TPIStream& tpi_stream, uint32_t class_type_index)
     -> ClassInheritanceModel
 {
     // Validate and retrieve the class record
@@ -550,72 +631,25 @@ auto Symbols::get_class_inheritance_model(const PDB::TPIStream& tpi_stream, uint
 
     // Parse the field list to count base classes and check for virtual inheritance
     int base_class_count = 0;
-    
-    const uint8_t* list_data = reinterpret_cast<const uint8_t*>(&field_list_record->data.LF_FIELD.list);
-    const uint8_t* list_end = list_data + field_list_record->header.size - Constants::PDB_TYPE_RECORD_HEADER_SIZE;
+    bool has_virtual_base = false;
 
-    // Iterate through all fields in the field list
-    while (list_data < list_end)
-    {
-        // Ensure we have at least enough space for the kind field
-        if (!is_valid_pointer_range(list_data, list_end, sizeof(uint16_t))) {
-            break; // Corrupted data, stop parsing
-        }
-        
-        const auto* field = reinterpret_cast<const PDB::CodeView::TPI::FieldList*>(list_data);
-        const auto kind_val = static_cast<uint16_t>(field->kind);
-
-        // Handle padding records (used for alignment in the PDB format)
-        if (is_padding_record(kind_val)) {
-            const uint32_t padding_size = get_padding_size(kind_val);
-            
-            // Validate that we won't go out of bounds
-            if (!is_valid_pointer_range(list_data, list_end, padding_size)) {
-                break; // Invalid padding, stop parsing
-            }
-            
-            list_data += padding_size;
-            continue;
-        }
-
-        // Check for virtual base classes (immediately determines Virtual inheritance)
-        if (field->kind == PDB::CodeView::TPI::TypeRecordKind::LF_VBCLASS || 
+    for_each_field(tpi_stream, field_list_record, [&](const PDB::CodeView::TPI::FieldList* field) {
+        if (field->kind == PDB::CodeView::TPI::TypeRecordKind::LF_VBCLASS ||
             field->kind == PDB::CodeView::TPI::TypeRecordKind::LF_IVBCLASS) {
-
-            // We can return immediately since virtual inheritance is the "highest" model
-            return ClassInheritanceModel::Virtual;
+            has_virtual_base = true;
         }
-        
-        // Count direct base classes
-        if (field->kind == PDB::CodeView::TPI::TypeRecordKind::LF_BCLASS) {
+        else if (field->kind == PDB::CodeView::TPI::TypeRecordKind::LF_BCLASS) {
             base_class_count++;
         }
+    });
 
-        // Calculate the size of this field record to advance to the next one
-        const uint32_t record_size = get_field_record_size(field);
-        if (record_size == 0) {
-            // Unknown field type or error in parsing - stop processing
-            // This is safer than potentially reading garbage data
-            break;
-        }
-        
-        // Move to the next field record
-        const size_t total_field_size = sizeof(field->kind) + record_size;
-        
-        // Validate before advancing
-        if (!is_valid_pointer_range(list_data, list_end, total_field_size)) {
-            break; // Would go out of bounds
-        }
-        
-        list_data += total_field_size;
+    if (has_virtual_base) {
+        return ClassInheritanceModel::Virtual;
     }
-
-    // Determine inheritance model based on what we found
-    // Note: We've already returned Virtual if we found virtual bases
     if (base_class_count > 1) {
         return ClassInheritanceModel::Multiple;
     }
-    
+
     return ClassInheritanceModel::Single;
 }
 

--- a/UVTD/src/TypeContainer.cpp
+++ b/UVTD/src/TypeContainer.cpp
@@ -4,15 +4,15 @@
 
 namespace RC::UVTD
 {
-    // Helper to check if two types are meaningfully different
-    // Ignores whitespace differences and normalizes some common variations
+    // Helper to check if two types are meaningfully different.
+    // Equivalent spellings across versions (allocator renames, TObjectPtr inside containers,
+    // whitespace) are not changes; recording them would generate churn in types_by_version
+    // that the wrapper generator only filters back out later.
     static auto types_are_different(const File::StringType& type1, const File::StringType& type2) -> bool
     {
         if (type1 == type2) return false;
 
-        // TODO: Add more sophisticated type comparison if needed
-        // For now, simple string comparison
-        return true;
+        return normalize_type_for_comparison(type1) != normalize_type_for_comparison(type2);
     }
 
     auto TypeContainer::join(const TypeContainer& other) -> void
@@ -118,7 +118,11 @@ namespace RC::UVTD
                     }
                     else
                     {
-                        // Same type - just update offset and bitfield info if needed
+                        // Same type after normalization. Adopt the incoming spelling too:
+                        // PDBs are processed oldest to newest, so the last equivalent spelling
+                        // (e.g. TObjectPtr / TSizedDefaultAllocator) wins for generated getters.
+                        existing->type = variable.type;
+                        existing->size = variable.size;
                         existing->offset = variable.offset;
                         existing->is_bitfield = variable.is_bitfield;
                         existing->bit_position = variable.bit_position;
@@ -154,7 +158,9 @@ namespace RC::UVTD
             auto symbol_name_final = symbol_name;
             auto symbol_name_clean_final = symbol_name_clean;
             unify_uobject_array_if_needed(symbol_name_final);
-            if (auto it = class_entries.find(symbol_name_final); it != class_entries.end())
+            unify_uobject_array_if_needed(symbol_name_clean_final);
+            // The map is keyed by the cleaned name; look up with the same key that emplace uses
+            if (auto it = class_entries.find(symbol_name_clean_final); it != class_entries.end())
             {
                 return it->second;
             }

--- a/UVTD/src/VTableDumper.cpp
+++ b/UVTD/src/VTableDumper.cpp
@@ -161,11 +161,7 @@ namespace RC::UVTD
 
         auto fields = tpi_stream.GetTypeRecord(class_record->data.LF_CLASS.field);
 
-        auto list_size = fields->header.size - sizeof(uint16_t);
-        for (size_t i = 0; i < list_size; i++)
-        {
-            auto field_record = (PDB::CodeView::TPI::FieldList*)((uint8_t*)&fields->data.LF_FIELD.list + i);
-
+        Symbols::for_each_field(tpi_stream, fields, [&](const PDB::CodeView::TPI::FieldList* field_record) {
             switch (field_record->kind)
             {
             case PDB::CodeView::TPI::TypeRecordKind::LF_METHOD:
@@ -175,7 +171,7 @@ namespace RC::UVTD
                 process_onemethod(tpi_stream, field_record, class_entry);
                 break;
             }
-        }
+        });
     }
 
     struct MethodListEntry

--- a/UVTD/src/VTableDumper.cpp
+++ b/UVTD/src/VTableDumper.cpp
@@ -99,6 +99,54 @@ namespace RC::UVTD
         return cleaned;
     }
 
+    // Normalizes a type name before it is baked into a mangled identifier so the identifier is
+    // stable across engine versions. Equivalent types that renamed over time (allocators,
+    // TObjectPtr, the UObject array containers) must not change the mangled name.
+    static File::StringType normalize_type_for_mangling(File::StringType type)
+    {
+        unify_uobject_array_if_needed(type);
+
+        size_t pos = 0;
+        while ((pos = type.find(STR("TSizedDefaultAllocator<32>"), pos)) != File::StringType::npos)
+        {
+            type.replace(pos, 26, STR("FDefaultAllocator"));
+        }
+
+        // TObjectPtr<X> is layout-compatible with X* and replaced it in 5.0
+        size_t tobj_pos = 0;
+        while ((tobj_pos = type.find(STR("TObjectPtr<"), tobj_pos)) != File::StringType::npos)
+        {
+            size_t start = tobj_pos + 11;
+            int depth = 1;
+            size_t end = start;
+            while (end < type.size() && depth > 0)
+            {
+                if (type[end] == '<') depth++;
+                else if (type[end] == '>') depth--;
+                if (depth > 0) end++;
+            }
+
+            if (depth == 0)
+            {
+                File::StringType inner_type = type.substr(start, end - start);
+                type.replace(tobj_pos, end - tobj_pos + 1, inner_type + STR("*"));
+            }
+            else
+            {
+                tobj_pos++;
+            }
+        }
+
+        // Collapse "T >" style spacing so nested templates mangle identically everywhere
+        pos = 0;
+        while ((pos = type.find(STR(" >"), pos)) != File::StringType::npos)
+        {
+            type.erase(pos, 1);
+        }
+
+        return type;
+    }
+
     File::StringType generate_mangled_suffix(const MethodSignature& signature)
     {
         File::StringType suffix = STR("");
@@ -139,7 +187,7 @@ namespace RC::UVTD
             for (size_t i = 0; i < params.size(); ++i)
             {
                 if (i > 0) suffix += STR("__");
-                suffix += sanitize_type_for_identifier(params[i].type);
+                suffix += sanitize_type_for_identifier(normalize_type_for_mangling(params[i].type));
             }
         }
 
@@ -218,6 +266,7 @@ namespace RC::UVTD
 
             auto& function = class_entry.functions[vtable_offset];
             function.name = mangled_name;
+            function.alias = base_method_name_clean;
             function.signature = signature;
             function.offset = vtable_offset;
             function.is_overload = true;
@@ -238,9 +287,17 @@ namespace RC::UVTD
 
         File::StringType method_name_clean = Symbols::clean_name(method_name);
 
+        // The plain name stays primary for a single overload, but the mangled name is also
+        // recorded so a virtual that has overloads in other engine versions can be looked up
+        // by one stable mangled name in every version (e.g. FOutputDevice::Serialize before
+        // and after it gained overloads in 4.11).
+        MethodSignature signature = symbols.generate_method_signature(tpi_stream, function_record, method_name);
+        File::StringType mangled_name = method_name_clean + generate_mangled_suffix(signature);
+
         auto& function = class_entry.functions[vtable_offset];
         function.name = method_name_clean;
-        function.signature = symbols.generate_method_signature(tpi_stream, function_record, method_name);
+        function.alias = mangled_name;
+        function.signature = signature;
         function.offset = vtable_offset;
         function.is_overload = false;
     }
@@ -355,6 +412,18 @@ namespace RC::UVTD
             // Generate VTable offset entries with object_item order
             ini_dumper.send(STR("[{}]\n"), class_entry.class_name);
 
+            // Count alias usage so ambiguous aliases (a plain name shared by several overloads)
+            // are not emitted. Primary names also count: an alias must not shadow one.
+            std::unordered_map<File::StringType, int32_t> name_usage;
+            for (const auto& [function_index, function_entry] : class_entry.functions)
+            {
+                name_usage[function_entry.name]++;
+                if (!function_entry.alias.empty() && function_entry.alias != function_entry.name)
+                {
+                    name_usage[function_entry.alias]++;
+                }
+            }
+
             for (const auto& [function_index, function_entry] : class_entry.functions)
             {
                 auto local_class_name = class_entry.class_name;
@@ -374,6 +443,24 @@ namespace RC::UVTD
                         function_entry.name,
                         function_entry.offset);
                 function_body_dumper.send(STR("}\n\n"));
+
+                // Emit the alias as an extra map entry when unambiguous. Only in the generated
+                // function bodies; the ini template is order-based (one line per vtable slot),
+                // so alias lines must never appear there.
+                if (!function_entry.alias.empty() && function_entry.alias != function_entry.name && name_usage[function_entry.alias] == 1)
+                {
+                    function_body_dumper.send(STR("if (auto it = {}::VTableLayoutMap.find(STR(\"{}\")); it == {}::VTableLayoutMap.end())\n"),
+                                              local_class_name,
+                                              function_entry.alias,
+                                              local_class_name);
+                    function_body_dumper.send(STR("{\n"));
+                    function_body_dumper.send(
+                            STR("    {}::VTableLayoutMap.emplace(STR(\"{}\"), 0x{:X});\n"),
+                            local_class_name,
+                            function_entry.alias,
+                            function_entry.offset);
+                    function_body_dumper.send(STR("}\n\n"));
+                }
 
                 // Handle INI output for function entries
                 ini_dumper.send(STR("; {}\n"), function_entry.signature.to_string());

--- a/UVTD/src/main.cpp
+++ b/UVTD/src/main.cpp
@@ -37,15 +37,18 @@ auto static get_user_selection() -> int32_t
 // We're outside DllMain here
 auto thread_dll_start([[maybe_unused]] LPVOID thread_param) -> unsigned long
 {
+    // In DLL mode thread_param is the module handle; in exe mode GetModuleFileNameW(nullptr)
+    // resolves the executable path, so Config/ and the log always live next to the binary
+    // instead of depending on the current working directory
     std::filesystem::path module_path{};
-
-    if (thread_param)
     {
         auto module_handle = reinterpret_cast<HMODULE>(thread_param);
         wchar_t module_filename_buffer[1024]{'\0'};
-        GetModuleFileNameW(module_handle, module_filename_buffer, sizeof(module_filename_buffer) / sizeof(wchar_t));
-        module_path = module_filename_buffer;
-        module_path = module_path.parent_path();
+        if (GetModuleFileNameW(module_handle, module_filename_buffer, sizeof(module_filename_buffer) / sizeof(wchar_t)) > 0)
+        {
+            module_path = module_filename_buffer;
+            module_path = module_path.parent_path();
+        }
     }
 
     Output::set_default_devices<Output::DebugConsoleDevice, Output::NewFileDevice>();

--- a/assets/Default_UVTD_Configs/Config/class_rename_map.json
+++ b/assets/Default_UVTD_Configs/Config/class_rename_map.json
@@ -1,0 +1,4 @@
+{
+  "UAssetObjectProperty": "FSoftObjectProperty",
+  "UAssetClassProperty": "FSoftClassProperty"
+}

--- a/assets/Default_UVTD_Configs/Config/member_rename_map.json
+++ b/assets/Default_UVTD_Configs/Config/member_rename_map.json
@@ -48,5 +48,22 @@
       "generate_alias_setter": true,
       "description": "Special handling for GetName to avoid conflicts"
     }
+  },
+  "TUObjectArray": {
+    "AllocatorInstance": {
+      "mapped_name": "Objects",
+      "generate_alias_setter": true,
+      "description": "4.7 and earlier: ObjObjects is TArray<UObjectBase*>; the allocator data pointer plays the role of Objects"
+    },
+    "ArrayNum": {
+      "mapped_name": "NumElements",
+      "generate_alias_setter": true,
+      "description": "4.7 and earlier TArray member, unified with the 4.11+ FFixedUObjectArray naming"
+    },
+    "ArrayMax": {
+      "mapped_name": "MaxElements",
+      "generate_alias_setter": true,
+      "description": "4.7 and earlier TArray member, unified with the 4.11+ FFixedUObjectArray naming"
+    }
   }
 }

--- a/assets/Default_UVTD_Configs/Config/object_items.json
+++ b/assets/Default_UVTD_Configs/Config/object_items.json
@@ -50,6 +50,11 @@
     "valid_for_member_vars": 1
   },
   {
+    "name": "TStaticIndirectArrayThreadSafeRead<UObjectBase,8388608,16384>",
+    "valid_for_vtable": 0,
+    "valid_for_member_vars": 1
+  },
+  {
     "name": "FFixedUObjectArray",
     "valid_for_vtable": 0,
     "valid_for_member_vars": 1

--- a/assets/Default_UVTD_Configs/Config/pdbs_to_dump.json
+++ b/assets/Default_UVTD_Configs/Config/pdbs_to_dump.json
@@ -1,4 +1,5 @@
 [
+  "PDBs/4_09.pdb",
   "PDBs/4_10.pdb",
   "PDBs/4_11.pdb",
   "PDBs/4_12.pdb",

--- a/assets/Default_UVTD_Configs/Config/types_filter.json
+++ b/assets/Default_UVTD_Configs/Config/types_filter.json
@@ -106,6 +106,8 @@
   ],
   "exclude_from_getters": [
     "FHeapAllocator::ForAnyElementType",
+    "TStatId",
+    "FGCDebugReferenceTokenMap",
     "TBaseDelegate",
     "FUniqueNetIdRepl",
     "FPlatformUserId",

--- a/assets/Default_UVTD_Configs/Config/types_filter.json
+++ b/assets/Default_UVTD_Configs/Config/types_filter.json
@@ -105,6 +105,7 @@
     "UE::Tasks::Private::FTaskHandle"
   ],
   "exclude_from_getters": [
+    "FHeapAllocator::ForAnyElementType",
     "TBaseDelegate",
     "FUniqueNetIdRepl",
     "FPlatformUserId",

--- a/assets/Default_UVTD_Configs/Config/valid_udt_names.json
+++ b/assets/Default_UVTD_Configs/Config/valid_udt_names.json
@@ -48,6 +48,8 @@
   "UClassProperty",
   "FSoftClassProperty",
   "USoftClassProperty",
+  "UAssetObjectProperty",
+  "UAssetClassProperty",
   "FDelegateProperty",
   "UDelegateProperty",
   "FInterfaceProperty",

--- a/tools/uvtd/compare_dumps.py
+++ b/tools/uvtd/compare_dumps.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Analyze and compare UVTD dump output.
+
+Usage:
+  compare_dumps.py analyze <UVTD_Generated_Output>
+      Cross-version consistency analysis of one dump tree:
+      - duplicate member lines within a template
+      - members whose bitfield bit length or storage size varies across versions
+      - members flipping between bitfield and plain across versions
+      - vtable functions whose name changes across versions (overload naming drift)
+
+  compare_dumps.py diff <outputA> <outputB>
+      Compare two dump trees (e.g. before/after a UVTD change), reporting
+      per-file changed line counts and the changed member/function lines.
+
+Both member variable layout templates (assets/MemberVarLayoutTemplates) and
+vtable layout templates (assets/VTableLayoutTemplates) are covered.
+"""
+
+import os
+import re
+import sys
+from collections import defaultdict
+
+MEMBER_TEMPLATE_RE = re.compile(r"^MemberVariableLayout_(.+)_Template\.ini$")
+VTABLE_TEMPLATE_RE = re.compile(r"^VTableLayout_(.+)_Template\.ini$")
+BITFIELD_VALUE_RE = re.compile(r"^0x([0-9A-Fa-f]+):(\d+):(\d+):(\d+)$")
+PLAIN_VALUE_RE = re.compile(r"^0x([0-9A-Fa-f]+)$")
+
+
+def find_dir(root, name):
+    for base, dirs, _ in os.walk(root):
+        if name in dirs:
+            return os.path.join(base, name)
+    return None
+
+
+def parse_member_template(path):
+    """Returns ({(section, member): value_tuple}, [duplicate (section, member)])."""
+    data = {}
+    dupes = []
+    section = None
+    for line in open(path, encoding="utf-8", errors="replace"):
+        line = line.strip()
+        if line.startswith("["):
+            section = line.strip("[]")
+            continue
+        if not section or line.startswith(";") or "=" not in line:
+            continue
+        name, val = [x.strip() for x in line.split("=", 1)]
+        if name == "UEP_TotalSize":
+            continue
+        key = (section, name)
+        if key in data:
+            dupes.append(key)
+        m = BITFIELD_VALUE_RE.match(val)
+        if m:
+            data[key] = ("BF", int(m.group(1), 16), int(m.group(2)), int(m.group(3)), int(m.group(4)))
+            continue
+        m = PLAIN_VALUE_RE.match(val)
+        if m:
+            data[key] = ("VAR", int(m.group(1), 16))
+        else:
+            data[key] = ("ODD", val)
+    return data, dupes
+
+
+def parse_vtable_template(path):
+    """Returns {section: [function names in slot order]}."""
+    data = defaultdict(list)
+    section = None
+    for line in open(path, encoding="utf-8", errors="replace"):
+        line = line.strip()
+        if line.startswith("["):
+            section = line.strip("[]")
+            continue
+        if not section or line.startswith(";") or not line:
+            continue
+        data[section].append(line)
+    return data
+
+
+def load_member_templates(root):
+    d = find_dir(root, "MemberVarLayoutTemplates")
+    out = {}
+    if not d:
+        return out
+    for f in sorted(os.listdir(d)):
+        m = MEMBER_TEMPLATE_RE.match(f)
+        if m:
+            out[m.group(1)] = parse_member_template(os.path.join(d, f))
+    return out
+
+
+def load_vtable_templates(root):
+    d = find_dir(root, "VTableLayoutTemplates")
+    out = {}
+    if not d:
+        return out
+    for f in sorted(os.listdir(d)):
+        m = VTABLE_TEMPLATE_RE.match(f)
+        if m:
+            out[m.group(1)] = parse_vtable_template(os.path.join(d, f))
+    return out
+
+
+def analyze(root):
+    issues = 0
+
+    member_templates = load_member_templates(root)
+    print(f"member templates: {len(member_templates)} versions")
+
+    print("\n== duplicate member lines within one template ==")
+    found = False
+    for ver, (_, dupes) in sorted(member_templates.items()):
+        for sec, name in dupes:
+            print(f"  {ver}: [{sec}] {name}")
+            found = True
+            issues += 1
+    if not found:
+        print("  none")
+
+    merged = defaultdict(dict)
+    for ver, (data, _) in member_templates.items():
+        for key, val in data.items():
+            merged[key][ver] = val
+
+    print("\n== members with varying bitfield BIT LENGTH across versions ==")
+    found = False
+    for (sec, name), vers in sorted(merged.items()):
+        lens = defaultdict(list)
+        for ver, v in vers.items():
+            if v[0] == "BF":
+                lens[v[3]].append(ver)
+        if len(lens) > 1:
+            found = True
+            issues += 1
+            print(f"  [{sec}] {name}:")
+            for ln, vs in sorted(lens.items()):
+                print(f"      len={ln}: {', '.join(sorted(vs))}")
+    if not found:
+        print("  none")
+
+    print("\n== members with varying bitfield STORAGE SIZE across versions ==")
+    print("   (uint32 storage before ~4.11 is genuine engine history; anything else is suspect)")
+    found = False
+    for (sec, name), vers in sorted(merged.items()):
+        sizes = defaultdict(list)
+        for ver, v in vers.items():
+            if v[0] == "BF":
+                sizes[v[4]].append(ver)
+        if len(sizes) > 1:
+            found = True
+            print(f"  [{sec}] {name}:")
+            for sz, vs in sorted(sizes.items()):
+                print(f"      size={sz}: {', '.join(sorted(vs))}")
+    if not found:
+        print("  none")
+
+    print("\n== members flipping bitfield <-> plain across versions (informational) ==")
+    count = 0
+    for (sec, name), vers in sorted(merged.items()):
+        kinds = {v[0] for v in vers.values()}
+        if "BF" in kinds and "VAR" in kinds:
+            count += 1
+    print(f"  {count} members (known genuine cases: FArchive flags @4.14, UWorld bools @4.22, UClass @4.18/5.0)")
+
+    vtable_templates = load_vtable_templates(root)
+    print(f"\nvtable templates: {len(vtable_templates)} versions")
+
+    print("\n== vtable slot coverage per class (min/max slots across versions) ==")
+    class_counts = defaultdict(dict)
+    for ver, sections in vtable_templates.items():
+        for sec, names in sections.items():
+            class_counts[sec][ver] = len(names)
+    for sec, per_ver in sorted(class_counts.items()):
+        lo, hi = min(per_ver.values()), max(per_ver.values())
+        print(f"  {sec}: {lo}..{hi} slots")
+
+    print(f"\nanalysis complete, {issues} hard issues")
+    return 1 if issues else 0
+
+
+def diff_trees(root_a, root_b):
+    changed = 0
+    for loader, label in ((load_member_templates, "member"), (load_vtable_templates, "vtable")):
+        a, b = loader(root_a), loader(root_b)
+        for ver in sorted(set(a) | set(b)):
+            if ver not in a:
+                print(f"[{label}] {ver}: only in B")
+                continue
+            if ver not in b:
+                print(f"[{label}] {ver}: only in A")
+                continue
+            if label == "member":
+                da, db = a[ver][0], b[ver][0]
+                keys = set(da) | set(db)
+                diffs = [k for k in keys if da.get(k) != db.get(k)]
+                if diffs:
+                    changed += len(diffs)
+                    print(f"[member] {ver}: {len(diffs)} changed members")
+                    for sec, name in sorted(diffs)[:40]:
+                        print(f"    [{sec}] {name}: {da.get((sec, name))} -> {db.get((sec, name))}")
+            else:
+                da, db = a[ver], b[ver]
+                for sec in sorted(set(da) | set(db)):
+                    la, lb = da.get(sec, []), db.get(sec, [])
+                    if la != lb:
+                        changed += 1
+                        print(f"[vtable] {ver} [{sec}]: {len(la)} -> {len(lb)} slots")
+                        for i, (x, y) in enumerate(zip(la, lb)):
+                            if x != y:
+                                print(f"    slot {i}: {x} -> {y}")
+                        for i in range(min(len(la), len(lb)), max(len(la), len(lb))):
+                            src = la if len(la) > len(lb) else lb
+                            side = "A" if len(la) > len(lb) else "B"
+                            print(f"    slot {i}: only in {side}: {src[i]}")
+    print(f"\n{changed} differences")
+    return 1 if changed else 0
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(__doc__)
+        return 2
+    cmd = sys.argv[1]
+    if cmd == "analyze":
+        return analyze(sys.argv[2])
+    if cmd == "diff" and len(sys.argv) >= 4:
+        return diff_trees(sys.argv[2], sys.argv[3])
+    print(__doc__)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**Description**
Correctness fixes for UVTD's PDB dumping. The type size cache is invalidated per PDB and
field lists are walked at record boundaries, so types no longer inherit sizes or members
from a previously processed engine version. Only the UObject array variant each version
actually uses is dumped, with the 4.7 `TArray`-based array emitted as `TUObjectArray`
using the 4.11+ member names, and vtable names are emitted in a stable mangled form with
plain aliases. Also adds the 4.9 PDB and `TStaticIndirectArrayThreadSafeRead` to the
configs, and `tools/uvtd/compare_dumps.py` for diffing dump runs.

No runtime or submodule changes, this only affects the UVTD tool and its config.


Fixes # (issue) (if applicable)

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

**How has this been tested?**
Built UVTD and ran a full dump over all 30 PDBs (4.07 through 5.07) with no errors.
Diffed the output against the previous dumps, changes were confined to the versions and
types the fixes target. The regenerated dumps themselves land in the `pre411-ue4ss` PR.


**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [x] I have commented my code, particularly in hard-to-understand areas.
