### PR TITLE
!BREAKING - Use accessors for softobjectpath.

### DIFF
--- a/UE4SS/src/LuaType/LuaFSoftObjectPath.cpp
+++ b/UE4SS/src/LuaType/LuaFSoftObjectPath.cpp
@@ -53,13 +53,13 @@ namespace RC::LuaType
     {
         table.add_pair("GetAssetPathName", [](const LuaMadeSimple::Lua& lua) -> int {
             auto& lua_object = lua.get_userdata<FSoftObjectPath>();
-            FName::construct(lua, lua_object.get_local_cpp_object().AssetPathName);
+            FName::construct(lua, lua_object.get_local_cpp_object().GetAssetPathName());
             return 1;
         });
 
         table.add_pair("GetSubPathString", [](const LuaMadeSimple::Lua& lua) -> int {
             auto& lua_object = lua.get_userdata<FSoftObjectPath>();
-            FString::construct(lua, &lua_object.get_local_cpp_object().SubPathString);
+            FString::construct(lua, &lua_object.get_local_cpp_object().GetSubPathString());
             return 1;
         });
 

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -38,6 +38,17 @@ Added new build definition "LessEqual421".  Using this definition for games on U
 **BREAKING:** Changed default `EFindName` parameter for FName constructors from `FNAME_Find` to `FNAME_Add`. 
 - FName constructors will now create new name table entries by default if the name doesn't exist, rather than returning NAME_None
 - To maintain the old behavior, explicitly pass `FNAME_Find` as the second parameter
+
+**BREAKING:** `FSoftObjectPath` no longer exposes the `AssetPathName` and `SubPathString` member variables. The struct layout now adapts at runtime to the running engine (5.1+ replaced the FName with an FTopLevelAssetPath), which fixes silent memory corruption when accessing soft object paths on 5.1+ games. C++ mods must migrate:
+- `path.AssetPathName` -> `path.GetAssetPathName()` (on 5.1+ this returns the combined `/Package/Path.Asset` name; use `path.GetAssetPath()` for the package/asset name pair)
+- `path.SubPathString` -> `path.GetSubPathString()` (non-const overload available for assignment)
+- Lua mods are unaffected; the Lua API is unchanged
+
+**BREAKING:** `FText` no longer exposes the `Data`, `SharedRefCollector`, `Flags` and `Unk` member variables. The layout adapts at runtime (5.4 changed TSharedRef to TRefCountPtr, shrinking FText from 0x18 to 0x10), and copies/destruction now use the engine's own FTextProperty value operations, so FText copies are properly reference counted in every engine version. C++ mods must migrate:
+- `text.Data` -> `text.GetTextData()`
+- `text.Flags` -> `text.GetFlags()`
+- Constructing, copying, assigning and `ToString()`/`ToFString()` are unchanged
+- Lua mods are unaffected
 - This affects all string-based FName constructors 
 
 Added optional scans for GUObjectHashTables, GNatives and ConsoleManagerSingleton; made FText an optional scan; externed the found GNatives for use by mods([UE4SS #744](https://github.com/UE4SS-RE/RE-UE4SS/pull/744)) 

--- a/assets/Default_UVTD_Configs/Config/valid_udt_names.json
+++ b/assets/Default_UVTD_Configs/Config/valid_udt_names.json
@@ -61,7 +61,7 @@
   "FFrame",
   "ULineBatchComponent",
   "TObjectPtr",
-  "FTransactionallySafeCriticalSection",    
+  "FTransactionallySafeCriticalSection",
   "FThreadSafeCounter",
   "FSchemaOwner",
   "TOptional",
@@ -73,5 +73,9 @@
   "FImplementedInterface",
   "FSchemaOwner",
   "FNativeFunctionLookup",
-  "FGCReferenceTokenStream"  
+  "FGCReferenceTokenStream",
+  "FText",
+  "FSoftObjectPath",
+  "FTopLevelAssetPath",
+  "FStaticConstructObjectParameters"
 ]

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -201,6 +201,73 @@ FORCEINLINE const TCHAR* operator*() const { return Data.Num() ? Data.GetData() 
    TArray<TCHAR>& arr = myString.GetCharArray();
    ```
 
+#### FSoftObjectPath Member Variables Replaced By Accessors
+
+**What Changed:**  
+`FSoftObjectPath` no longer exposes the `AssetPathName` and `SubPathString` member variables. The struct now stores opaque bytes and resolves the engine's actual layout at runtime, because UE 5.1 changed the layout (`FName AssetPathName` became `FTopLevelAssetPath AssetPath`, moving `SubPathString` from offset 0x8 to 0x10). The old compile-time members read the wrong memory on every 5.1+ game.
+
+**Before (v3.x):**
+```cpp
+FSoftObjectPath Path = ...;
+FName AssetName = Path.AssetPathName;
+FString& SubPath = Path.SubPathString;
+Path.SubPathString = NewSubPath;
+```
+
+**After (v4.x):**
+```cpp
+FSoftObjectPath Path = ...;
+FName AssetName = Path.GetAssetPathName();
+FString& SubPath = Path.GetSubPathString();
+Path.GetSubPathString() = NewSubPath;
+
+// New: package/asset name pair, works on every engine version
+FTopLevelAssetPath AssetPath = Path.GetAssetPath();
+```
+
+**Migration Steps:**
+
+1. Replace `Path.AssetPathName` with `Path.GetAssetPathName()`.
+2. Replace `Path.SubPathString` with `Path.GetSubPathString()`. A non-const overload exists, so reads, writes, and passing by reference all work.
+3. If you need the package and asset names separately, prefer `GetAssetPath()`, which returns an `FTopLevelAssetPath` in every engine version (synthesized by splitting the path on pre-5.1).
+
+**Important Notes:**
+- On 5.1+ engines there is no single-FName representation in memory, so `GetAssetPathName()` creates the combined `/Package/Path.Asset` FName on demand (with `FNAME_Add`).
+- Writing the asset path goes through `SetPath()` or `operator=(const FString&)`, unchanged from before.
+- `TArray<FSoftObjectPath>` now strides by the runtime size (`FSoftObjectPath::StaticSize()`), fixing element access on 5.1+ and case-preserving builds.
+- The Lua API (`GetAssetPathName()`, `GetSubPathString()`) is unchanged; Lua mods are unaffected.
+
+#### FText Member Variables Replaced By Accessors
+
+**What Changed:**  
+`FText` no longer exposes the `Data`, `SharedRefCollector`, `Flags` and `Unk` member variables. UE 5.4 changed the internal representation from `TSharedRef<ITextData>` (FText is 0x18 bytes) to `TRefCountPtr<ITextData>` (0x10 bytes), so a fixed member layout cannot be correct everywhere. FText now stores opaque bytes sized by `FText::StaticSize()`, and copies, assignments and destruction go through the engine's own `FTextProperty` value operations, which means FText copies are properly reference counted in every engine version.
+
+**Before (v3.x):**
+```cpp
+FText Text = ...;
+ITextData* Data = Text.Data;
+uint32 Flags = Text.Flags;
+```
+
+**After (v4.x):**
+```cpp
+FText Text = ...;
+ITextData* Data = Text.GetTextData();
+uint32 Flags = Text.GetFlags();
+```
+
+**Migration Steps:**
+
+1. Replace `Text.Data` with `Text.GetTextData()`.
+2. Replace `Text.Flags` with `Text.GetFlags()`.
+3. Remove any use of `SharedRefCollector` or `Unk`; they were artifacts of the guessed layout. The reference controller is engine-managed now.
+4. Code that constructs, copies, assigns, or converts FText (`ToString()`, `ToFString()`, `SetString()`, `FText(FString)`) requires no changes.
+
+**Important Notes:**
+- Copies made through C++ are now owning references; they are released automatically when the FText is destroyed. Byte-wise duplication of FText values (memcpy into a buffer that outlives the source) should be replaced with assignment, or with `FText::StealFromBuffer` / `CopyBorrowedTo` when interacting with engine param buffers.
+- Passing FText by value to engine functions works unchanged; the temporary carries its own reference.
+- The Lua API is unchanged; Lua mods are unaffected.
+
 ### Deprecations
 
 - `GetCharTArray()` is now deprecated but still available for compatibility.


### PR DESCRIPTION
**Description**
Uses the `FSoftObjectPath` accessors in the Lua bindings instead of the raw
`AssetPathName`/`SubPathString` members, which no longer exist now that the submodule
resolves the 5.1+ layout from reflection at runtime. Adds `FText`, `FSoftObjectPath`,
`FTopLevelAssetPath` and `FStaticConstructObjectParameters` to UVTD's valid UDT names so
their sizes reach the layout templates. Documents the `FSoftObjectPath` and `FText`
member-to-accessor migrations in the upgrade guide and changelog. The UEPseudo submodule
bump is included.


Fixes # (issue) (if applicable)

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Is/requires documentation update

**How has this been tested?**
Builds clean. The runtime layout resolution itself lives in UEPseudo.


**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added the necessary description of this PR to the changelog.

**Screenshots**
<!--Add screenshots to help explain your PR, if applicable.-->


**Additional context**
Breaking: `FSoftObjectPath::AssetPathName` and `SubPathString` are replaced by accessors.

