### PR TITLE
fix(GUI): avoid game-thread-only enum lookups in external render mode and fix case-preserving name dump

### DIFF
--- a/UE4SS/src/GUI/Dumpers.cpp
+++ b/UE4SS/src/GUI/Dumpers.cpp
@@ -328,7 +328,7 @@ namespace RC::GUI::Dumpers
             auto& name_components = name_json["Components"];
             name_components["ComparisonIndex"] = name.GetComparisonIndex().ToUnstableInt();
 #ifdef WITH_CASE_PRESERVING_NAME
-            name_components["DisplayIndex"] = name.GetDisplayIndex();
+            name_components["DisplayIndex"] = name.GetDisplayIndex().ToUnstableInt();
 #else
             name_components["DisplayIndex"] = nullptr;
 #endif

--- a/UE4SS/src/GUI/LiveView.cpp
+++ b/UE4SS/src/GUI/LiveView.cpp
@@ -1513,7 +1513,8 @@ namespace RC::GUI
             }
             render_property_value_context_menu(tree_node_id);
         }
-        else if (property->IsA<FEnumProperty>() || (property->IsA<FByteProperty>() && static_cast<FByteProperty*>(property)->IsEnum()))
+        else if (UE4SSProgram::settings_manager.Debug.RenderMode != RenderMode::ExternalThread && (
+                     property->IsA<FEnumProperty>() || (property->IsA<FByteProperty>() && static_cast<FByteProperty*>(property)->IsEnum())))
         {
             UEnum* uenum{};
             if (property->IsA<FByteProperty>())
@@ -1630,7 +1631,11 @@ namespace RC::GUI
         for (const auto name : names)
         {
             auto enum_name = name.Key.ToString();
-            auto enum_friendly_name = UKismetNodeHelperLibrary::GetEnumeratorUserFriendlyName(uenum, name.Value);
+            StringType enum_friendly_name = STR("Unable to Display Friendly Name with GUI Outside of Gamethread.");
+            if (UE4SSProgram::settings_manager.Debug.RenderMode != RenderMode::ExternalThread)
+            {
+                enum_friendly_name = UKismetNodeHelperLibrary::GetEnumeratorUserFriendlyName(uenum, name.Value);
+            }
 
             ImGui::TableNextRow();
             bool open_edit_name_popup{};


### PR DESCRIPTION
**Description**
Two small GUI fixes. LiveView no longer calls
`UKismetNodeHelperLibrary::GetEnumeratorUserFriendlyName` in `ExternalThread` render mode
since that lookup is only safe on the game thread. Enum property values fall back to the
generic exported text and the enum editor shows a placeholder in the friendly name
column. The FName dumper now calls `.ToUnstableInt()` on the display index under
`WITH_CASE_PRESERVING_NAME`, which otherwise fails to compile.


Fixes # (issue) (if applicable)

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

**How has this been tested?**
Verified to reduce crashes when using live view.


**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [x] I have commented my code, particularly in hard-to-understand areas.


