### PR TITLE
4.7-4.10 support

### DIFF
--- a/UE4SS/generated_include/MacroSetter.hpp
+++ b/UE4SS/generated_include/MacroSetter.hpp
@@ -65,10 +65,10 @@ if (auto val = parser.get_int64(STR("UStruct"), STR("Children"), -1); val != -1)
     Unreal::UStruct::MemberOffsets.emplace(STR("Children"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UStruct"), STR("PropertiesSize"), -1); val != -1)
     Unreal::UStruct::MemberOffsets.emplace(STR("PropertiesSize"), static_cast<int32_t>(val));
-if (auto val = parser.get_int64(STR("UStruct"), STR("MinAlignment"), -1); val != -1)
-    Unreal::UStruct::MemberOffsets.emplace(STR("MinAlignment"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UStruct"), STR("Script"), -1); val != -1)
     Unreal::UStruct::MemberOffsets.emplace(STR("Script"), static_cast<int32_t>(val));
+if (auto val = parser.get_int64(STR("UStruct"), STR("MinAlignment"), -1); val != -1)
+    Unreal::UStruct::MemberOffsets.emplace(STR("MinAlignment"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UStruct"), STR("PropertyLink"), -1); val != -1)
     Unreal::UStruct::MemberOffsets.emplace(STR("PropertyLink"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UStruct"), STR("RefLink"), -1); val != -1)
@@ -123,8 +123,6 @@ if (auto val = parser.get_int64(STR("UGameViewportClient"), STR("Window"), -1); 
     Unreal::UGameViewportClient::MemberOffsets.emplace(STR("Window"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UGameViewportClient"), STR("ViewportOverlayWidget"), -1); val != -1)
     Unreal::UGameViewportClient::MemberOffsets.emplace(STR("ViewportOverlayWidget"), static_cast<int32_t>(val));
-if (auto val = parser.get_int64(STR("UGameViewportClient"), STR("GameLayerManagerPtr"), -1); val != -1)
-    Unreal::UGameViewportClient::MemberOffsets.emplace(STR("GameLayerManagerPtr"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UGameViewportClient"), STR("CurrentBufferVisualizationMode"), -1); val != -1)
     Unreal::UGameViewportClient::MemberOffsets.emplace(STR("CurrentBufferVisualizationMode"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UGameViewportClient"), STR("HighResScreenshotDialog"), -1); val != -1)
@@ -143,6 +141,8 @@ if (auto val = parser.get_int64(STR("UGameViewportClient"), STR("MouseCaptureMod
     Unreal::UGameViewportClient::MemberOffsets.emplace(STR("MouseCaptureMode"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UGameViewportClient"), STR("bHideCursorDuringCapture"), -1); val != -1)
     Unreal::UGameViewportClient::MemberOffsets.emplace(STR("bHideCursorDuringCapture"), static_cast<int32_t>(val));
+if (auto val = parser.get_int64(STR("UGameViewportClient"), STR("GameLayerManagerPtr"), -1); val != -1)
+    Unreal::UGameViewportClient::MemberOffsets.emplace(STR("GameLayerManagerPtr"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UGameViewportClient"), STR("AudioDeviceHandle"), -1); val != -1)
     Unreal::UGameViewportClient::MemberOffsets.emplace(STR("AudioDeviceHandle"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UGameViewportClient"), STR("bHasAudioFocus"), -1); val != -1)
@@ -203,12 +203,14 @@ if (auto val = parser.get_int64(STR("FUObjectArray"), STR("OpenForDisregardForGC
     Unreal::FUObjectArray::MemberOffsets.emplace(STR("OpenForDisregardForGC"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("FUObjectArray"), STR("ObjObjects"), -1); val != -1)
     Unreal::FUObjectArray::MemberOffsets.emplace(STR("ObjObjects"), static_cast<int32_t>(val));
-if (auto val = parser.get_int64(STR("FUObjectArray"), STR("ObjAvailableList"), -1); val != -1)
-    Unreal::FUObjectArray::MemberOffsets.emplace(STR("ObjAvailableList"), static_cast<int32_t>(val));
+if (auto val = parser.get_int64(STR("FUObjectArray"), STR("ObjAvailable"), -1); val != -1)
+    Unreal::FUObjectArray::MemberOffsets.emplace(STR("ObjAvailable"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("FUObjectArray"), STR("UObjectCreateListeners"), -1); val != -1)
     Unreal::FUObjectArray::MemberOffsets.emplace(STR("UObjectCreateListeners"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("FUObjectArray"), STR("UObjectDeleteListeners"), -1); val != -1)
     Unreal::FUObjectArray::MemberOffsets.emplace(STR("UObjectDeleteListeners"), static_cast<int32_t>(val));
+if (auto val = parser.get_int64(STR("FUObjectArray"), STR("ObjAvailableList"), -1); val != -1)
+    Unreal::FUObjectArray::MemberOffsets.emplace(STR("ObjAvailableList"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("FUObjectArray"), STR("MaxObjectsNotConsideredByGC"), -1); val != -1)
     Unreal::FUObjectArray::MemberOffsets.emplace(STR("MaxObjectsNotConsideredByGC"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("FUObjectArray"), STR("MasterSerialNumber"), -1); val != -1)
@@ -221,18 +223,26 @@ if (auto val = parser.get_int64(STR("FUObjectArray"), STR("ObjAvailableListEstim
     Unreal::FUObjectArray::MemberOffsets.emplace(STR("ObjAvailableListEstimateCount"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("FUObjectArray"), STR("UEP_TotalSize"), -1); val != -1)
     Unreal::FUObjectArray::MemberOffsets.emplace(STR("UEP_TotalSize"), static_cast<int32_t>(val));
+if (auto val = parser.get_int64(STR("TUObjectArray"), STR("ArrayNum"), -1); val != -1)
+    Unreal::TUObjectArray::MemberOffsets.emplace(STR("NumElements"), static_cast<int32_t>(val));
+// Also support using the renamed version in the INI file
+if (auto val = parser.get_int64(STR("TUObjectArray"), STR("NumElements"), -1); val != -1)
+    Unreal::TUObjectArray::MemberOffsets.emplace(STR("NumElements"), static_cast<int32_t>(val));
+if (auto val = parser.get_int64(STR("TUObjectArray"), STR("ArrayMax"), -1); val != -1)
+    Unreal::TUObjectArray::MemberOffsets.emplace(STR("MaxElements"), static_cast<int32_t>(val));
+// Also support using the renamed version in the INI file
+if (auto val = parser.get_int64(STR("TUObjectArray"), STR("MaxElements"), -1); val != -1)
+    Unreal::TUObjectArray::MemberOffsets.emplace(STR("MaxElements"), static_cast<int32_t>(val));
+if (auto val = parser.get_int64(STR("TUObjectArray"), STR("Chunks"), -1); val != -1)
+    Unreal::TUObjectArray::MemberOffsets.emplace(STR("Chunks"), static_cast<int32_t>(val));
+if (auto val = parser.get_int64(STR("TUObjectArray"), STR("NumChunks"), -1); val != -1)
+    Unreal::TUObjectArray::MemberOffsets.emplace(STR("NumChunks"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("TUObjectArray"), STR("Objects"), -1); val != -1)
     Unreal::TUObjectArray::MemberOffsets.emplace(STR("Objects"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("TUObjectArray"), STR("PreAllocatedObjects"), -1); val != -1)
     Unreal::TUObjectArray::MemberOffsets.emplace(STR("PreAllocatedObjects"), static_cast<int32_t>(val));
-if (auto val = parser.get_int64(STR("TUObjectArray"), STR("MaxElements"), -1); val != -1)
-    Unreal::TUObjectArray::MemberOffsets.emplace(STR("MaxElements"), static_cast<int32_t>(val));
-if (auto val = parser.get_int64(STR("TUObjectArray"), STR("NumElements"), -1); val != -1)
-    Unreal::TUObjectArray::MemberOffsets.emplace(STR("NumElements"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("TUObjectArray"), STR("MaxChunks"), -1); val != -1)
     Unreal::TUObjectArray::MemberOffsets.emplace(STR("MaxChunks"), static_cast<int32_t>(val));
-if (auto val = parser.get_int64(STR("TUObjectArray"), STR("NumChunks"), -1); val != -1)
-    Unreal::TUObjectArray::MemberOffsets.emplace(STR("NumChunks"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("TUObjectArray"), STR("UEP_TotalSize"), -1); val != -1)
     Unreal::TUObjectArray::MemberOffsets.emplace(STR("UEP_TotalSize"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("FArchive"), STR("ArNetVer"), -1); val != -1)
@@ -241,8 +251,6 @@ if (auto val = parser.get_int64(STR("FArchive"), STR("ArUE4Ver"), -1); val != -1
     Unreal::FArchive::MemberOffsets.emplace(STR("ArUE4Ver"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("FArchive"), STR("ArLicenseeUE4Ver"), -1); val != -1)
     Unreal::FArchive::MemberOffsets.emplace(STR("ArLicenseeUE4Ver"), static_cast<int32_t>(val));
-if (auto val = parser.get_int64(STR("FArchive"), STR("ArEngineVer"), -1); val != -1)
-    Unreal::FArchive::MemberOffsets.emplace(STR("ArEngineVer"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("FArchive"), STR("CustomVersionContainer"), -1); val != -1)
     Unreal::FArchive::MemberOffsets.emplace(STR("CustomVersionContainer"), static_cast<int32_t>(val));
 if (auto val_str = parser.get_string(STR("FArchive"), STR("ArIsLoading"), {}); !val_str.empty())
@@ -275,8 +283,6 @@ if (auto val_str = parser.get_string(STR("FArchive"), STR("ArNoDelta"), {}); !va
     ParseMemberOffset(val_str, Unreal::FArchive::MemberOffsets, Unreal::FArchive::BitfieldInfos, STR("ArNoDelta"));
 if (auto val_str = parser.get_string(STR("FArchive"), STR("ArIgnoreOuterRef"), {}); !val_str.empty())
     ParseMemberOffset(val_str, Unreal::FArchive::MemberOffsets, Unreal::FArchive::BitfieldInfos, STR("ArIgnoreOuterRef"));
-if (auto val_str = parser.get_string(STR("FArchive"), STR("ArIgnoreClassGeneratedByRef"), {}); !val_str.empty())
-    ParseMemberOffset(val_str, Unreal::FArchive::MemberOffsets, Unreal::FArchive::BitfieldInfos, STR("ArIgnoreClassGeneratedByRef"));
 if (auto val_str = parser.get_string(STR("FArchive"), STR("ArIgnoreClassRef"), {}); !val_str.empty())
     ParseMemberOffset(val_str, Unreal::FArchive::MemberOffsets, Unreal::FArchive::BitfieldInfos, STR("ArIgnoreClassRef"));
 if (auto val_str = parser.get_string(STR("FArchive"), STR("ArAllowLazyLoading"), {}); !val_str.empty())
@@ -305,6 +311,10 @@ if (auto val = parser.get_int64(STR("FArchive"), STR("SerializedProperty"), -1);
     Unreal::FArchive::MemberOffsets.emplace(STR("SerializedProperty"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("FArchive"), STR("bCustomVersionsAreReset"), -1); val != -1)
     Unreal::FArchive::MemberOffsets.emplace(STR("bCustomVersionsAreReset"), static_cast<int32_t>(val));
+if (auto val = parser.get_int64(STR("FArchive"), STR("ArEngineVer"), -1); val != -1)
+    Unreal::FArchive::MemberOffsets.emplace(STR("ArEngineVer"), static_cast<int32_t>(val));
+if (auto val_str = parser.get_string(STR("FArchive"), STR("ArIgnoreClassGeneratedByRef"), {}); !val_str.empty())
+    ParseMemberOffset(val_str, Unreal::FArchive::MemberOffsets, Unreal::FArchive::BitfieldInfos, STR("ArIgnoreClassGeneratedByRef"));
 if (auto val = parser.get_int64(STR("FArchive"), STR("ArCustomPropertyList"), -1); val != -1)
     Unreal::FArchive::MemberOffsets.emplace(STR("ArCustomPropertyList"), static_cast<int32_t>(val));
 if (auto val_str = parser.get_string(STR("FArchive"), STR("ArUseCustomPropertyList"), {}); !val_str.empty())
@@ -485,6 +495,8 @@ if (auto val = parser.get_int64(STR("AGameMode"), STR("CurrentID"), -1); val != 
     Unreal::AGameMode::MemberOffsets.emplace(STR("CurrentID"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("AGameMode"), STR("DefaultPlayerName"), -1); val != -1)
     Unreal::AGameMode::MemberOffsets.emplace(STR("DefaultPlayerName"), static_cast<int32_t>(val));
+if (auto val = parser.get_int64(STR("AGameMode"), STR("PlayerStarts"), -1); val != -1)
+    Unreal::AGameMode::MemberOffsets.emplace(STR("PlayerStarts"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("AGameMode"), STR("EngineMessageClass"), -1); val != -1)
     Unreal::AGameMode::MemberOffsets.emplace(STR("EngineMessageClass"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("AGameMode"), STR("SpectatorClass"), -1); val != -1)
@@ -497,6 +509,8 @@ if (auto val = parser.get_int64(STR("AGameMode"), STR("GameModeClassAliases"), -
     Unreal::AGameMode::MemberOffsets.emplace(STR("GameModeClassAliases"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("AGameMode"), STR("InactivePlayerStateLifeSpan"), -1); val != -1)
     Unreal::AGameMode::MemberOffsets.emplace(STR("InactivePlayerStateLifeSpan"), static_cast<int32_t>(val));
+if (auto val = parser.get_int64(STR("AGameMode"), STR("TimerHandle_DefaultTimer"), -1); val != -1)
+    Unreal::AGameMode::MemberOffsets.emplace(STR("TimerHandle_DefaultTimer"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("AGameMode"), STR("bHandleDedicatedServerReplays"), -1); val != -1)
     Unreal::AGameMode::MemberOffsets.emplace(STR("bHandleDedicatedServerReplays"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("AGameMode"), STR("MaxInactivePlayers"), -1); val != -1)
@@ -577,20 +591,20 @@ if (auto val_str = parser.get_string(STR("AActor"), STR("bAutoDestroyWhenFinishe
     ParseMemberOffset(val_str, Unreal::AActor::MemberOffsets, Unreal::AActor::BitfieldInfos, STR("bAutoDestroyWhenFinished"));
 if (auto val_str = parser.get_string(STR("AActor"), STR("bCanBeDamaged"), {}); !val_str.empty())
     ParseMemberOffset(val_str, Unreal::AActor::MemberOffsets, Unreal::AActor::BitfieldInfos, STR("bCanBeDamaged"));
-if (auto val_str = parser.get_string(STR("AActor"), STR("bActorIsBeingDestroyed"), {}); !val_str.empty())
-    ParseMemberOffset(val_str, Unreal::AActor::MemberOffsets, Unreal::AActor::BitfieldInfos, STR("bActorIsBeingDestroyed"));
+if (auto val_str = parser.get_string(STR("AActor"), STR("bPendingKillPending"), {}); !val_str.empty())
+    ParseMemberOffset(val_str, Unreal::AActor::MemberOffsets, Unreal::AActor::BitfieldInfos, STR("bPendingKillPending"));
 if (auto val_str = parser.get_string(STR("AActor"), STR("bCollideWhenPlacing"), {}); !val_str.empty())
     ParseMemberOffset(val_str, Unreal::AActor::MemberOffsets, Unreal::AActor::BitfieldInfos, STR("bCollideWhenPlacing"));
 if (auto val_str = parser.get_string(STR("AActor"), STR("bFindCameraComponentWhenViewTarget"), {}); !val_str.empty())
     ParseMemberOffset(val_str, Unreal::AActor::MemberOffsets, Unreal::AActor::BitfieldInfos, STR("bFindCameraComponentWhenViewTarget"));
-if (auto val_str = parser.get_string(STR("AActor"), STR("bRelevantForNetworkReplays"), {}); !val_str.empty())
-    ParseMemberOffset(val_str, Unreal::AActor::MemberOffsets, Unreal::AActor::BitfieldInfos, STR("bRelevantForNetworkReplays"));
-if (auto val = parser.get_int64(STR("AActor"), STR("SpawnCollisionHandlingMethod"), -1); val != -1)
-    Unreal::AActor::MemberOffsets.emplace(STR("SpawnCollisionHandlingMethod"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("AActor"), STR("CreationTime"), -1); val != -1)
     Unreal::AActor::MemberOffsets.emplace(STR("CreationTime"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("AActor"), STR("Children"), -1); val != -1)
     Unreal::AActor::MemberOffsets.emplace(STR("Children"), static_cast<int32_t>(val));
+if (auto val = parser.get_int64(STR("AActor"), STR("AnimUpdateRateShiftTag"), -1); val != -1)
+    Unreal::AActor::MemberOffsets.emplace(STR("AnimUpdateRateShiftTag"), static_cast<int32_t>(val));
+if (auto val = parser.get_int64(STR("AActor"), STR("AnimUpdateRateFrameCount"), -1); val != -1)
+    Unreal::AActor::MemberOffsets.emplace(STR("AnimUpdateRateFrameCount"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("AActor"), STR("RootComponent"), -1); val != -1)
     Unreal::AActor::MemberOffsets.emplace(STR("RootComponent"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("AActor"), STR("ControllingMatineeActors"), -1); val != -1)
@@ -607,14 +621,10 @@ if (auto val = parser.get_int64(STR("AActor"), STR("ParentComponentActor"), -1);
     Unreal::AActor::MemberOffsets.emplace(STR("ParentComponentActor"), static_cast<int32_t>(val));
 if (auto val_str = parser.get_string(STR("AActor"), STR("bActorInitialized"), {}); !val_str.empty())
     ParseMemberOffset(val_str, Unreal::AActor::MemberOffsets, Unreal::AActor::BitfieldInfos, STR("bActorInitialized"));
-if (auto val_str = parser.get_string(STR("AActor"), STR("bActorHasBegunPlay"), {}); !val_str.empty())
-    ParseMemberOffset(val_str, Unreal::AActor::MemberOffsets, Unreal::AActor::BitfieldInfos, STR("bActorHasBegunPlay"));
 if (auto val_str = parser.get_string(STR("AActor"), STR("bActorSeamlessTraveled"), {}); !val_str.empty())
     ParseMemberOffset(val_str, Unreal::AActor::MemberOffsets, Unreal::AActor::BitfieldInfos, STR("bActorSeamlessTraveled"));
 if (auto val_str = parser.get_string(STR("AActor"), STR("bIgnoresOriginShifting"), {}); !val_str.empty())
     ParseMemberOffset(val_str, Unreal::AActor::MemberOffsets, Unreal::AActor::BitfieldInfos, STR("bIgnoresOriginShifting"));
-if (auto val_str = parser.get_string(STR("AActor"), STR("bEnableAutoLODGeneration"), {}); !val_str.empty())
-    ParseMemberOffset(val_str, Unreal::AActor::MemberOffsets, Unreal::AActor::BitfieldInfos, STR("bEnableAutoLODGeneration"));
 if (auto val = parser.get_int64(STR("AActor"), STR("Tags"), -1); val != -1)
     Unreal::AActor::MemberOffsets.emplace(STR("Tags"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("AActor"), STR("HiddenEditorViews"), -1); val != -1)
@@ -651,6 +661,16 @@ if (auto val = parser.get_int64(STR("AActor"), STR("OnEndPlay"), -1); val != -1)
     Unreal::AActor::MemberOffsets.emplace(STR("OnEndPlay"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("AActor"), STR("DetachFence"), -1); val != -1)
     Unreal::AActor::MemberOffsets.emplace(STR("DetachFence"), static_cast<int32_t>(val));
+if (auto val_str = parser.get_string(STR("AActor"), STR("bRelevantForNetworkReplays"), {}); !val_str.empty())
+    ParseMemberOffset(val_str, Unreal::AActor::MemberOffsets, Unreal::AActor::BitfieldInfos, STR("bRelevantForNetworkReplays"));
+if (auto val_str = parser.get_string(STR("AActor"), STR("bActorHasBegunPlay"), {}); !val_str.empty())
+    ParseMemberOffset(val_str, Unreal::AActor::MemberOffsets, Unreal::AActor::BitfieldInfos, STR("bActorHasBegunPlay"));
+if (auto val_str = parser.get_string(STR("AActor"), STR("bEnableAutoLODGeneration"), {}); !val_str.empty())
+    ParseMemberOffset(val_str, Unreal::AActor::MemberOffsets, Unreal::AActor::BitfieldInfos, STR("bEnableAutoLODGeneration"));
+if (auto val_str = parser.get_string(STR("AActor"), STR("bActorIsBeingDestroyed"), {}); !val_str.empty())
+    ParseMemberOffset(val_str, Unreal::AActor::MemberOffsets, Unreal::AActor::BitfieldInfos, STR("bActorIsBeingDestroyed"));
+if (auto val = parser.get_int64(STR("AActor"), STR("SpawnCollisionHandlingMethod"), -1); val != -1)
+    Unreal::AActor::MemberOffsets.emplace(STR("SpawnCollisionHandlingMethod"), static_cast<int32_t>(val));
 if (auto val_str = parser.get_string(STR("AActor"), STR("bAllowTickBeforeBeginPlay"), {}); !val_str.empty())
     ParseMemberOffset(val_str, Unreal::AActor::MemberOffsets, Unreal::AActor::BitfieldInfos, STR("bAllowTickBeforeBeginPlay"));
 if (auto val_str = parser.get_string(STR("AActor"), STR("bTickFunctionsRegistered"), {}); !val_str.empty())
@@ -739,6 +759,8 @@ if (auto val = parser.get_int64(STR("ULocalPlayer"), STR("AspectRatioAxisConstra
     Unreal::ULocalPlayer::MemberOffsets.emplace(STR("AspectRatioAxisConstraint"), static_cast<int32_t>(val));
 if (auto val_str = parser.get_string(STR("ULocalPlayer"), STR("bSentSplitJoin"), {}); !val_str.empty())
     ParseMemberOffset(val_str, Unreal::ULocalPlayer::MemberOffsets, Unreal::ULocalPlayer::BitfieldInfos, STR("bSentSplitJoin"));
+if (auto val = parser.get_int64(STR("ULocalPlayer"), STR("OnlineSession"), -1); val != -1)
+    Unreal::ULocalPlayer::MemberOffsets.emplace(STR("OnlineSession"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("ULocalPlayer"), STR("ControllerId"), -1); val != -1)
     Unreal::ULocalPlayer::MemberOffsets.emplace(STR("ControllerId"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("ULocalPlayer"), STR("bEmulateSplitscreen"), -1); val != -1)
@@ -844,12 +866,12 @@ if (auto val = parser.get_int64(STR("FWorldContext"), STR("RunAsDedicated"), -1)
     Unreal::FWorldContext::MemberOffsets.emplace(STR("RunAsDedicated"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("FWorldContext"), STR("bWaitingOnOnlineSubsystem"), -1); val != -1)
     Unreal::FWorldContext::MemberOffsets.emplace(STR("bWaitingOnOnlineSubsystem"), static_cast<int32_t>(val));
-if (auto val = parser.get_int64(STR("FWorldContext"), STR("AudioDeviceHandle"), -1); val != -1)
-    Unreal::FWorldContext::MemberOffsets.emplace(STR("AudioDeviceHandle"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("FWorldContext"), STR("ExternalReferences"), -1); val != -1)
     Unreal::FWorldContext::MemberOffsets.emplace(STR("ExternalReferences"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("FWorldContext"), STR("ThisCurrentWorld"), -1); val != -1)
     Unreal::FWorldContext::MemberOffsets.emplace(STR("ThisCurrentWorld"), static_cast<int32_t>(val));
+if (auto val = parser.get_int64(STR("FWorldContext"), STR("AudioDeviceHandle"), -1); val != -1)
+    Unreal::FWorldContext::MemberOffsets.emplace(STR("AudioDeviceHandle"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("FWorldContext"), STR("CustomDescription"), -1); val != -1)
     Unreal::FWorldContext::MemberOffsets.emplace(STR("CustomDescription"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("FWorldContext"), STR("AudioDeviceID"), -1); val != -1)
@@ -866,12 +888,12 @@ if (auto val = parser.get_int64(STR("FWorldContext"), STR("UEP_TotalSize"), -1);
     Unreal::FWorldContext::MemberOffsets.emplace(STR("UEP_TotalSize"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UScriptStruct"), STR("StructFlags"), -1); val != -1)
     Unreal::UScriptStruct::MemberOffsets.emplace(STR("StructFlags"), static_cast<int32_t>(val));
+if (auto val = parser.get_int64(STR("UScriptStruct"), STR("CppStructOps"), -1); val != -1)
+    Unreal::UScriptStruct::MemberOffsets.emplace(STR("CppStructOps"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UScriptStruct"), STR("bCppStructOpsFromBaseClass"), -1); val != -1)
     Unreal::UScriptStruct::MemberOffsets.emplace(STR("bCppStructOpsFromBaseClass"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UScriptStruct"), STR("bPrepareCppStructOpsCompleted"), -1); val != -1)
     Unreal::UScriptStruct::MemberOffsets.emplace(STR("bPrepareCppStructOpsCompleted"), static_cast<int32_t>(val));
-if (auto val = parser.get_int64(STR("UScriptStruct"), STR("CppStructOps"), -1); val != -1)
-    Unreal::UScriptStruct::MemberOffsets.emplace(STR("CppStructOps"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UScriptStruct"), STR("UEP_TotalSize"), -1); val != -1)
     Unreal::UScriptStruct::MemberOffsets.emplace(STR("UEP_TotalSize"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UWorld"), STR("ExtraReferencedObjects"), -1); val != -1)
@@ -890,6 +912,8 @@ if (auto val = parser.get_int64(STR("UWorld"), STR("AuthorityGameMode"), -1); va
     Unreal::UWorld::MemberOffsets.emplace(STR("AuthorityGameMode"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UWorld"), STR("NetworkActors"), -1); val != -1)
     Unreal::UWorld::MemberOffsets.emplace(STR("NetworkActors"), static_cast<int32_t>(val));
+if (auto val = parser.get_int64(STR("UWorld"), STR("EditorViews"), -1); val != -1)
+    Unreal::UWorld::MemberOffsets.emplace(STR("EditorViews"), static_cast<int32_t>(val));
 if (auto val_str = parser.get_string(STR("UWorld"), STR("bRequiresHitProxies"), {}); !val_str.empty())
     ParseMemberOffset(val_str, Unreal::UWorld::MemberOffsets, Unreal::UWorld::BitfieldInfos, STR("bRequiresHitProxies"));
 if (auto val_str = parser.get_string(STR("UWorld"), STR("bStreamingDataDirty"), {}); !val_str.empty())
@@ -934,8 +958,6 @@ if (auto val_str = parser.get_string(STR("UWorld"), STR("bShouldSimulatePhysics"
     ParseMemberOffset(val_str, Unreal::UWorld::MemberOffsets, Unreal::UWorld::BitfieldInfos, STR("bShouldSimulatePhysics"));
 if (auto val = parser.get_int64(STR("UWorld"), STR("DebugDrawTraceTag"), -1); val != -1)
     Unreal::UWorld::MemberOffsets.emplace(STR("DebugDrawTraceTag"), static_cast<int32_t>(val));
-if (auto val = parser.get_int64(STR("UWorld"), STR("AudioDeviceHandle"), -1); val != -1)
-    Unreal::UWorld::MemberOffsets.emplace(STR("AudioDeviceHandle"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UWorld"), STR("LastTimeUnbuiltLightingWasEncountered"), -1); val != -1)
     Unreal::UWorld::MemberOffsets.emplace(STR("LastTimeUnbuiltLightingWasEncountered"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UWorld"), STR("TimeSeconds"), -1); val != -1)
@@ -992,6 +1014,8 @@ if (auto val_str = parser.get_string(STR("UWorld"), STR("bDebugFrameStepExecutio
     ParseMemberOffset(val_str, Unreal::UWorld::MemberOffsets, Unreal::UWorld::BitfieldInfos, STR("bDebugFrameStepExecution"));
 if (auto val_str = parser.get_string(STR("UWorld"), STR("bAreConstraintsDirty"), {}); !val_str.empty())
     ParseMemberOffset(val_str, Unreal::UWorld::MemberOffsets, Unreal::UWorld::BitfieldInfos, STR("bAreConstraintsDirty"));
+if (auto val = parser.get_int64(STR("UWorld"), STR("AudioDeviceHandle"), -1); val != -1)
+    Unreal::UWorld::MemberOffsets.emplace(STR("AudioDeviceHandle"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UWorld"), STR("AsyncPreRegisterLevelStreamingTasks"), -1); val != -1)
     Unreal::UWorld::MemberOffsets.emplace(STR("AsyncPreRegisterLevelStreamingTasks"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UWorld"), STR("bCreateRenderStateForHiddenComponents"), -1); val != -1)
@@ -1072,38 +1096,36 @@ if (auto val = parser.get_int64(STR("UFunction"), STR("RPCResponseId"), -1); val
     Unreal::UFunction::MemberOffsets.emplace(STR("RPCResponseId"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UFunction"), STR("FirstPropertyToInit"), -1); val != -1)
     Unreal::UFunction::MemberOffsets.emplace(STR("FirstPropertyToInit"), static_cast<int32_t>(val));
+if (auto val = parser.get_int64(STR("UFunction"), STR("Func"), -1); val != -1)
+    Unreal::UFunction::MemberOffsets.emplace(STR("Func"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UFunction"), STR("EventGraphFunction"), -1); val != -1)
     Unreal::UFunction::MemberOffsets.emplace(STR("EventGraphFunction"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UFunction"), STR("EventGraphCallOffset"), -1); val != -1)
     Unreal::UFunction::MemberOffsets.emplace(STR("EventGraphCallOffset"), static_cast<int32_t>(val));
-if (auto val = parser.get_int64(STR("UFunction"), STR("Func"), -1); val != -1)
-    Unreal::UFunction::MemberOffsets.emplace(STR("Func"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UFunction"), STR("UEP_TotalSize"), -1); val != -1)
     Unreal::UFunction::MemberOffsets.emplace(STR("UEP_TotalSize"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UClass"), STR("ClassConstructor"), -1); val != -1)
     Unreal::UClass::MemberOffsets.emplace(STR("ClassConstructor"), static_cast<int32_t>(val));
-if (auto val = parser.get_int64(STR("UClass"), STR("ClassVTableHelperCtorCaller"), -1); val != -1)
-    Unreal::UClass::MemberOffsets.emplace(STR("ClassVTableHelperCtorCaller"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UClass"), STR("ClassAddReferencedObjects"), -1); val != -1)
     Unreal::UClass::MemberOffsets.emplace(STR("ClassAddReferencedObjects"), static_cast<int32_t>(val));
-if (auto val = parser.get_int64(STR("UClass"), STR("ClassUnique"), -1); val != -1)
-    Unreal::UClass::MemberOffsets.emplace(STR("ClassUnique"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UClass"), STR("ClassFlags"), -1); val != -1)
     Unreal::UClass::MemberOffsets.emplace(STR("ClassFlags"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UClass"), STR("ClassCastFlags"), -1); val != -1)
     Unreal::UClass::MemberOffsets.emplace(STR("ClassCastFlags"), static_cast<int32_t>(val));
+if (auto val = parser.get_int64(STR("UClass"), STR("ClassUnique"), -1); val != -1)
+    Unreal::UClass::MemberOffsets.emplace(STR("ClassUnique"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UClass"), STR("ClassWithin"), -1); val != -1)
     Unreal::UClass::MemberOffsets.emplace(STR("ClassWithin"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UClass"), STR("ClassGeneratedBy"), -1); val != -1)
     Unreal::UClass::MemberOffsets.emplace(STR("ClassGeneratedBy"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UClass"), STR("ClassConfigName"), -1); val != -1)
     Unreal::UClass::MemberOffsets.emplace(STR("ClassConfigName"), static_cast<int32_t>(val));
-if (auto val = parser.get_int64(STR("UClass"), STR("bCooked"), -1); val != -1)
-    Unreal::UClass::MemberOffsets.emplace(STR("bCooked"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UClass"), STR("NetFields"), -1); val != -1)
     Unreal::UClass::MemberOffsets.emplace(STR("NetFields"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UClass"), STR("ClassDefaultObject"), -1); val != -1)
     Unreal::UClass::MemberOffsets.emplace(STR("ClassDefaultObject"), static_cast<int32_t>(val));
+if (auto val = parser.get_int64(STR("UClass"), STR("bCooked"), -1); val != -1)
+    Unreal::UClass::MemberOffsets.emplace(STR("bCooked"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UClass"), STR("FuncMap"), -1); val != -1)
     Unreal::UClass::MemberOffsets.emplace(STR("FuncMap"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UClass"), STR("Interfaces"), -1); val != -1)
@@ -1112,6 +1134,8 @@ if (auto val = parser.get_int64(STR("UClass"), STR("ReferenceTokenStream"), -1);
     Unreal::UClass::MemberOffsets.emplace(STR("ReferenceTokenStream"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UClass"), STR("NativeFunctionLookupTable"), -1); val != -1)
     Unreal::UClass::MemberOffsets.emplace(STR("NativeFunctionLookupTable"), static_cast<int32_t>(val));
+if (auto val = parser.get_int64(STR("UClass"), STR("ClassVTableHelperCtorCaller"), -1); val != -1)
+    Unreal::UClass::MemberOffsets.emplace(STR("ClassVTableHelperCtorCaller"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UClass"), STR("ParentFuncMap"), -1); val != -1)
     Unreal::UClass::MemberOffsets.emplace(STR("ParentFuncMap"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UClass"), STR("InterfaceFuncMap"), -1); val != -1)
@@ -1225,6 +1249,8 @@ if (auto val = parser.get_int64(STR("FSetProperty"), STR("UEP_TotalSize"), -1); 
     Unreal::FSetProperty::MemberOffsets.emplace(STR("UEP_TotalSize"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UDataTable"), STR("RowStruct"), -1); val != -1)
     Unreal::UDataTable::MemberOffsets.emplace(STR("RowStruct"), static_cast<int32_t>(val));
+if (auto val = parser.get_int64(STR("UDataTable"), STR("ImportPath"), -1); val != -1)
+    Unreal::UDataTable::MemberOffsets.emplace(STR("ImportPath"), static_cast<int32_t>(val));
 if (auto val = parser.get_int64(STR("UDataTable"), STR("RowMap"), -1); val != -1)
     Unreal::UDataTable::MemberOffsets.emplace(STR("RowMap"), static_cast<int32_t>(val));
 if (auto val_str = parser.get_string(STR("UDataTable"), STR("bStripFromClientBuilds"), {}); !val_str.empty())

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -25,6 +25,8 @@ Added support for UE Version 5.5 - ([UE4SS #708](https://github.com/UE4SS-RE/RE-
 
 Added support for UE Version 5.4 - ([UE4SS #503](https://github.com/UE4SS-RE/RE-UE4SS/pull/503)) 
 
+Added support for UE Versions 4.7 through 4.10 - ([UE4SS #1390](https://github.com/UE4SS-RE/RE-UE4SS/pull/1390))
+
 Added basic support for Development/Debug/Test built Unreal Engine games ([UE4SS #607](https://github.com/UE4SS-RE/RE-UE4SS/pull/607)) 
 - To use this functionality, set DebugBuild to true in UE4SS-Settings.ini 
 

--- a/assets/Default_UVTD_Configs/Config/pdbs_to_dump.json
+++ b/assets/Default_UVTD_Configs/Config/pdbs_to_dump.json
@@ -1,4 +1,6 @@
 [
+  "PDBs/4_07.pdb",
+  "PDBs/4_08.pdb",
   "PDBs/4_09.pdb",
   "PDBs/4_10.pdb",
   "PDBs/4_11.pdb",

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_07_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_07_Template.ini
@@ -1,0 +1,780 @@
+[UObjectBase]
+; Total Size: 0x28
+; EObjectFlags                        Size: 0x0004
+ObjectFlags = 0x8
+; int32                               Size: 0x0004
+InternalIndex = 0xC
+; UClass*                             Size: 0x0008
+Class = 0x10
+; FName                               Size: 0x0008
+Name = 0x18
+; UObject*                            Size: 0x0008
+Outer = 0x20
+UEP_TotalSize = 0x28
+
+[UScriptStruct::ICppStructOps]
+; Total Size: 0x10
+; const int32                         Size: 0x0004
+Size = 0x8
+; const int32                         Size: 0x0004
+Alignment = 0xC
+UEP_TotalSize = 0x10
+
+[FOutputDevice]
+; Total Size: 0x10
+; bool                                Size: 0x0001
+bSuppressEventTag = 0x8
+; bool                                Size: 0x0001
+bAutoEmitLineTerminator = 0x9
+UEP_TotalSize = 0x10
+
+[UStruct]
+; Total Size: 0x90
+; UStruct*                            Size: 0x0008
+SuperStruct = 0x30
+; UField*                             Size: 0x0008
+Children = 0x38
+; int32                               Size: 0x0004  Padding: 0x4
+PropertiesSize = 0x40
+; TArray<unsigned char,FDefaultAllocator> Size: 0x0010
+Script = 0x48
+; int32                               Size: 0x0004  Padding: 0x4
+MinAlignment = 0x58
+; FProperty*                          Size: 0x0008
+PropertyLink = 0x60
+; FProperty*                          Size: 0x0008
+RefLink = 0x68
+; FProperty*                          Size: 0x0008
+DestructorLink = 0x70
+; FProperty*                          Size: 0x0008
+PostConstructLink = 0x78
+; TArray<UObject *,FDefaultAllocator> Size: 0x0010
+ScriptObjectReferences = 0x80
+UEP_TotalSize = 0x90
+
+[UGameViewportClient]
+; Total Size: 0x180
+; UConsole*                           Size: 0x0008
+ViewportConsole = 0x38
+; TArray<FDebugDisplayProperty,FDefaultAllocator> Size: 0x0010
+DebugProperties = 0x40
+; FTitleSafeZoneArea                  Size: 0x0010
+TitleSafeZone = 0x50
+; TArray<FSplitscreenData,FDefaultAllocator> Size: 0x0010
+SplitscreenInfo = 0x60
+; int32                               Size: 0x0004
+MaxSplitscreenPlayers = 0x70
+; uint32                              Size: 0x0004
+bShowTitleSafeZone = 0x74:0:1:4
+; uint32                              Size: 0x0004
+bIsPlayInEditorViewport = 0x74:1:1:4
+; uint32                              Size: 0x0004
+bDisableWorldRendering = 0x74:2:1:4
+; TEnumAsByte<enum ESplitScreenType::Type> Size: 0x0001  Padding: 0x7
+ActiveSplitscreenType = 0x78
+; UWorld*                             Size: 0x0008  Padding: 0x8
+World = 0x80
+; bool                                Size: 0x0001  Padding: 0x3
+bSuppressTransitionMessage = 0x90
+; int32                               Size: 0x0004
+ViewModeIndex = 0x94
+; FEngineShowFlags                    Size: 0x0014  Padding: 0x4
+EngineShowFlags = 0x98
+; FViewport*                          Size: 0x0008
+Viewport = 0xB0
+; FViewportFrame*                     Size: 0x0008
+ViewportFrame = 0xB8
+; TWeakPtr<SWindow,0>                 Size: 0x0010
+Window = 0xC0
+; TWeakPtr<SOverlay,0>                Size: 0x0010
+ViewportOverlayWidget = 0xD0
+; FName                               Size: 0x0008
+CurrentBufferVisualizationMode = 0xE0
+; TWeakPtr<SWindow,0>                 Size: 0x0010
+HighResScreenshotDialog = 0xE8
+; TMap<enum EMouseCursor::Type, TSharedRef<SWidget,0>> Size: 0x0050
+CursorWidgets = 0xF8
+; TBaseDelegate<void,int,int,TArray<FColor,FDefaultAllocator> const &,FString const &> Size: 0x0008
+PNGScreenshotCapturedDelegate = 0x148
+; TBaseDelegate<void,FViewport *>     Size: 0x0008
+CloseRequestedDelegate = 0x150
+; FStatUnitData*                      Size: 0x0008
+StatUnitData = 0x158
+; FStatHitchesData*                   Size: 0x0008
+StatHitchesData = 0x160
+; bool                                Size: 0x0001
+bDisableSplitScreenOverride = 0x168
+; bool                                Size: 0x0001  Padding: 0x2
+bIgnoreInput = 0x169
+; EMouseCaptureMode::Type             Size: 0x0004
+MouseCaptureMode = 0x16C
+; bool                                Size: 0x0001
+bHideCursorDuringCapture = 0x170
+UEP_TotalSize = 0x180
+
+[FUObjectArray]
+; Total Size: 0x50
+; int32                               Size: 0x0004
+ObjFirstGCIndex = 0x0
+; int32                               Size: 0x0004
+ObjLastNonGCIndex = 0x4
+; int32                               Size: 0x0004  Padding: 0x4
+OpenForDisregardForGC = 0x8
+; TArray<UObjectBase *,FDefaultAllocator> Size: 0x0010
+ObjObjects = 0x10
+; TArray<int,FDefaultAllocator>       Size: 0x0010
+ObjAvailable = 0x20
+; TArray<FUObjectArray::FUObjectCreateListener *,FDefaultAllocator> Size: 0x0010
+UObjectCreateListeners = 0x30
+; TArray<FUObjectArray::FUObjectDeleteListener *,FDefaultAllocator> Size: 0x0010
+UObjectDeleteListeners = 0x40
+UEP_TotalSize = 0x50
+
+[TUObjectArray]
+; Total Size: 0x10
+; FHeapAllocator::ForAnyElementType   Size: 0x0008
+AllocatorInstance = 0x0
+; int32                               Size: 0x0004
+ArrayNum = 0x8
+; int32                               Size: 0x0004
+ArrayMax = 0xC
+UEP_TotalSize = 0x10
+
+[FArchive]
+; Total Size: 0x60
+; int32                               Size: 0x0004
+ArNetVer = 0x8
+; int32                               Size: 0x0004
+ArUE4Ver = 0xC
+; int32                               Size: 0x0004  Padding: 0x4
+ArLicenseeUE4Ver = 0x10
+; FCustomVersionContainer*            Size: 0x0008
+CustomVersionContainer = 0x18
+; bool                                Size: 0x0001
+ArIsLoading = 0x20
+; bool                                Size: 0x0001
+ArIsSaving = 0x21
+; bool                                Size: 0x0001
+ArIsTransacting = 0x22
+; bool                                Size: 0x0001
+ArWantBinaryPropertySerialization = 0x23
+; bool                                Size: 0x0001
+ArForceUnicode = 0x24
+; bool                                Size: 0x0001
+ArIsPersistent = 0x25
+; bool                                Size: 0x0001
+ArIsError = 0x26
+; bool                                Size: 0x0001
+ArIsCriticalError = 0x27
+; bool                                Size: 0x0001
+ArContainsCode = 0x28
+; bool                                Size: 0x0001
+ArContainsMap = 0x29
+; bool                                Size: 0x0001
+ArRequiresLocalizationGather = 0x2A
+; bool                                Size: 0x0001
+ArForceByteSwapping = 0x2B
+; bool                                Size: 0x0001
+ArIgnoreArchetypeRef = 0x2C
+; bool                                Size: 0x0001
+ArNoDelta = 0x2D
+; bool                                Size: 0x0001
+ArIgnoreOuterRef = 0x2E
+; bool                                Size: 0x0001
+ArIgnoreClassRef = 0x2F
+; bool                                Size: 0x0001
+ArAllowLazyLoading = 0x30
+; bool                                Size: 0x0001
+ArIsObjectReferenceCollector = 0x31
+; bool                                Size: 0x0001
+ArIsModifyingWeakAndStrongReferences = 0x32
+; bool                                Size: 0x0001
+ArIsCountingMemory = 0x33
+; bool                                Size: 0x0001
+ArShouldSkipBulkData = 0x34
+; bool                                Size: 0x0001
+ArIsFilterEditorOnly = 0x35
+; bool                                Size: 0x0001  Padding: 0x1
+ArIsSaveGame = 0x36
+; int32                               Size: 0x0004
+ArSerializingDefaults = 0x38
+; uint32                              Size: 0x0004
+ArPortFlags = 0x3C
+; int64                               Size: 0x0008
+ArMaxSerializeSize = 0x40
+; const ITargetPlatform*              Size: 0x0008
+CookingTargetPlatform = 0x48
+; FProperty*                          Size: 0x0008
+SerializedProperty = 0x50
+; bool                                Size: 0x0001
+bCustomVersionsAreReset = 0x58
+UEP_TotalSize = 0x60
+
+[AGameMode]
+; Total Size: 0x3D8
+; FName                               Size: 0x0008
+MatchState = 0x300
+; uint32                              Size: 0x0004
+bUseSeamlessTravel = 0x308:0:1:4
+; uint32                              Size: 0x0004
+bPauseable = 0x308:1:1:4
+; uint32                              Size: 0x0004
+bStartPlayersAsSpectators = 0x308:2:1:4
+; uint32                              Size: 0x0004  Padding: 0x4
+bDelayedStart = 0x308:3:1:4
+; FString                             Size: 0x0010  Padding: 0x8
+OptionsString = 0x310
+; TSubclassOf<AHUD>                   Size: 0x0008
+HUDClass = 0x328
+; int32                               Size: 0x0004
+NumSpectators = 0x330
+; int32                               Size: 0x0004
+NumPlayers = 0x334
+; int32                               Size: 0x0004
+NumBots = 0x338
+; float                               Size: 0x0004
+MinRespawnDelay = 0x33C
+; AGameSession*                       Size: 0x0008
+GameSession = 0x340
+; int32                               Size: 0x0004
+NumTravellingPlayers = 0x348
+; int32                               Size: 0x0004
+CurrentID = 0x34C
+; FString                             Size: 0x0010
+DefaultPlayerName = 0x350
+; TArray<APlayerStart *,FDefaultAllocator> Size: 0x0010
+PlayerStarts = 0x360
+; TSubclassOf<ULocalMessage>          Size: 0x0008  Padding: 0x8
+EngineMessageClass = 0x370
+; TSubclassOf<ASpectatorPawn>         Size: 0x0008
+SpectatorClass = 0x380
+; TSubclassOf<APlayerState>           Size: 0x0008  Padding: 0x10
+PlayerStateClass = 0x388
+; TArray<APlayerState *,FDefaultAllocator> Size: 0x0010
+InactivePlayerArray = 0x3A0
+; TArray<TBaseDelegate<bool>,FDefaultAllocator> Size: 0x0010
+Pausers = 0x3B0
+; TArray<FGameClassShortName,FDefaultAllocator> Size: 0x0010
+GameModeClassAliases = 0x3C0
+; float                               Size: 0x0004
+InactivePlayerStateLifeSpan = 0x3D0
+; FTimerHandle                        Size: 0x0004
+TimerHandle_DefaultTimer = 0x3D4
+UEP_TotalSize = 0x3D8
+
+[AActor]
+; Total Size: 0x300
+; FActorTickFunction                  Size: 0x0050
+PrimaryActorTick = 0x28
+; float                               Size: 0x0004
+CustomTimeDilation = 0x78
+; uint32                              Size: 0x0004
+bHidden = 0x7C:0:1:4
+; uint32                              Size: 0x0004
+bNetTemporary = 0x7C:1:1:4
+; uint32                              Size: 0x0004
+bNetStartup = 0x7C:2:1:4
+; uint32                              Size: 0x0004
+bOnlyRelevantToOwner = 0x7C:3:1:4
+; uint32                              Size: 0x0004
+bAlwaysRelevant = 0x7C:4:1:4
+; uint32                              Size: 0x0004
+bReplicateMovement = 0x7C:5:1:4
+; uint32                              Size: 0x0004
+bTearOff = 0x7C:6:1:4
+; uint32                              Size: 0x0004
+bExchangedRoles = 0x7C:7:1:4
+; uint32                              Size: 0x0004
+bPendingNetUpdate = 0x7C:8:1:4
+; uint32                              Size: 0x0004
+bNetLoadOnClient = 0x7C:9:1:4
+; uint32                              Size: 0x0004
+bNetUseOwnerRelevancy = 0x7C:10:1:4
+; uint32                              Size: 0x0004
+bBlockInput = 0x7C:11:1:4
+; uint32                              Size: 0x0004
+bRunningUserConstructionScript = 0x7C:12:1:4
+; uint32                              Size: 0x0004
+bHasFinishedSpawning = 0x7C:13:1:4
+; uint32                              Size: 0x0004
+bActorEnableCollision = 0x7C:14:1:4
+; uint32                              Size: 0x0004
+bReplicates = 0x7C:15:1:4
+; TEnumAsByte<enum ENetRole>          Size: 0x0001  Padding: 0x7
+RemoteRole = 0x80
+; AActor*                             Size: 0x0008
+Owner = 0x88
+; FRepMovement                        Size: 0x0034  Padding: 0x4
+ReplicatedMovement = 0x90
+; FRepAttachment                      Size: 0x0040
+AttachmentReplication = 0xC8
+; TEnumAsByte<enum ENetRole>          Size: 0x0001
+Role = 0x108
+; TEnumAsByte<enum ENetDormancy>      Size: 0x0001
+NetDormancy = 0x109
+; TEnumAsByte<enum EAutoReceiveInput::Type> Size: 0x0001  Padding: 0x1
+AutoReceiveInput = 0x10A
+; int32                               Size: 0x0004
+InputPriority = 0x10C
+; UInputComponent*                    Size: 0x0008
+InputComponent = 0x110
+; TEnumAsByte<enum EInputConsumeOptions> Size: 0x0001  Padding: 0x3
+InputConsumeOption_DEPRECATED = 0x118
+; float                               Size: 0x0004
+NetCullDistanceSquared = 0x11C
+; int32                               Size: 0x0004
+NetTag = 0x120
+; float                               Size: 0x0004
+NetUpdateTime = 0x124
+; float                               Size: 0x0004
+NetUpdateFrequency = 0x128
+; float                               Size: 0x0004
+NetPriority = 0x12C
+; float                               Size: 0x0004
+LastNetUpdateTime = 0x130
+; FName                               Size: 0x0008
+NetDriverName = 0x134
+; uint32                              Size: 0x0004
+bAutoDestroyWhenFinished = 0x13C:0:1:4
+; uint32                              Size: 0x0004
+bCanBeDamaged = 0x13C:1:1:4
+; uint32                              Size: 0x0004
+bPendingKillPending = 0x13C:2:1:4
+; uint32                              Size: 0x0004
+bCollideWhenPlacing = 0x13C:3:1:4
+; uint32                              Size: 0x0004  Padding: 0x8
+bFindCameraComponentWhenViewTarget = 0x13C:4:1:4
+; float                               Size: 0x0004  Padding: 0x4
+CreationTime = 0x148
+; TArray<AActor *,FDefaultAllocator>  Size: 0x0010
+Children = 0x150
+; uint32                              Size: 0x0004
+AnimUpdateRateShiftTag = 0x160
+; uint32                              Size: 0x0004
+AnimUpdateRateFrameCount = 0x164
+; USceneComponent*                    Size: 0x0008
+RootComponent = 0x168
+; TArray<AMatineeActor *,FDefaultAllocator> Size: 0x0010
+ControllingMatineeActors = 0x170
+; float                               Size: 0x0004
+InitialLifeSpan = 0x180
+; FTimerHandle                        Size: 0x0004
+TimerHandle_LifeSpanExpired = 0x184
+; uint32                              Size: 0x0004  Padding: 0x4
+bAllowReceiveTickEventOnDedicatedServer = 0x188:0:1:4
+; TArray<FName,FDefaultAllocator>     Size: 0x0010
+Layers = 0x190
+; TWeakObjectPtr<AActor,FWeakObjectPtr,FIndexToObject> Size: 0x0008
+ParentComponentActor = 0x1A0
+; uint32                              Size: 0x0004
+bActorInitialized = 0x1A8:0:1:4
+; uint32                              Size: 0x0004
+bActorSeamlessTraveled = 0x1A8:1:1:4
+; uint32                              Size: 0x0004  Padding: 0x4
+bIgnoresOriginShifting = 0x1A8:2:1:4
+; TArray<FName,FDefaultAllocator>     Size: 0x0010
+Tags = 0x1B0
+; uint64                              Size: 0x0008
+HiddenEditorViews = 0x1C0
+; FTakeAnyDamageSignature             Size: 0x0010
+OnTakeAnyDamage = 0x1C8
+; FTakePointDamageSignature           Size: 0x0010
+OnTakePointDamage = 0x1D8
+; FActorBeginOverlapSignature         Size: 0x0010
+OnActorBeginOverlap = 0x1E8
+; FActorEndOverlapSignature           Size: 0x0010
+OnActorEndOverlap = 0x1F8
+; FActorBeginCursorOverSignature      Size: 0x0010
+OnBeginCursorOver = 0x208
+; FActorEndCursorOverSignature        Size: 0x0010
+OnEndCursorOver = 0x218
+; FActorOnClickedSignature            Size: 0x0010
+OnClicked = 0x228
+; FActorOnReleasedSignature           Size: 0x0010
+OnReleased = 0x238
+; FActorOnInputTouchBeginSignature    Size: 0x0010
+OnInputTouchBegin = 0x248
+; FActorOnInputTouchEndSignature      Size: 0x0010
+OnInputTouchEnd = 0x258
+; FActorBeginTouchOverSignature       Size: 0x0010
+OnInputTouchEnter = 0x268
+; FActorEndTouchOverSignature         Size: 0x0010
+OnInputTouchLeave = 0x278
+; FActorHitSignature                  Size: 0x0010
+OnActorHit = 0x288
+; FActorDestroyedSignature            Size: 0x0010
+OnDestroyed = 0x298
+; FActorEndPlaySignature              Size: 0x0010  Padding: 0x40
+OnEndPlay = 0x2A8
+; FRenderCommandFence                 Size: 0x0008
+DetachFence = 0x2F8
+UEP_TotalSize = 0x300
+
+[UPlayer]
+; Total Size: 0x48
+; int32                               Size: 0x0004
+CurrentNetSpeed = 0x38
+; int32                               Size: 0x0004
+ConfiguredInternetSpeed = 0x3C
+; int32                               Size: 0x0004
+ConfiguredLanSpeed = 0x40
+UEP_TotalSize = 0x48
+
+[ULocalPlayer]
+; Total Size: 0xF0
+; TSharedPtr<FUniqueNetId,0>          Size: 0x0010
+CachedUniqueNetId = 0x48
+; UGameViewportClient*                Size: 0x0008
+ViewportClient = 0x58
+; FVector2D                           Size: 0x0008
+Origin = 0x60
+; FVector2D                           Size: 0x0008
+Size = 0x68
+; FVector                             Size: 0x000C
+LastViewLocation = 0x70
+; TEnumAsByte<enum EAspectRatioAxisConstraint> Size: 0x0001  Padding: 0xB
+AspectRatioAxisConstraint = 0x7C
+; uint32                              Size: 0x0004  Padding: 0x54
+bSentSplitJoin = 0x88:0:1:4
+; UOnlineSession*                     Size: 0x0008
+OnlineSession = 0xE0
+; int32                               Size: 0x0004
+ControllerId = 0xE8
+UEP_TotalSize = 0xF0
+
+[UField]
+; Total Size: 0x30
+; UField*                             Size: 0x0008
+Next = 0x28
+UEP_TotalSize = 0x30
+
+[FProperty]
+; Total Size: 0x70
+; int32                               Size: 0x0004
+ArrayDim = 0x30
+; int32                               Size: 0x0004
+ElementSize = 0x34
+; uint64                              Size: 0x0008
+PropertyFlags = 0x38
+; uint16                              Size: 0x0002  Padding: 0x2
+RepIndex = 0x40
+; FName                               Size: 0x0008
+RepNotifyFunc = 0x44
+; int32                               Size: 0x0004
+Offset_Internal = 0x4C
+; FProperty*                          Size: 0x0008
+PropertyLinkNext = 0x50
+; FProperty*                          Size: 0x0008
+NextRef = 0x58
+; FProperty*                          Size: 0x0008
+DestructorLinkNext = 0x60
+; FProperty*                          Size: 0x0008
+PostConstructLinkNext = 0x68
+UEP_TotalSize = 0x70
+
+[FMulticastDelegateProperty]
+; Total Size: 0x78
+; UFunction*                          Size: 0x0008
+SignatureFunction = 0x70
+UEP_TotalSize = 0x78
+
+[FObjectPropertyBase]
+; Total Size: 0x78
+; UClass*                             Size: 0x0008
+PropertyClass = 0x70
+UEP_TotalSize = 0x78
+
+[FWorldContext]
+; Total Size: 0x298
+; FName                               Size: 0x0008
+ContextHandle = 0xC0
+; FString                             Size: 0x0010
+TravelURL = 0xC8
+; uint8                               Size: 0x0001  Padding: 0x7
+TravelType = 0xD8
+; FURL                                Size: 0x0070
+LastURL = 0xE0
+; FURL                                Size: 0x0070  Padding: 0x18
+LastRemoteURL = 0x150
+; TArray<FName,FDefaultAllocator>     Size: 0x0010  Padding: 0x10
+LevelsToLoadForPendingMapChange = 0x1D8
+; FString                             Size: 0x0010
+PendingMapChangeFailureDescription = 0x1F8
+; uint32                              Size: 0x0004  Padding: 0x24
+bShouldCommitPendingMapChange = 0x208:0:1:4
+; UGameViewportClient*                Size: 0x0008  Padding: 0x18
+GameViewport = 0x230
+; int32                               Size: 0x0004  Padding: 0x4
+PIEInstance = 0x250
+; FString                             Size: 0x0010
+PIEPrefix = 0x258
+; FString                             Size: 0x0010
+PIERemapPrefix = 0x268
+; bool                                Size: 0x0001
+RunAsDedicated = 0x278
+; bool                                Size: 0x0001  Padding: 0x6
+bWaitingOnOnlineSubsystem = 0x279
+; TArray<UWorld * *,FDefaultAllocator> Size: 0x0010
+ExternalReferences = 0x280
+; UWorld*                             Size: 0x0008
+ThisCurrentWorld = 0x290
+UEP_TotalSize = 0x298
+
+[UScriptStruct]
+; Total Size: 0xA8
+; EStructFlags                        Size: 0x0004  Padding: 0x4
+StructFlags = 0x90
+; UScriptStruct::ICppStructOps*       Size: 0x0008
+CppStructOps = 0x98
+; bool                                Size: 0x0001
+bCppStructOpsFromBaseClass = 0xA0
+; bool                                Size: 0x0001
+bPrepareCppStructOpsCompleted = 0xA1
+UEP_TotalSize = 0xA8
+
+[UWorld]
+; Total Size: 0x758
+; TArray<UObject *,FDefaultAllocator> Size: 0x0010
+ExtraReferencedObjects = 0x70
+; TArray<UObject *,FDefaultAllocator> Size: 0x0010  Padding: 0x10
+PerModuleDataObjects = 0x80
+; FString                             Size: 0x0010  Padding: 0x20
+StreamingLevelsPrefix = 0xA0
+; TArray<FVector,FDefaultAllocator>   Size: 0x0010
+ViewLocationsRenderedLastFrame = 0xD0
+; uint32                              Size: 0x0004
+bWorldWasLoadedThisTick = 0xE0:0:1:4
+; uint32                              Size: 0x0004  Padding: 0xC
+bTriggerPostLoadMap = 0xE0:1:1:4
+; AGameMode*                          Size: 0x0008  Padding: 0x20
+AuthorityGameMode = 0xF0
+; TArray<AActor *,FDefaultAllocator>  Size: 0x0010  Padding: 0x2C
+NetworkActors = 0x118
+; FLevelViewportInfo[4]               Size: 0x0080  Padding: 0x18C
+EditorViews = 0x154
+; bool                                Size: 0x0001  Padding: 0xDF
+bRequiresHitProxies = 0x360
+; uint32                              Size: 0x0004  Padding: 0x4
+bStreamingDataDirty = 0x440:0:1:4
+; double                              Size: 0x0008  Padding: 0x80
+BuildStreamingDataTimer = 0x448
+; FURL                                Size: 0x0070  Padding: 0x10
+URL = 0x4D0
+; bool                                Size: 0x0001
+bInTick = 0x550
+; bool                                Size: 0x0001
+bIsBuilt = 0x551
+; bool                                Size: 0x0001  Padding: 0x145
+bTickNewlySpawned = 0x552
+; bool                                Size: 0x0001  Padding: 0x3
+bPostTickComponentUpdate = 0x698
+; int32                               Size: 0x0004
+PlayerNum = 0x69C
+; float                               Size: 0x0004
+TimeSinceLastPendingKillPurge = 0x6A0
+; bool                                Size: 0x0001
+FullPurgeTriggered = 0x6A4
+; bool                                Size: 0x0001
+bShouldDelayGarbageCollect = 0x6A5
+; bool                                Size: 0x0001  Padding: 0x1
+bIsWorldInitialized = 0x6A6
+; int32                               Size: 0x0004
+StreamingVolumeUpdateDelay = 0x6A8
+; bool                                Size: 0x0001
+bIsLevelStreamingFrozen = 0x6AC
+; bool                                Size: 0x0001
+bShouldForceUnloadStreamingLevels = 0x6AD
+; bool                                Size: 0x0001
+bShouldForceVisibleStreamingLevels = 0x6AE
+; bool                                Size: 0x0001  Padding: 0x1
+bDoDelayedUpdateCullDistanceVolumes = 0x6AF
+; bool                                Size: 0x0001
+bHack_Force_UsesGameHiddenFlags_True = 0x6B1
+; bool                                Size: 0x0001
+bIsRunningConstructionScript = 0x6B2
+; bool                                Size: 0x0001
+bShouldSimulatePhysics = 0x6B3
+; FName                               Size: 0x0008  Padding: 0x1C
+DebugDrawTraceTag = 0x6B4
+; double                              Size: 0x0008
+LastTimeUnbuiltLightingWasEncountered = 0x6D8
+; float                               Size: 0x0004
+TimeSeconds = 0x6E0
+; float                               Size: 0x0004
+RealTimeSeconds = 0x6E4
+; float                               Size: 0x0004
+AudioTimeSeconds = 0x6E8
+; float                               Size: 0x0004
+DeltaTimeSeconds = 0x6EC
+; float                               Size: 0x0004  Padding: 0x18
+PauseDelay = 0x6F0
+; bool                                Size: 0x0001  Padding: 0x13
+bOriginOffsetThisFrame = 0x70C
+; FString                             Size: 0x0010
+NextURL = 0x720
+; float                               Size: 0x0004  Padding: 0x4
+NextSwitchCountdown = 0x730
+; TArray<FName,FDefaultAllocator>     Size: 0x0010
+PreparingLevelNames = 0x738
+; FName                               Size: 0x0008
+CommittedPersistentLevelName = 0x748
+; uint32                              Size: 0x0004
+NumLightingUnbuiltObjects = 0x750
+; uint32                              Size: 0x0004
+bDropDetail = 0x754:0:1:4
+; uint32                              Size: 0x0004
+bAggressiveLOD = 0x754:1:1:4
+; uint32                              Size: 0x0004
+bIsDefaultLevel = 0x754:2:1:4
+; uint32                              Size: 0x0004
+bRequestedBlockOnAsyncLoading = 0x754:3:1:4
+; uint32                              Size: 0x0004
+bActorsInitialized = 0x754:4:1:4
+; uint32                              Size: 0x0004
+bBegunPlay = 0x754:5:1:4
+; uint32                              Size: 0x0004
+bMatchStarted = 0x754:6:1:4
+; uint32                              Size: 0x0004
+bPlayersOnly = 0x754:7:1:4
+; uint32                              Size: 0x0004
+bPlayersOnlyPending = 0x754:8:1:4
+; uint32                              Size: 0x0004
+bStartup = 0x754:9:1:4
+; uint32                              Size: 0x0004
+bIsTearingDown = 0x754:10:1:4
+; uint32                              Size: 0x0004
+bKismetScriptError = 0x754:11:1:4
+; uint32                              Size: 0x0004
+bDebugPauseExecution = 0x754:12:1:4
+; uint32                              Size: 0x0004
+bAllowAudioPlayback = 0x754:13:1:4
+; uint32                              Size: 0x0004
+bDebugFrameStepExecution = 0x754:14:1:4
+; uint32                              Size: 0x0004
+bAreConstraintsDirty = 0x754:15:1:4
+UEP_TotalSize = 0x758
+
+[UFunction]
+; Total Size: 0xB0
+; uint32                              Size: 0x0004
+FunctionFlags = 0x90
+; uint16                              Size: 0x0002
+RepOffset = 0x94
+; uint8                               Size: 0x0001  Padding: 0x1
+NumParms = 0x96
+; uint16                              Size: 0x0002
+ParmsSize = 0x98
+; uint16                              Size: 0x0002
+ReturnValueOffset = 0x9A
+; uint16                              Size: 0x0002
+RPCId = 0x9C
+; uint16                              Size: 0x0002
+RPCResponseId = 0x9E
+; FProperty*                          Size: 0x0008
+FirstPropertyToInit = 0xA0
+; void (UObject::*)(FFrame&, void* const) Size: 0x0008
+Func = 0xA8
+UEP_TotalSize = 0xB0
+
+[UClass]
+; Total Size: 0x180
+; std::function<void(const void*)>*   Size: 0x0008
+ClassConstructor = 0x90
+; std::function<void(UObject*, void*)>* Size: 0x0008
+ClassAddReferencedObjects = 0x98
+; uint32                              Size: 0x0004  Padding: 0x4
+ClassFlags = 0xA0
+; uint64                              Size: 0x0008
+ClassCastFlags = 0xA8
+; int32                               Size: 0x0004  Padding: 0x4
+ClassUnique = 0xB0
+; UClass*                             Size: 0x0008
+ClassWithin = 0xB8
+; UObject*                            Size: 0x0008
+ClassGeneratedBy = 0xC0
+; FName                               Size: 0x0008  Padding: 0x10
+ClassConfigName = 0xC8
+; TArray<UField *,FDefaultAllocator>  Size: 0x0010
+NetFields = 0xE0
+; UObject*                            Size: 0x0008
+ClassDefaultObject = 0xF0
+; bool                                Size: 0x0001  Padding: 0x7
+bCooked = 0xF8
+; TMap<FName, UFunction *>            Size: 0x0050
+FuncMap = 0x100
+; TArray<FImplementedInterface,FDefaultAllocator> Size: 0x0010
+Interfaces = 0x150
+; FGCReferenceTokenStream             Size: 0x0010
+ReferenceTokenStream = 0x160
+; TArray<FNativeFunctionLookup,FDefaultAllocator> Size: 0x0010
+NativeFunctionLookupTable = 0x170
+UEP_TotalSize = 0x180
+
+[UEnum]
+; Total Size: 0x58
+; FString                             Size: 0x0010
+CppType = 0x30
+; TArray<FName,FDefaultAllocator>     Size: 0x0010
+Names = 0x40
+; UEnum::ECppForm                     Size: 0x0004
+CppForm = 0x50
+UEP_TotalSize = 0x58
+
+[FStructProperty]
+; Total Size: 0x78
+; UScriptStruct*                      Size: 0x0008
+Struct = 0x70
+UEP_TotalSize = 0x78
+
+[FArrayProperty]
+; Total Size: 0x78
+; FProperty*                          Size: 0x0008
+Inner = 0x70
+UEP_TotalSize = 0x78
+
+[FBoolProperty]
+; Total Size: 0x78
+; uint8                               Size: 0x0001
+FieldSize = 0x70
+; uint8                               Size: 0x0001
+ByteOffset = 0x71
+; uint8                               Size: 0x0001
+ByteMask = 0x72
+; uint8                               Size: 0x0001
+FieldMask = 0x73
+UEP_TotalSize = 0x78
+
+[FByteProperty]
+; Total Size: 0x78
+; UEnum*                              Size: 0x0008
+Enum = 0x70
+UEP_TotalSize = 0x78
+
+[FClassProperty]
+; Total Size: 0x80
+; UClass*                             Size: 0x0008
+MetaClass = 0x78
+UEP_TotalSize = 0x80
+
+[FDelegateProperty]
+; Total Size: 0x78
+; UFunction*                          Size: 0x0008
+SignatureFunction = 0x70
+UEP_TotalSize = 0x78
+
+[FInterfaceProperty]
+; Total Size: 0x78
+; UClass*                             Size: 0x0008
+InterfaceClass = 0x70
+UEP_TotalSize = 0x78
+
+[UDataTable]
+; Total Size: 0x90
+; UScriptStruct*                      Size: 0x0008
+RowStruct = 0x28
+; FString                             Size: 0x0010
+ImportPath = 0x30
+; TMap<FName, unsigned char *>        Size: 0x0050
+RowMap = 0x40
+UEP_TotalSize = 0x90
+

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_08_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_08_Template.ini
@@ -1,0 +1,808 @@
+[UObjectBase]
+; Total Size: 0x28
+; EObjectFlags                        Size: 0x0004
+ObjectFlags = 0x8
+; int32                               Size: 0x0004
+InternalIndex = 0xC
+; UClass*                             Size: 0x0008
+Class = 0x10
+; FName                               Size: 0x0008
+Name = 0x18
+; UObject*                            Size: 0x0008
+Outer = 0x20
+UEP_TotalSize = 0x28
+
+[UScriptStruct::ICppStructOps]
+; Total Size: 0x10
+; const int32                         Size: 0x0004
+Size = 0x8
+; const int32                         Size: 0x0004
+Alignment = 0xC
+UEP_TotalSize = 0x10
+
+[FOutputDevice]
+; Total Size: 0x10
+; bool                                Size: 0x0001
+bSuppressEventTag = 0x8
+; bool                                Size: 0x0001
+bAutoEmitLineTerminator = 0x9
+UEP_TotalSize = 0x10
+
+[UStruct]
+; Total Size: 0x88
+; UStruct*                            Size: 0x0008
+SuperStruct = 0x30
+; UField*                             Size: 0x0008
+Children = 0x38
+; int32                               Size: 0x0004
+PropertiesSize = 0x40
+; int32                               Size: 0x0004
+MinAlignment = 0x44
+; TArray<unsigned char,FDefaultAllocator> Size: 0x0010
+Script = 0x48
+; FProperty*                          Size: 0x0008
+PropertyLink = 0x58
+; FProperty*                          Size: 0x0008
+RefLink = 0x60
+; FProperty*                          Size: 0x0008
+DestructorLink = 0x68
+; FProperty*                          Size: 0x0008
+PostConstructLink = 0x70
+; TArray<UObject *,FDefaultAllocator> Size: 0x0010
+ScriptObjectReferences = 0x78
+UEP_TotalSize = 0x88
+
+[UGameViewportClient]
+; Total Size: 0x248
+; UConsole*                           Size: 0x0008
+ViewportConsole = 0x38
+; TArray<FDebugDisplayProperty,FDefaultAllocator> Size: 0x0010
+DebugProperties = 0x40
+; FTitleSafeZoneArea                  Size: 0x0010
+TitleSafeZone = 0x50
+; TArray<FSplitscreenData,FDefaultAllocator> Size: 0x0010
+SplitscreenInfo = 0x60
+; int32                               Size: 0x0004
+MaxSplitscreenPlayers = 0x70
+; uint32                              Size: 0x0004
+bShowTitleSafeZone = 0x74:0:1:4
+; uint32                              Size: 0x0004
+bIsPlayInEditorViewport = 0x74:1:1:4
+; uint32                              Size: 0x0004
+bDisableWorldRendering = 0x74:2:1:4
+; TEnumAsByte<enum ESplitScreenType::Type> Size: 0x0001  Padding: 0x7
+ActiveSplitscreenType = 0x78
+; UWorld*                             Size: 0x0008  Padding: 0x8
+World = 0x80
+; bool                                Size: 0x0001  Padding: 0x3
+bSuppressTransitionMessage = 0x90
+; int32                               Size: 0x0004
+ViewModeIndex = 0x94
+; FEngineShowFlags                    Size: 0x0010
+EngineShowFlags = 0x98
+; FViewport*                          Size: 0x0008
+Viewport = 0xA8
+; FViewportFrame*                     Size: 0x0008
+ViewportFrame = 0xB0
+; TWeakPtr<SWindow,0>                 Size: 0x0010
+Window = 0xB8
+; TWeakPtr<SOverlay,0>                Size: 0x0010
+ViewportOverlayWidget = 0xC8
+; TWeakPtr<IGameLayerManager,0>       Size: 0x0010
+GameLayerManagerPtr = 0xD8
+; FName                               Size: 0x0008
+CurrentBufferVisualizationMode = 0xE8
+; TWeakPtr<SWindow,0>                 Size: 0x0010
+HighResScreenshotDialog = 0xF0
+; TMap<enum EMouseCursor::Type, TSharedRef<SWidget,0>> Size: 0x0050
+CursorWidgets = 0x100
+; TBaseDelegate<void,FViewport *>     Size: 0x0008  Padding: 0xC0
+CloseRequestedDelegate = 0x150
+; FStatUnitData*                      Size: 0x0008
+StatUnitData = 0x218
+; FStatHitchesData*                   Size: 0x0008
+StatHitchesData = 0x220
+; bool                                Size: 0x0001
+bDisableSplitScreenOverride = 0x228
+; bool                                Size: 0x0001  Padding: 0x2
+bIgnoreInput = 0x229
+; EMouseCaptureMode::Type             Size: 0x0004
+MouseCaptureMode = 0x22C
+; bool                                Size: 0x0001  Padding: 0xF
+bHideCursorDuringCapture = 0x230
+; uint32                              Size: 0x0004
+AudioDeviceHandle = 0x240
+; bool                                Size: 0x0001
+bHasAudioFocus = 0x244
+UEP_TotalSize = 0x248
+
+[FUObjectArray]
+; Total Size: 0x1068
+; int32                               Size: 0x0004
+ObjFirstGCIndex = 0x0
+; int32                               Size: 0x0004
+ObjLastNonGCIndex = 0x4
+; int32                               Size: 0x0004  Padding: 0x4
+OpenForDisregardForGC = 0x8
+; TStaticIndirectArrayThreadSafeRead<UObjectBase,8388608,16384> Size: 0x1008  Padding: 0x28
+ObjObjects = 0x10
+; TLockFreePointerList<int>           Size: 0x0008
+ObjAvailableList = 0x1040
+; TArray<FUObjectArray::FUObjectCreateListener *,FDefaultAllocator> Size: 0x0010
+UObjectCreateListeners = 0x1048
+; TArray<FUObjectArray::FUObjectDeleteListener *,FDefaultAllocator> Size: 0x0010
+UObjectDeleteListeners = 0x1058
+UEP_TotalSize = 0x1068
+
+[TUObjectArray]
+; Total Size: 0x1008
+; UObjectBase**[512]                  Size: 0x1000
+Chunks = 0x0
+; int32                               Size: 0x0004
+NumElements = 0x1000
+; int32                               Size: 0x0004
+NumChunks = 0x1004
+UEP_TotalSize = 0x1008
+
+[FArchive]
+; Total Size: 0x68
+; int32                               Size: 0x0004
+ArNetVer = 0x8
+; int32                               Size: 0x0004
+ArUE4Ver = 0xC
+; int32                               Size: 0x0004
+ArLicenseeUE4Ver = 0x10
+; FEngineVersionBase                  Size: 0x000C
+ArEngineVer = 0x14
+; FCustomVersionContainer*            Size: 0x0008
+CustomVersionContainer = 0x20
+; bool                                Size: 0x0001
+ArIsLoading = 0x28
+; bool                                Size: 0x0001
+ArIsSaving = 0x29
+; bool                                Size: 0x0001
+ArIsTransacting = 0x2A
+; bool                                Size: 0x0001
+ArWantBinaryPropertySerialization = 0x2B
+; bool                                Size: 0x0001
+ArForceUnicode = 0x2C
+; bool                                Size: 0x0001
+ArIsPersistent = 0x2D
+; bool                                Size: 0x0001
+ArIsError = 0x2E
+; bool                                Size: 0x0001
+ArIsCriticalError = 0x2F
+; bool                                Size: 0x0001
+ArContainsCode = 0x30
+; bool                                Size: 0x0001
+ArContainsMap = 0x31
+; bool                                Size: 0x0001
+ArRequiresLocalizationGather = 0x32
+; bool                                Size: 0x0001
+ArForceByteSwapping = 0x33
+; bool                                Size: 0x0001
+ArIgnoreArchetypeRef = 0x34
+; bool                                Size: 0x0001
+ArNoDelta = 0x35
+; bool                                Size: 0x0001
+ArIgnoreOuterRef = 0x36
+; bool                                Size: 0x0001
+ArIgnoreClassRef = 0x37
+; bool                                Size: 0x0001
+ArAllowLazyLoading = 0x38
+; bool                                Size: 0x0001
+ArIsObjectReferenceCollector = 0x39
+; bool                                Size: 0x0001
+ArIsModifyingWeakAndStrongReferences = 0x3A
+; bool                                Size: 0x0001
+ArIsCountingMemory = 0x3B
+; bool                                Size: 0x0001
+ArShouldSkipBulkData = 0x3C
+; bool                                Size: 0x0001
+ArIsFilterEditorOnly = 0x3D
+; bool                                Size: 0x0001  Padding: 0x1
+ArIsSaveGame = 0x3E
+; int32                               Size: 0x0004
+ArSerializingDefaults = 0x40
+; uint32                              Size: 0x0004
+ArPortFlags = 0x44
+; int64                               Size: 0x0008
+ArMaxSerializeSize = 0x48
+; const ITargetPlatform*              Size: 0x0008
+CookingTargetPlatform = 0x50
+; FProperty*                          Size: 0x0008
+SerializedProperty = 0x58
+; bool                                Size: 0x0001
+bCustomVersionsAreReset = 0x60
+UEP_TotalSize = 0x68
+
+[AGameMode]
+; Total Size: 0x3D0
+; FName                               Size: 0x0008
+MatchState = 0x2F0
+; uint32                              Size: 0x0004
+bUseSeamlessTravel = 0x2F8:0:1:4
+; uint32                              Size: 0x0004
+bPauseable = 0x2F8:1:1:4
+; uint32                              Size: 0x0004
+bStartPlayersAsSpectators = 0x2F8:2:1:4
+; uint32                              Size: 0x0004  Padding: 0x4
+bDelayedStart = 0x2F8:3:1:4
+; FString                             Size: 0x0010  Padding: 0x8
+OptionsString = 0x300
+; TSubclassOf<AHUD>                   Size: 0x0008
+HUDClass = 0x318
+; int32                               Size: 0x0004
+NumSpectators = 0x320
+; int32                               Size: 0x0004
+NumPlayers = 0x324
+; int32                               Size: 0x0004
+NumBots = 0x328
+; float                               Size: 0x0004
+MinRespawnDelay = 0x32C
+; AGameSession*                       Size: 0x0008
+GameSession = 0x330
+; int32                               Size: 0x0004
+NumTravellingPlayers = 0x338
+; int32                               Size: 0x0004
+CurrentID = 0x33C
+; FText                               Size: 0x0028
+DefaultPlayerName = 0x340
+; TSubclassOf<ULocalMessage>          Size: 0x0008  Padding: 0x8
+EngineMessageClass = 0x368
+; TSubclassOf<ASpectatorPawn>         Size: 0x0008
+SpectatorClass = 0x378
+; TSubclassOf<APlayerState>           Size: 0x0008  Padding: 0x10
+PlayerStateClass = 0x380
+; TArray<APlayerState *,FDefaultAllocator> Size: 0x0010
+InactivePlayerArray = 0x398
+; TArray<TBaseDelegate<bool>,FDefaultAllocator> Size: 0x0010
+Pausers = 0x3A8
+; TArray<FGameClassShortName,FDefaultAllocator> Size: 0x0010
+GameModeClassAliases = 0x3B8
+; float                               Size: 0x0004
+InactivePlayerStateLifeSpan = 0x3C8
+; bool                                Size: 0x0001
+bHandleDedicatedServerReplays = 0x3CC
+UEP_TotalSize = 0x3D0
+
+[AActor]
+; Total Size: 0x2F0
+; FActorTickFunction                  Size: 0x0048
+PrimaryActorTick = 0x28
+; float                               Size: 0x0004
+CustomTimeDilation = 0x70
+; uint32                              Size: 0x0004
+bHidden = 0x74:0:1:4
+; uint32                              Size: 0x0004
+bNetTemporary = 0x74:1:1:4
+; uint32                              Size: 0x0004
+bNetStartup = 0x74:2:1:4
+; uint32                              Size: 0x0004
+bOnlyRelevantToOwner = 0x74:3:1:4
+; uint32                              Size: 0x0004
+bAlwaysRelevant = 0x74:4:1:4
+; uint32                              Size: 0x0004
+bReplicateMovement = 0x74:5:1:4
+; uint32                              Size: 0x0004
+bTearOff = 0x74:6:1:4
+; uint32                              Size: 0x0004
+bExchangedRoles = 0x74:7:1:4
+; uint32                              Size: 0x0004
+bPendingNetUpdate = 0x74:8:1:4
+; uint32                              Size: 0x0004
+bNetLoadOnClient = 0x74:9:1:4
+; uint32                              Size: 0x0004
+bNetUseOwnerRelevancy = 0x74:10:1:4
+; uint32                              Size: 0x0004
+bBlockInput = 0x74:11:1:4
+; uint32                              Size: 0x0004
+bRunningUserConstructionScript = 0x74:12:1:4
+; uint32                              Size: 0x0004
+bHasFinishedSpawning = 0x74:13:1:4
+; uint32                              Size: 0x0004
+bActorEnableCollision = 0x74:14:1:4
+; uint32                              Size: 0x0004
+bReplicates = 0x74:15:1:4
+; TEnumAsByte<enum ENetRole>          Size: 0x0001  Padding: 0x7
+RemoteRole = 0x78
+; AActor*                             Size: 0x0008
+Owner = 0x80
+; FRepMovement                        Size: 0x0034  Padding: 0x4
+ReplicatedMovement = 0x88
+; FRepAttachment                      Size: 0x0040
+AttachmentReplication = 0xC0
+; TEnumAsByte<enum ENetRole>          Size: 0x0001
+Role = 0x100
+; TEnumAsByte<enum ENetDormancy>      Size: 0x0001
+NetDormancy = 0x101
+; TEnumAsByte<enum EAutoReceiveInput::Type> Size: 0x0001  Padding: 0x1
+AutoReceiveInput = 0x102
+; int32                               Size: 0x0004
+InputPriority = 0x104
+; UInputComponent*                    Size: 0x0008
+InputComponent = 0x108
+; TEnumAsByte<enum EInputConsumeOptions> Size: 0x0001  Padding: 0x3
+InputConsumeOption_DEPRECATED = 0x110
+; float                               Size: 0x0004
+NetCullDistanceSquared = 0x114
+; int32                               Size: 0x0004
+NetTag = 0x118
+; float                               Size: 0x0004
+NetUpdateTime = 0x11C
+; float                               Size: 0x0004
+NetUpdateFrequency = 0x120
+; float                               Size: 0x0004
+NetPriority = 0x124
+; float                               Size: 0x0004
+LastNetUpdateTime = 0x128
+; FName                               Size: 0x0008
+NetDriverName = 0x12C
+; uint32                              Size: 0x0004
+bAutoDestroyWhenFinished = 0x134:0:1:4
+; uint32                              Size: 0x0004
+bCanBeDamaged = 0x134:1:1:4
+; uint32                              Size: 0x0004
+bPendingKillPending = 0x134:2:1:4
+; uint32                              Size: 0x0004
+bCollideWhenPlacing = 0x134:3:1:4
+; uint32                              Size: 0x0004
+bFindCameraComponentWhenViewTarget = 0x134:4:1:4
+; uint32                              Size: 0x0004
+bRelevantForNetworkReplays = 0x134:5:1:4
+; float                               Size: 0x0004  Padding: 0xC
+CreationTime = 0x138
+; TArray<AActor *,FDefaultAllocator>  Size: 0x0010
+Children = 0x148
+; USceneComponent*                    Size: 0x0008
+RootComponent = 0x158
+; TArray<AMatineeActor *,FDefaultAllocator> Size: 0x0010
+ControllingMatineeActors = 0x160
+; float                               Size: 0x0004
+InitialLifeSpan = 0x170
+; FTimerHandle                        Size: 0x0004
+TimerHandle_LifeSpanExpired = 0x174
+; uint32                              Size: 0x0004  Padding: 0x4
+bAllowReceiveTickEventOnDedicatedServer = 0x178:0:1:4
+; TArray<FName,FDefaultAllocator>     Size: 0x0010
+Layers = 0x180
+; TWeakObjectPtr<AActor,FWeakObjectPtr> Size: 0x0008
+ParentComponentActor = 0x190
+; uint32                              Size: 0x0004
+bActorInitialized = 0x198:0:1:4
+; uint32                              Size: 0x0004
+bActorHasBegunPlay = 0x198:1:1:4
+; uint32                              Size: 0x0004
+bActorSeamlessTraveled = 0x198:2:1:4
+; uint32                              Size: 0x0004
+bIgnoresOriginShifting = 0x198:3:1:4
+; uint32                              Size: 0x0004  Padding: 0x4
+bEnableAutoLODGeneration = 0x198:4:1:4
+; TArray<FName,FDefaultAllocator>     Size: 0x0010
+Tags = 0x1A0
+; uint64                              Size: 0x0008
+HiddenEditorViews = 0x1B0
+; FTakeAnyDamageSignature             Size: 0x0010
+OnTakeAnyDamage = 0x1B8
+; FTakePointDamageSignature           Size: 0x0010
+OnTakePointDamage = 0x1C8
+; FActorBeginOverlapSignature         Size: 0x0010
+OnActorBeginOverlap = 0x1D8
+; FActorEndOverlapSignature           Size: 0x0010
+OnActorEndOverlap = 0x1E8
+; FActorBeginCursorOverSignature      Size: 0x0010
+OnBeginCursorOver = 0x1F8
+; FActorEndCursorOverSignature        Size: 0x0010
+OnEndCursorOver = 0x208
+; FActorOnClickedSignature            Size: 0x0010
+OnClicked = 0x218
+; FActorOnReleasedSignature           Size: 0x0010
+OnReleased = 0x228
+; FActorOnInputTouchBeginSignature    Size: 0x0010
+OnInputTouchBegin = 0x238
+; FActorOnInputTouchEndSignature      Size: 0x0010
+OnInputTouchEnd = 0x248
+; FActorBeginTouchOverSignature       Size: 0x0010
+OnInputTouchEnter = 0x258
+; FActorEndTouchOverSignature         Size: 0x0010
+OnInputTouchLeave = 0x268
+; FActorHitSignature                  Size: 0x0010
+OnActorHit = 0x278
+; FActorDestroyedSignature            Size: 0x0010
+OnDestroyed = 0x288
+; FActorEndPlaySignature              Size: 0x0010  Padding: 0x40
+OnEndPlay = 0x298
+; FRenderCommandFence                 Size: 0x0008
+DetachFence = 0x2E8
+UEP_TotalSize = 0x2F0
+
+[UPlayer]
+; Total Size: 0x48
+; int32                               Size: 0x0004
+CurrentNetSpeed = 0x38
+; int32                               Size: 0x0004
+ConfiguredInternetSpeed = 0x3C
+; int32                               Size: 0x0004
+ConfiguredLanSpeed = 0x40
+UEP_TotalSize = 0x48
+
+[ULocalPlayer]
+; Total Size: 0x198
+; TSharedPtr<FUniqueNetId,0>          Size: 0x0010
+CachedUniqueNetId = 0x48
+; UGameViewportClient*                Size: 0x0008
+ViewportClient = 0x58
+; FVector2D                           Size: 0x0008
+Origin = 0x60
+; FVector2D                           Size: 0x0008
+Size = 0x68
+; FVector                             Size: 0x000C
+LastViewLocation = 0x70
+; TEnumAsByte<enum EAspectRatioAxisConstraint> Size: 0x0001  Padding: 0xB
+AspectRatioAxisConstraint = 0x7C
+; uint32                              Size: 0x0004  Padding: 0x54
+bSentSplitJoin = 0x88:0:1:4
+; UOnlineSession*                     Size: 0x0008
+OnlineSession = 0xE0
+; int32                               Size: 0x0004  Padding: 0x4
+ControllerId = 0xE8
+; FReply                              Size: 0x00A8
+SlateOperations = 0xF0
+UEP_TotalSize = 0x198
+
+[UField]
+; Total Size: 0x30
+; UField*                             Size: 0x0008
+Next = 0x28
+UEP_TotalSize = 0x30
+
+[FProperty]
+; Total Size: 0x70
+; int32                               Size: 0x0004
+ArrayDim = 0x30
+; int32                               Size: 0x0004
+ElementSize = 0x34
+; uint64                              Size: 0x0008
+PropertyFlags = 0x38
+; uint16                              Size: 0x0002  Padding: 0x2
+RepIndex = 0x40
+; FName                               Size: 0x0008
+RepNotifyFunc = 0x44
+; int32                               Size: 0x0004
+Offset_Internal = 0x4C
+; FProperty*                          Size: 0x0008
+PropertyLinkNext = 0x50
+; FProperty*                          Size: 0x0008
+NextRef = 0x58
+; FProperty*                          Size: 0x0008
+DestructorLinkNext = 0x60
+; FProperty*                          Size: 0x0008
+PostConstructLinkNext = 0x68
+UEP_TotalSize = 0x70
+
+[FMulticastDelegateProperty]
+; Total Size: 0x78
+; UFunction*                          Size: 0x0008
+SignatureFunction = 0x70
+UEP_TotalSize = 0x78
+
+[FObjectPropertyBase]
+; Total Size: 0x78
+; UClass*                             Size: 0x0008
+PropertyClass = 0x70
+UEP_TotalSize = 0x78
+
+[FWorldContext]
+; Total Size: 0x298
+; FName                               Size: 0x0008
+ContextHandle = 0xC0
+; FString                             Size: 0x0010
+TravelURL = 0xC8
+; uint8                               Size: 0x0001  Padding: 0x7
+TravelType = 0xD8
+; FURL                                Size: 0x0070
+LastURL = 0xE0
+; FURL                                Size: 0x0070  Padding: 0x18
+LastRemoteURL = 0x150
+; TArray<FName,FDefaultAllocator>     Size: 0x0010  Padding: 0x10
+LevelsToLoadForPendingMapChange = 0x1D8
+; FString                             Size: 0x0010
+PendingMapChangeFailureDescription = 0x1F8
+; uint32                              Size: 0x0004  Padding: 0x24
+bShouldCommitPendingMapChange = 0x208:0:1:4
+; UGameViewportClient*                Size: 0x0008  Padding: 0x18
+GameViewport = 0x230
+; int32                               Size: 0x0004  Padding: 0x4
+PIEInstance = 0x250
+; FString                             Size: 0x0010
+PIEPrefix = 0x258
+; FString                             Size: 0x0010
+PIERemapPrefix = 0x268
+; bool                                Size: 0x0001
+RunAsDedicated = 0x278
+; bool                                Size: 0x0001  Padding: 0x2
+bWaitingOnOnlineSubsystem = 0x279
+; uint32                              Size: 0x0004
+AudioDeviceHandle = 0x27C
+; TArray<UWorld * *,FDefaultAllocator> Size: 0x0010
+ExternalReferences = 0x280
+; UWorld*                             Size: 0x0008
+ThisCurrentWorld = 0x290
+UEP_TotalSize = 0x298
+
+[UScriptStruct]
+; Total Size: 0x98
+; EStructFlags                        Size: 0x0004
+StructFlags = 0x88
+; bool                                Size: 0x0001
+bCppStructOpsFromBaseClass = 0x8C
+; bool                                Size: 0x0001  Padding: 0x2
+bPrepareCppStructOpsCompleted = 0x8D
+; UScriptStruct::ICppStructOps*       Size: 0x0008
+CppStructOps = 0x90
+UEP_TotalSize = 0x98
+
+[UWorld]
+; Total Size: 0x708
+; TArray<UObject *,FDefaultAllocator> Size: 0x0010
+ExtraReferencedObjects = 0x70
+; TArray<UObject *,FDefaultAllocator> Size: 0x0010  Padding: 0x10
+PerModuleDataObjects = 0x80
+; FString                             Size: 0x0010  Padding: 0x20
+StreamingLevelsPrefix = 0xA0
+; TArray<FVector,FDefaultAllocator>   Size: 0x0010
+ViewLocationsRenderedLastFrame = 0xD0
+; uint32                              Size: 0x0004
+bWorldWasLoadedThisTick = 0xE0:0:1:4
+; uint32                              Size: 0x0004  Padding: 0xC
+bTriggerPostLoadMap = 0xE0:1:1:4
+; AGameMode*                          Size: 0x0008  Padding: 0x20
+AuthorityGameMode = 0xF0
+; TArray<AActor *,FDefaultAllocator>  Size: 0x0010  Padding: 0x1B8
+NetworkActors = 0x118
+; bool                                Size: 0x0001  Padding: 0x11F
+bRequiresHitProxies = 0x2E0
+; uint32                              Size: 0x0004  Padding: 0x4
+bStreamingDataDirty = 0x400:0:1:4
+; double                              Size: 0x0008  Padding: 0x80
+BuildStreamingDataTimer = 0x408
+; FURL                                Size: 0x0070  Padding: 0x10
+URL = 0x490
+; bool                                Size: 0x0001
+bInTick = 0x510
+; bool                                Size: 0x0001
+bIsBuilt = 0x511
+; bool                                Size: 0x0001  Padding: 0x125
+bTickNewlySpawned = 0x512
+; bool                                Size: 0x0001  Padding: 0x3
+bPostTickComponentUpdate = 0x638
+; int32                               Size: 0x0004
+PlayerNum = 0x63C
+; float                               Size: 0x0004
+TimeSinceLastPendingKillPurge = 0x640
+; bool                                Size: 0x0001
+FullPurgeTriggered = 0x644
+; bool                                Size: 0x0001
+bShouldDelayGarbageCollect = 0x645
+; bool                                Size: 0x0001  Padding: 0x1
+bIsWorldInitialized = 0x646
+; int32                               Size: 0x0004
+StreamingVolumeUpdateDelay = 0x648
+; bool                                Size: 0x0001
+bIsLevelStreamingFrozen = 0x64C
+; bool                                Size: 0x0001
+bShouldForceUnloadStreamingLevels = 0x64D
+; bool                                Size: 0x0001
+bShouldForceVisibleStreamingLevels = 0x64E
+; bool                                Size: 0x0001  Padding: 0x1
+bDoDelayedUpdateCullDistanceVolumes = 0x64F
+; bool                                Size: 0x0001
+bHack_Force_UsesGameHiddenFlags_True = 0x651
+; bool                                Size: 0x0001
+bIsRunningConstructionScript = 0x652
+; bool                                Size: 0x0001
+bShouldSimulatePhysics = 0x653
+; FName                               Size: 0x0008  Padding: 0x1C
+DebugDrawTraceTag = 0x654
+; uint32                              Size: 0x0004  Padding: 0x4
+AudioDeviceHandle = 0x678
+; double                              Size: 0x0008
+LastTimeUnbuiltLightingWasEncountered = 0x680
+; float                               Size: 0x0004
+TimeSeconds = 0x688
+; float                               Size: 0x0004
+RealTimeSeconds = 0x68C
+; float                               Size: 0x0004
+AudioTimeSeconds = 0x690
+; float                               Size: 0x0004
+DeltaTimeSeconds = 0x694
+; float                               Size: 0x0004  Padding: 0x18
+PauseDelay = 0x698
+; bool                                Size: 0x0001  Padding: 0x13
+bOriginOffsetThisFrame = 0x6B4
+; FString                             Size: 0x0010
+NextURL = 0x6C8
+; float                               Size: 0x0004  Padding: 0x4
+NextSwitchCountdown = 0x6D8
+; TArray<FName,FDefaultAllocator>     Size: 0x0010
+PreparingLevelNames = 0x6E0
+; FName                               Size: 0x0008
+CommittedPersistentLevelName = 0x6F0
+; uint32                              Size: 0x0004
+NumLightingUnbuiltObjects = 0x6F8
+; uint32                              Size: 0x0004
+bDropDetail = 0x6FC:0:1:4
+; uint32                              Size: 0x0004
+bAggressiveLOD = 0x6FC:1:1:4
+; uint32                              Size: 0x0004
+bIsDefaultLevel = 0x6FC:2:1:4
+; uint32                              Size: 0x0004
+bRequestedBlockOnAsyncLoading = 0x6FC:3:1:4
+; uint32                              Size: 0x0004
+bActorsInitialized = 0x6FC:4:1:4
+; uint32                              Size: 0x0004
+bBegunPlay = 0x6FC:5:1:4
+; uint32                              Size: 0x0004
+bMatchStarted = 0x6FC:6:1:4
+; uint32                              Size: 0x0004
+bPlayersOnly = 0x6FC:7:1:4
+; uint32                              Size: 0x0004
+bPlayersOnlyPending = 0x6FC:8:1:4
+; uint32                              Size: 0x0004
+bStartup = 0x6FC:9:1:4
+; uint32                              Size: 0x0004
+bIsTearingDown = 0x6FC:10:1:4
+; uint32                              Size: 0x0004
+bKismetScriptError = 0x6FC:11:1:4
+; uint32                              Size: 0x0004
+bDebugPauseExecution = 0x6FC:12:1:4
+; uint32                              Size: 0x0004
+bAllowAudioPlayback = 0x6FC:13:1:4
+; uint32                              Size: 0x0004
+bDebugFrameStepExecution = 0x6FC:14:1:4
+; uint32                              Size: 0x0004
+bAreConstraintsDirty = 0x6FC:15:1:4
+; FThreadSafeCounter                  Size: 0x0004
+AsyncPreRegisterLevelStreamingTasks = 0x700
+UEP_TotalSize = 0x708
+
+[UFunction]
+; Total Size: 0xB8
+; uint32                              Size: 0x0004
+FunctionFlags = 0x88
+; uint16                              Size: 0x0002
+RepOffset = 0x8C
+; uint8                               Size: 0x0001  Padding: 0x1
+NumParms = 0x8E
+; uint16                              Size: 0x0002
+ParmsSize = 0x90
+; uint16                              Size: 0x0002
+ReturnValueOffset = 0x92
+; uint16                              Size: 0x0002
+RPCId = 0x94
+; uint16                              Size: 0x0002
+RPCResponseId = 0x96
+; FProperty*                          Size: 0x0008
+FirstPropertyToInit = 0x98
+; UFunction*                          Size: 0x0008
+EventGraphFunction = 0xA0
+; int32                               Size: 0x0004  Padding: 0x4
+EventGraphCallOffset = 0xA8
+; void (UObject::*)(FFrame&, void* const) Size: 0x0008
+Func = 0xB0
+UEP_TotalSize = 0xB8
+
+[UClass]
+; Total Size: 0x180
+; std::function<void(const void*)>*   Size: 0x0008
+ClassConstructor = 0x90
+; std::function<UObject*(void*)>*     Size: 0x0008
+ClassVTableHelperCtorCaller = 0x98
+; std::function<void(UObject*, void*)>* Size: 0x0008
+ClassAddReferencedObjects = 0xA0
+; int32                               Size: 0x0004
+ClassUnique = 0xA8
+; uint32                              Size: 0x0004
+ClassFlags = 0xAC
+; uint64                              Size: 0x0008
+ClassCastFlags = 0xB0
+; UClass*                             Size: 0x0008
+ClassWithin = 0xB8
+; UObject*                            Size: 0x0008
+ClassGeneratedBy = 0xC0
+; FName                               Size: 0x0008
+ClassConfigName = 0xC8
+; bool                                Size: 0x0001  Padding: 0x17
+bCooked = 0xD0
+; TArray<UField *,FDefaultAllocator>  Size: 0x0010
+NetFields = 0xE8
+; UObject*                            Size: 0x0008
+ClassDefaultObject = 0xF8
+; TMap<FName, UFunction *>            Size: 0x0050
+FuncMap = 0x100
+; TArray<FImplementedInterface,FDefaultAllocator> Size: 0x0010
+Interfaces = 0x150
+; FGCReferenceTokenStream             Size: 0x0010
+ReferenceTokenStream = 0x160
+; TArray<FNativeFunctionLookup,FDefaultAllocator> Size: 0x0010
+NativeFunctionLookupTable = 0x170
+UEP_TotalSize = 0x180
+
+[UEnum]
+; Total Size: 0x58
+; FString                             Size: 0x0010
+CppType = 0x30
+; TArray<FName,FDefaultAllocator>     Size: 0x0010
+Names = 0x40
+; UEnum::ECppForm                     Size: 0x0004
+CppForm = 0x50
+UEP_TotalSize = 0x58
+
+[FStructProperty]
+; Total Size: 0x78
+; UScriptStruct*                      Size: 0x0008
+Struct = 0x70
+UEP_TotalSize = 0x78
+
+[FArrayProperty]
+; Total Size: 0x78
+; FProperty*                          Size: 0x0008
+Inner = 0x70
+UEP_TotalSize = 0x78
+
+[FMapProperty]
+; Total Size: 0xA8
+; FProperty*                          Size: 0x0008
+KeyProp = 0x70
+; FProperty*                          Size: 0x0008
+ValueProp = 0x78
+; FScriptMapLayout                    Size: 0x0024
+MapLayout = 0x80
+UEP_TotalSize = 0xA8
+
+[FBoolProperty]
+; Total Size: 0x78
+; uint8                               Size: 0x0001
+FieldSize = 0x70
+; uint8                               Size: 0x0001
+ByteOffset = 0x71
+; uint8                               Size: 0x0001
+ByteMask = 0x72
+; uint8                               Size: 0x0001
+FieldMask = 0x73
+UEP_TotalSize = 0x78
+
+[FByteProperty]
+; Total Size: 0x78
+; UEnum*                              Size: 0x0008
+Enum = 0x70
+UEP_TotalSize = 0x78
+
+[FClassProperty]
+; Total Size: 0x80
+; UClass*                             Size: 0x0008
+MetaClass = 0x78
+UEP_TotalSize = 0x80
+
+[FDelegateProperty]
+; Total Size: 0x78
+; UFunction*                          Size: 0x0008
+SignatureFunction = 0x70
+UEP_TotalSize = 0x78
+
+[FInterfaceProperty]
+; Total Size: 0x78
+; UClass*                             Size: 0x0008
+InterfaceClass = 0x70
+UEP_TotalSize = 0x78
+
+[UDataTable]
+; Total Size: 0x90
+; UScriptStruct*                      Size: 0x0008
+RowStruct = 0x28
+; FString                             Size: 0x0010
+ImportPath = 0x30
+; TMap<FName, unsigned char *>        Size: 0x0050
+RowMap = 0x40
+UEP_TotalSize = 0x90
+

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_09_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_09_Template.ini
@@ -1,0 +1,806 @@
+[UObjectBase]
+; Total Size: 0x28
+; EObjectFlags                        Size: 0x0004
+ObjectFlags = 0x8
+; int32                               Size: 0x0004
+InternalIndex = 0xC
+; UClass*                             Size: 0x0008
+Class = 0x10
+; FName                               Size: 0x0008
+Name = 0x18
+; UObject*                            Size: 0x0008
+Outer = 0x20
+UEP_TotalSize = 0x28
+
+[UScriptStruct::ICppStructOps]
+; Total Size: 0x10
+; const int32                         Size: 0x0004
+Size = 0x8
+; const int32                         Size: 0x0004
+Alignment = 0xC
+UEP_TotalSize = 0x10
+
+[FOutputDevice]
+; Total Size: 0x10
+; bool                                Size: 0x0001
+bSuppressEventTag = 0x8
+; bool                                Size: 0x0001
+bAutoEmitLineTerminator = 0x9
+UEP_TotalSize = 0x10
+
+[UStruct]
+; Total Size: 0x88
+; UStruct*                            Size: 0x0008
+SuperStruct = 0x30
+; UField*                             Size: 0x0008
+Children = 0x38
+; int32                               Size: 0x0004
+PropertiesSize = 0x40
+; int32                               Size: 0x0004
+MinAlignment = 0x44
+; TArray<unsigned char,FDefaultAllocator> Size: 0x0010
+Script = 0x48
+; FProperty*                          Size: 0x0008
+PropertyLink = 0x58
+; FProperty*                          Size: 0x0008
+RefLink = 0x60
+; FProperty*                          Size: 0x0008
+DestructorLink = 0x68
+; FProperty*                          Size: 0x0008
+PostConstructLink = 0x70
+; TArray<UObject *,FDefaultAllocator> Size: 0x0010
+ScriptObjectReferences = 0x78
+UEP_TotalSize = 0x88
+
+[UGameViewportClient]
+; Total Size: 0x248
+; UConsole*                           Size: 0x0008
+ViewportConsole = 0x38
+; TArray<FDebugDisplayProperty,FDefaultAllocator> Size: 0x0010
+DebugProperties = 0x40
+; FTitleSafeZoneArea                  Size: 0x0010
+TitleSafeZone = 0x50
+; TArray<FSplitscreenData,FDefaultAllocator> Size: 0x0010
+SplitscreenInfo = 0x60
+; int32                               Size: 0x0004
+MaxSplitscreenPlayers = 0x70
+; uint32                              Size: 0x0004
+bShowTitleSafeZone = 0x74:0:1:4
+; uint32                              Size: 0x0004
+bIsPlayInEditorViewport = 0x74:1:1:4
+; uint32                              Size: 0x0004
+bDisableWorldRendering = 0x74:2:1:4
+; TEnumAsByte<enum ESplitScreenType::Type> Size: 0x0001  Padding: 0x7
+ActiveSplitscreenType = 0x78
+; UWorld*                             Size: 0x0008  Padding: 0x8
+World = 0x80
+; bool                                Size: 0x0001  Padding: 0x3
+bSuppressTransitionMessage = 0x90
+; int32                               Size: 0x0004
+ViewModeIndex = 0x94
+; FEngineShowFlags                    Size: 0x0010
+EngineShowFlags = 0x98
+; FViewport*                          Size: 0x0008
+Viewport = 0xA8
+; FViewportFrame*                     Size: 0x0008
+ViewportFrame = 0xB0
+; TWeakPtr<SWindow,0>                 Size: 0x0010
+Window = 0xB8
+; TWeakPtr<SOverlay,0>                Size: 0x0010
+ViewportOverlayWidget = 0xC8
+; TWeakPtr<IGameLayerManager,0>       Size: 0x0010
+GameLayerManagerPtr = 0xD8
+; FName                               Size: 0x0008
+CurrentBufferVisualizationMode = 0xE8
+; TWeakPtr<SWindow,0>                 Size: 0x0010
+HighResScreenshotDialog = 0xF0
+; TMap<enum EMouseCursor::Type, TSharedRef<SWidget,0>> Size: 0x0050
+CursorWidgets = 0x100
+; TBaseDelegate<void,FViewport *>     Size: 0x0008  Padding: 0xC0
+CloseRequestedDelegate = 0x150
+; FStatUnitData*                      Size: 0x0008
+StatUnitData = 0x218
+; FStatHitchesData*                   Size: 0x0008
+StatHitchesData = 0x220
+; bool                                Size: 0x0001
+bDisableSplitScreenOverride = 0x228
+; bool                                Size: 0x0001  Padding: 0x2
+bIgnoreInput = 0x229
+; EMouseCaptureMode::Type             Size: 0x0004
+MouseCaptureMode = 0x22C
+; bool                                Size: 0x0001  Padding: 0xF
+bHideCursorDuringCapture = 0x230
+; uint32                              Size: 0x0004
+AudioDeviceHandle = 0x240
+; bool                                Size: 0x0001
+bHasAudioFocus = 0x244
+UEP_TotalSize = 0x248
+
+[FUObjectArray]
+; Total Size: 0x1090
+; int32                               Size: 0x0004
+ObjFirstGCIndex = 0x0
+; int32                               Size: 0x0004
+ObjLastNonGCIndex = 0x4
+; int32                               Size: 0x0004  Padding: 0x4
+OpenForDisregardForGC = 0x8
+; TStaticIndirectArrayThreadSafeRead<UObjectBase,8388608,16384> Size: 0x1008  Padding: 0x28
+ObjObjects = 0x10
+; TLockFreePointerList<int>           Size: 0x0008
+ObjAvailableList = 0x1040
+; TArray<FUObjectArray::FUObjectCreateListener *,FDefaultAllocator> Size: 0x0010
+UObjectCreateListeners = 0x1048
+; TArray<FUObjectArray::FUObjectDeleteListener *,FDefaultAllocator> Size: 0x0010
+UObjectDeleteListeners = 0x1058
+UEP_TotalSize = 0x1090
+
+[TUObjectArray]
+; Total Size: 0x1008
+; UObjectBase**[512]                  Size: 0x1000
+Chunks = 0x0
+; int32                               Size: 0x0004
+NumElements = 0x1000
+; int32                               Size: 0x0004
+NumChunks = 0x1004
+UEP_TotalSize = 0x1008
+
+[FArchive]
+; Total Size: 0x68
+; int32                               Size: 0x0004
+ArNetVer = 0x8
+; int32                               Size: 0x0004
+ArUE4Ver = 0xC
+; int32                               Size: 0x0004
+ArLicenseeUE4Ver = 0x10
+; FEngineVersionBase                  Size: 0x000C
+ArEngineVer = 0x14
+; FCustomVersionContainer*            Size: 0x0008
+CustomVersionContainer = 0x20
+; bool                                Size: 0x0001
+ArIsLoading = 0x28
+; bool                                Size: 0x0001
+ArIsSaving = 0x29
+; bool                                Size: 0x0001
+ArIsTransacting = 0x2A
+; bool                                Size: 0x0001
+ArWantBinaryPropertySerialization = 0x2B
+; bool                                Size: 0x0001
+ArForceUnicode = 0x2C
+; bool                                Size: 0x0001
+ArIsPersistent = 0x2D
+; bool                                Size: 0x0001
+ArIsError = 0x2E
+; bool                                Size: 0x0001
+ArIsCriticalError = 0x2F
+; bool                                Size: 0x0001
+ArContainsCode = 0x30
+; bool                                Size: 0x0001
+ArContainsMap = 0x31
+; bool                                Size: 0x0001
+ArRequiresLocalizationGather = 0x32
+; bool                                Size: 0x0001
+ArForceByteSwapping = 0x33
+; bool                                Size: 0x0001
+ArIgnoreArchetypeRef = 0x34
+; bool                                Size: 0x0001
+ArNoDelta = 0x35
+; bool                                Size: 0x0001
+ArIgnoreOuterRef = 0x36
+; bool                                Size: 0x0001
+ArIgnoreClassRef = 0x37
+; bool                                Size: 0x0001
+ArAllowLazyLoading = 0x38
+; bool                                Size: 0x0001
+ArIsObjectReferenceCollector = 0x39
+; bool                                Size: 0x0001
+ArIsModifyingWeakAndStrongReferences = 0x3A
+; bool                                Size: 0x0001
+ArIsCountingMemory = 0x3B
+; bool                                Size: 0x0001
+ArShouldSkipBulkData = 0x3C
+; bool                                Size: 0x0001
+ArIsFilterEditorOnly = 0x3D
+; bool                                Size: 0x0001  Padding: 0x1
+ArIsSaveGame = 0x3E
+; int32                               Size: 0x0004
+ArSerializingDefaults = 0x40
+; uint32                              Size: 0x0004
+ArPortFlags = 0x44
+; int64                               Size: 0x0008
+ArMaxSerializeSize = 0x48
+; const ITargetPlatform*              Size: 0x0008
+CookingTargetPlatform = 0x50
+; FProperty*                          Size: 0x0008
+SerializedProperty = 0x58
+; bool                                Size: 0x0001
+bCustomVersionsAreReset = 0x60
+UEP_TotalSize = 0x68
+
+[AGameMode]
+; Total Size: 0x430
+; FName                               Size: 0x0008
+MatchState = 0x348
+; uint32                              Size: 0x0004
+bUseSeamlessTravel = 0x350:0:1:4
+; uint32                              Size: 0x0004
+bPauseable = 0x350:1:1:4
+; uint32                              Size: 0x0004
+bStartPlayersAsSpectators = 0x350:2:1:4
+; uint32                              Size: 0x0004  Padding: 0x4
+bDelayedStart = 0x350:3:1:4
+; FString                             Size: 0x0010  Padding: 0x8
+OptionsString = 0x358
+; TSubclassOf<AHUD>                   Size: 0x0008
+HUDClass = 0x370
+; int32                               Size: 0x0004
+NumSpectators = 0x378
+; int32                               Size: 0x0004
+NumPlayers = 0x37C
+; int32                               Size: 0x0004
+NumBots = 0x380
+; float                               Size: 0x0004
+MinRespawnDelay = 0x384
+; AGameSession*                       Size: 0x0008
+GameSession = 0x388
+; int32                               Size: 0x0004
+NumTravellingPlayers = 0x390
+; int32                               Size: 0x0004
+CurrentID = 0x394
+; FText                               Size: 0x0028
+DefaultPlayerName = 0x398
+; TSubclassOf<ULocalMessage>          Size: 0x0008  Padding: 0x8
+EngineMessageClass = 0x3C0
+; TSubclassOf<ASpectatorPawn>         Size: 0x0008  Padding: 0x8
+SpectatorClass = 0x3D0
+; TSubclassOf<APlayerState>           Size: 0x0008  Padding: 0x10
+PlayerStateClass = 0x3E0
+; TArray<APlayerState *,FDefaultAllocator> Size: 0x0010
+InactivePlayerArray = 0x3F8
+; TArray<TBaseDelegate<bool>,FDefaultAllocator> Size: 0x0010
+Pausers = 0x408
+; TArray<FGameClassShortName,FDefaultAllocator> Size: 0x0010
+GameModeClassAliases = 0x418
+; float                               Size: 0x0004
+InactivePlayerStateLifeSpan = 0x428
+; bool                                Size: 0x0001
+bHandleDedicatedServerReplays = 0x42C
+UEP_TotalSize = 0x430
+
+[AActor]
+; Total Size: 0x348
+; FActorTickFunction                  Size: 0x0050
+PrimaryActorTick = 0x28
+; float                               Size: 0x0004
+CustomTimeDilation = 0x78
+; uint32                              Size: 0x0004
+bHidden = 0x7C:0:1:4
+; uint32                              Size: 0x0004
+bNetTemporary = 0x7C:1:1:4
+; uint32                              Size: 0x0004
+bNetStartup = 0x7C:2:1:4
+; uint32                              Size: 0x0004
+bOnlyRelevantToOwner = 0x7C:3:1:4
+; uint32                              Size: 0x0004
+bAlwaysRelevant = 0x7C:4:1:4
+; uint32                              Size: 0x0004
+bReplicateMovement = 0x7C:5:1:4
+; uint32                              Size: 0x0004
+bTearOff = 0x7C:6:1:4
+; uint32                              Size: 0x0004
+bExchangedRoles = 0x7C:7:1:4
+; uint32                              Size: 0x0004
+bPendingNetUpdate = 0x7C:8:1:4
+; uint32                              Size: 0x0004
+bNetLoadOnClient = 0x7C:9:1:4
+; uint32                              Size: 0x0004
+bNetUseOwnerRelevancy = 0x7C:10:1:4
+; uint32                              Size: 0x0004
+bBlockInput = 0x7C:11:1:4
+; uint32                              Size: 0x0004
+bRunningUserConstructionScript = 0x7C:12:1:4
+; uint32                              Size: 0x0004
+bHasFinishedSpawning = 0x7C:13:1:4
+; uint32                              Size: 0x0004
+bActorEnableCollision = 0x7C:14:1:4
+; uint32                              Size: 0x0004
+bReplicates = 0x7C:15:1:4
+; TEnumAsByte<enum ENetRole>          Size: 0x0001  Padding: 0x7
+RemoteRole = 0x80
+; AActor*                             Size: 0x0008
+Owner = 0x88
+; FRepMovement                        Size: 0x0034  Padding: 0x4
+ReplicatedMovement = 0x90
+; FRepAttachment                      Size: 0x0040
+AttachmentReplication = 0xC8
+; TEnumAsByte<enum ENetRole>          Size: 0x0001
+Role = 0x108
+; TEnumAsByte<enum ENetDormancy>      Size: 0x0001
+NetDormancy = 0x109
+; TEnumAsByte<enum EAutoReceiveInput::Type> Size: 0x0001  Padding: 0x1
+AutoReceiveInput = 0x10A
+; int32                               Size: 0x0004
+InputPriority = 0x10C
+; UInputComponent*                    Size: 0x0008
+InputComponent = 0x110
+; TEnumAsByte<enum EInputConsumeOptions> Size: 0x0001  Padding: 0x3
+InputConsumeOption_DEPRECATED = 0x118
+; float                               Size: 0x0004
+NetCullDistanceSquared = 0x11C
+; int32                               Size: 0x0004
+NetTag = 0x120
+; float                               Size: 0x0004
+NetUpdateTime = 0x124
+; float                               Size: 0x0004
+NetUpdateFrequency = 0x128
+; float                               Size: 0x0004
+NetPriority = 0x12C
+; float                               Size: 0x0004
+LastNetUpdateTime = 0x130
+; FName                               Size: 0x0008
+NetDriverName = 0x134
+; uint32                              Size: 0x0004
+bAutoDestroyWhenFinished = 0x13C:0:1:4
+; uint32                              Size: 0x0004
+bCanBeDamaged = 0x13C:1:1:4
+; uint32                              Size: 0x0004
+bActorIsBeingDestroyed = 0x13C:2:1:4
+; uint32                              Size: 0x0004
+bCollideWhenPlacing = 0x13C:3:1:4
+; uint32                              Size: 0x0004
+bFindCameraComponentWhenViewTarget = 0x13C:4:1:4
+; uint32                              Size: 0x0004
+bRelevantForNetworkReplays = 0x13C:5:1:4
+; ESpawnActorCollisionHandlingMethod  Size: 0x0001  Padding: 0x3
+SpawnCollisionHandlingMethod = 0x140
+; float                               Size: 0x0004  Padding: 0x8
+CreationTime = 0x144
+; TArray<AActor *,FDefaultAllocator>  Size: 0x0010
+Children = 0x150
+; USceneComponent*                    Size: 0x0008
+RootComponent = 0x160
+; TArray<AMatineeActor *,FDefaultAllocator> Size: 0x0010
+ControllingMatineeActors = 0x168
+; float                               Size: 0x0004
+InitialLifeSpan = 0x178
+; FTimerHandle                        Size: 0x0004
+TimerHandle_LifeSpanExpired = 0x17C
+; uint32                              Size: 0x0004  Padding: 0x4
+bAllowReceiveTickEventOnDedicatedServer = 0x180:0:1:4
+; TArray<FName,FDefaultAllocator>     Size: 0x0010
+Layers = 0x188
+; TWeakObjectPtr<AActor,FWeakObjectPtr> Size: 0x0008
+ParentComponentActor = 0x198
+; uint32                              Size: 0x0004
+bActorInitialized = 0x1A0:0:1:4
+; uint32                              Size: 0x0004
+bActorHasBegunPlay = 0x1A0:1:1:4
+; uint32                              Size: 0x0004
+bActorSeamlessTraveled = 0x1A0:2:1:4
+; uint32                              Size: 0x0004
+bIgnoresOriginShifting = 0x1A0:3:1:4
+; uint32                              Size: 0x0004  Padding: 0x4
+bEnableAutoLODGeneration = 0x1A0:4:1:4
+; TArray<FName,FDefaultAllocator>     Size: 0x0010
+Tags = 0x1A8
+; uint64                              Size: 0x0008
+HiddenEditorViews = 0x1B8
+; FTakeAnyDamageSignature             Size: 0x0010
+OnTakeAnyDamage = 0x1C0
+; FTakePointDamageSignature           Size: 0x0010
+OnTakePointDamage = 0x1D0
+; FActorBeginOverlapSignature         Size: 0x0010
+OnActorBeginOverlap = 0x1E0
+; FActorEndOverlapSignature           Size: 0x0010
+OnActorEndOverlap = 0x1F0
+; FActorBeginCursorOverSignature      Size: 0x0010
+OnBeginCursorOver = 0x200
+; FActorEndCursorOverSignature        Size: 0x0010
+OnEndCursorOver = 0x210
+; FActorOnClickedSignature            Size: 0x0010
+OnClicked = 0x220
+; FActorOnReleasedSignature           Size: 0x0010
+OnReleased = 0x230
+; FActorOnInputTouchBeginSignature    Size: 0x0010
+OnInputTouchBegin = 0x240
+; FActorOnInputTouchEndSignature      Size: 0x0010
+OnInputTouchEnd = 0x250
+; FActorBeginTouchOverSignature       Size: 0x0010
+OnInputTouchEnter = 0x260
+; FActorEndTouchOverSignature         Size: 0x0010
+OnInputTouchLeave = 0x270
+; FActorHitSignature                  Size: 0x0010
+OnActorHit = 0x280
+; FActorDestroyedSignature            Size: 0x0010
+OnDestroyed = 0x290
+; FActorEndPlaySignature              Size: 0x0010  Padding: 0x90
+OnEndPlay = 0x2A0
+; FRenderCommandFence                 Size: 0x0008
+DetachFence = 0x340
+UEP_TotalSize = 0x348
+
+[UPlayer]
+; Total Size: 0x48
+; int32                               Size: 0x0004
+CurrentNetSpeed = 0x38
+; int32                               Size: 0x0004
+ConfiguredInternetSpeed = 0x3C
+; int32                               Size: 0x0004
+ConfiguredLanSpeed = 0x40
+UEP_TotalSize = 0x48
+
+[ULocalPlayer]
+; Total Size: 0x190
+; TSharedPtr<FUniqueNetId const ,0>   Size: 0x0010
+CachedUniqueNetId = 0x48
+; UGameViewportClient*                Size: 0x0008
+ViewportClient = 0x58
+; FVector2D                           Size: 0x0008
+Origin = 0x60
+; FVector2D                           Size: 0x0008
+Size = 0x68
+; FVector                             Size: 0x000C
+LastViewLocation = 0x70
+; TEnumAsByte<enum EAspectRatioAxisConstraint> Size: 0x0001  Padding: 0xB
+AspectRatioAxisConstraint = 0x7C
+; uint32                              Size: 0x0004  Padding: 0x54
+bSentSplitJoin = 0x88:0:1:4
+; int32                               Size: 0x0004  Padding: 0x4
+ControllerId = 0xE0
+; FReply                              Size: 0x00A8
+SlateOperations = 0xE8
+UEP_TotalSize = 0x190
+
+[UField]
+; Total Size: 0x30
+; UField*                             Size: 0x0008
+Next = 0x28
+UEP_TotalSize = 0x30
+
+[FProperty]
+; Total Size: 0x70
+; int32                               Size: 0x0004
+ArrayDim = 0x30
+; int32                               Size: 0x0004
+ElementSize = 0x34
+; uint64                              Size: 0x0008
+PropertyFlags = 0x38
+; uint16                              Size: 0x0002  Padding: 0x2
+RepIndex = 0x40
+; FName                               Size: 0x0008
+RepNotifyFunc = 0x44
+; int32                               Size: 0x0004
+Offset_Internal = 0x4C
+; FProperty*                          Size: 0x0008
+PropertyLinkNext = 0x50
+; FProperty*                          Size: 0x0008
+NextRef = 0x58
+; FProperty*                          Size: 0x0008
+DestructorLinkNext = 0x60
+; FProperty*                          Size: 0x0008
+PostConstructLinkNext = 0x68
+UEP_TotalSize = 0x70
+
+[FMulticastDelegateProperty]
+; Total Size: 0x78
+; UFunction*                          Size: 0x0008
+SignatureFunction = 0x70
+UEP_TotalSize = 0x78
+
+[FObjectPropertyBase]
+; Total Size: 0x78
+; UClass*                             Size: 0x0008
+PropertyClass = 0x70
+UEP_TotalSize = 0x78
+
+[FWorldContext]
+; Total Size: 0x298
+; FName                               Size: 0x0008
+ContextHandle = 0xC0
+; FString                             Size: 0x0010
+TravelURL = 0xC8
+; uint8                               Size: 0x0001  Padding: 0x7
+TravelType = 0xD8
+; FURL                                Size: 0x0070
+LastURL = 0xE0
+; FURL                                Size: 0x0070  Padding: 0x18
+LastRemoteURL = 0x150
+; TArray<FName,FDefaultAllocator>     Size: 0x0010  Padding: 0x10
+LevelsToLoadForPendingMapChange = 0x1D8
+; FString                             Size: 0x0010
+PendingMapChangeFailureDescription = 0x1F8
+; uint32                              Size: 0x0004  Padding: 0x24
+bShouldCommitPendingMapChange = 0x208:0:1:4
+; UGameViewportClient*                Size: 0x0008  Padding: 0x18
+GameViewport = 0x230
+; int32                               Size: 0x0004  Padding: 0x4
+PIEInstance = 0x250
+; FString                             Size: 0x0010
+PIEPrefix = 0x258
+; FString                             Size: 0x0010
+PIERemapPrefix = 0x268
+; bool                                Size: 0x0001
+RunAsDedicated = 0x278
+; bool                                Size: 0x0001  Padding: 0x2
+bWaitingOnOnlineSubsystem = 0x279
+; uint32                              Size: 0x0004
+AudioDeviceHandle = 0x27C
+; TArray<UWorld * *,FDefaultAllocator> Size: 0x0010
+ExternalReferences = 0x280
+; UWorld*                             Size: 0x0008
+ThisCurrentWorld = 0x290
+UEP_TotalSize = 0x298
+
+[UScriptStruct]
+; Total Size: 0x98
+; EStructFlags                        Size: 0x0004
+StructFlags = 0x88
+; bool                                Size: 0x0001
+bCppStructOpsFromBaseClass = 0x8C
+; bool                                Size: 0x0001  Padding: 0x2
+bPrepareCppStructOpsCompleted = 0x8D
+; UScriptStruct::ICppStructOps*       Size: 0x0008
+CppStructOps = 0x90
+UEP_TotalSize = 0x98
+
+[UWorld]
+; Total Size: 0x768
+; TArray<UObject *,FDefaultAllocator> Size: 0x0010
+ExtraReferencedObjects = 0x70
+; TArray<UObject *,FDefaultAllocator> Size: 0x0010  Padding: 0x10
+PerModuleDataObjects = 0x80
+; FString                             Size: 0x0010  Padding: 0x20
+StreamingLevelsPrefix = 0xA0
+; TArray<FVector,FDefaultAllocator>   Size: 0x0010
+ViewLocationsRenderedLastFrame = 0xD0
+; uint32                              Size: 0x0004
+bWorldWasLoadedThisTick = 0xE0:0:1:4
+; uint32                              Size: 0x0004  Padding: 0xC
+bTriggerPostLoadMap = 0xE0:1:1:4
+; AGameMode*                          Size: 0x0008  Padding: 0x20
+AuthorityGameMode = 0xF0
+; TSet<AActor *,DefaultKeyFuncs<AActor *,0>,FDefaultSetAllocator> Size: 0x0050  Padding: 0x1B8
+NetworkActors = 0x118
+; bool                                Size: 0x0001  Padding: 0x11F
+bRequiresHitProxies = 0x320
+; uint32                              Size: 0x0004  Padding: 0x4
+bStreamingDataDirty = 0x440:0:1:4
+; double                              Size: 0x0008  Padding: 0x80
+BuildStreamingDataTimer = 0x448
+; FURL                                Size: 0x0070  Padding: 0x10
+URL = 0x4D0
+; bool                                Size: 0x0001
+bInTick = 0x550
+; bool                                Size: 0x0001
+bIsBuilt = 0x551
+; bool                                Size: 0x0001  Padding: 0x145
+bTickNewlySpawned = 0x552
+; bool                                Size: 0x0001  Padding: 0x3
+bPostTickComponentUpdate = 0x698
+; int32                               Size: 0x0004
+PlayerNum = 0x69C
+; float                               Size: 0x0004
+TimeSinceLastPendingKillPurge = 0x6A0
+; bool                                Size: 0x0001
+FullPurgeTriggered = 0x6A4
+; bool                                Size: 0x0001
+bShouldDelayGarbageCollect = 0x6A5
+; bool                                Size: 0x0001  Padding: 0x1
+bIsWorldInitialized = 0x6A6
+; int32                               Size: 0x0004
+StreamingVolumeUpdateDelay = 0x6A8
+; bool                                Size: 0x0001
+bIsLevelStreamingFrozen = 0x6AC
+; bool                                Size: 0x0001
+bShouldForceUnloadStreamingLevels = 0x6AD
+; bool                                Size: 0x0001
+bShouldForceVisibleStreamingLevels = 0x6AE
+; bool                                Size: 0x0001  Padding: 0x1
+bDoDelayedUpdateCullDistanceVolumes = 0x6AF
+; bool                                Size: 0x0001
+bHack_Force_UsesGameHiddenFlags_True = 0x6B1
+; bool                                Size: 0x0001
+bIsRunningConstructionScript = 0x6B2
+; bool                                Size: 0x0001
+bShouldSimulatePhysics = 0x6B3
+; FName                               Size: 0x0008  Padding: 0x1C
+DebugDrawTraceTag = 0x6B4
+; uint32                              Size: 0x0004  Padding: 0x4
+AudioDeviceHandle = 0x6D8
+; double                              Size: 0x0008
+LastTimeUnbuiltLightingWasEncountered = 0x6E0
+; float                               Size: 0x0004
+TimeSeconds = 0x6E8
+; float                               Size: 0x0004
+RealTimeSeconds = 0x6EC
+; float                               Size: 0x0004
+AudioTimeSeconds = 0x6F0
+; float                               Size: 0x0004
+DeltaTimeSeconds = 0x6F4
+; float                               Size: 0x0004  Padding: 0x18
+PauseDelay = 0x6F8
+; bool                                Size: 0x0001  Padding: 0x13
+bOriginOffsetThisFrame = 0x714
+; FString                             Size: 0x0010
+NextURL = 0x728
+; float                               Size: 0x0004  Padding: 0x4
+NextSwitchCountdown = 0x738
+; TArray<FName,FDefaultAllocator>     Size: 0x0010
+PreparingLevelNames = 0x740
+; FName                               Size: 0x0008
+CommittedPersistentLevelName = 0x750
+; uint32                              Size: 0x0004
+NumLightingUnbuiltObjects = 0x758
+; uint32                              Size: 0x0004
+bDropDetail = 0x75C:0:1:4
+; uint32                              Size: 0x0004
+bAggressiveLOD = 0x75C:1:1:4
+; uint32                              Size: 0x0004
+bIsDefaultLevel = 0x75C:2:1:4
+; uint32                              Size: 0x0004
+bRequestedBlockOnAsyncLoading = 0x75C:3:1:4
+; uint32                              Size: 0x0004
+bActorsInitialized = 0x75C:4:1:4
+; uint32                              Size: 0x0004
+bBegunPlay = 0x75C:5:1:4
+; uint32                              Size: 0x0004
+bMatchStarted = 0x75C:6:1:4
+; uint32                              Size: 0x0004
+bPlayersOnly = 0x75C:7:1:4
+; uint32                              Size: 0x0004
+bPlayersOnlyPending = 0x75C:8:1:4
+; uint32                              Size: 0x0004
+bStartup = 0x75C:9:1:4
+; uint32                              Size: 0x0004
+bIsTearingDown = 0x75C:10:1:4
+; uint32                              Size: 0x0004
+bKismetScriptError = 0x75C:11:1:4
+; uint32                              Size: 0x0004
+bDebugPauseExecution = 0x75C:12:1:4
+; uint32                              Size: 0x0004
+bAllowAudioPlayback = 0x75C:13:1:4
+; uint32                              Size: 0x0004
+bDebugFrameStepExecution = 0x75C:14:1:4
+; uint32                              Size: 0x0004
+bAreConstraintsDirty = 0x75C:15:1:4
+; FThreadSafeCounter                  Size: 0x0004
+AsyncPreRegisterLevelStreamingTasks = 0x760
+UEP_TotalSize = 0x768
+
+[UFunction]
+; Total Size: 0xB8
+; uint32                              Size: 0x0004
+FunctionFlags = 0x88
+; uint16                              Size: 0x0002
+RepOffset = 0x8C
+; uint8                               Size: 0x0001  Padding: 0x1
+NumParms = 0x8E
+; uint16                              Size: 0x0002
+ParmsSize = 0x90
+; uint16                              Size: 0x0002
+ReturnValueOffset = 0x92
+; uint16                              Size: 0x0002
+RPCId = 0x94
+; uint16                              Size: 0x0002
+RPCResponseId = 0x96
+; FProperty*                          Size: 0x0008
+FirstPropertyToInit = 0x98
+; UFunction*                          Size: 0x0008
+EventGraphFunction = 0xA0
+; int32                               Size: 0x0004  Padding: 0x4
+EventGraphCallOffset = 0xA8
+; void (UObject::*)(FFrame&, void* const) Size: 0x0008
+Func = 0xB0
+UEP_TotalSize = 0xB8
+
+[UClass]
+; Total Size: 0x180
+; std::function<void(const void*)>*   Size: 0x0008
+ClassConstructor = 0x90
+; std::function<UObject*(void*)>*     Size: 0x0008
+ClassVTableHelperCtorCaller = 0x98
+; std::function<void(UObject*, void*)>* Size: 0x0008
+ClassAddReferencedObjects = 0xA0
+; int32                               Size: 0x0004
+ClassUnique = 0xA8
+; uint32                              Size: 0x0004
+ClassFlags = 0xAC
+; uint64                              Size: 0x0008
+ClassCastFlags = 0xB0
+; UClass*                             Size: 0x0008
+ClassWithin = 0xB8
+; UObject*                            Size: 0x0008
+ClassGeneratedBy = 0xC0
+; FName                               Size: 0x0008
+ClassConfigName = 0xC8
+; bool                                Size: 0x0001  Padding: 0x17
+bCooked = 0xD0
+; TArray<UField *,FDefaultAllocator>  Size: 0x0010
+NetFields = 0xE8
+; UObject*                            Size: 0x0008
+ClassDefaultObject = 0xF8
+; TMap<FName, UFunction *>            Size: 0x0050
+FuncMap = 0x100
+; TArray<FImplementedInterface,FDefaultAllocator> Size: 0x0010
+Interfaces = 0x150
+; FGCReferenceTokenStream             Size: 0x0010
+ReferenceTokenStream = 0x160
+; TArray<FNativeFunctionLookup,FDefaultAllocator> Size: 0x0010
+NativeFunctionLookupTable = 0x170
+UEP_TotalSize = 0x180
+
+[UEnum]
+; Total Size: 0x58
+; FString                             Size: 0x0010
+CppType = 0x30
+; TArray<TPair<FName,unsigned char>,FDefaultAllocator> Size: 0x0010
+Names = 0x40
+; UEnum::ECppForm                     Size: 0x0004
+CppForm = 0x50
+UEP_TotalSize = 0x58
+
+[FStructProperty]
+; Total Size: 0x78
+; UScriptStruct*                      Size: 0x0008
+Struct = 0x70
+UEP_TotalSize = 0x78
+
+[FArrayProperty]
+; Total Size: 0x78
+; FProperty*                          Size: 0x0008
+Inner = 0x70
+UEP_TotalSize = 0x78
+
+[FMapProperty]
+; Total Size: 0xA8
+; FProperty*                          Size: 0x0008
+KeyProp = 0x70
+; FProperty*                          Size: 0x0008
+ValueProp = 0x78
+; FScriptMapLayout                    Size: 0x0024
+MapLayout = 0x80
+UEP_TotalSize = 0xA8
+
+[FBoolProperty]
+; Total Size: 0x78
+; uint8                               Size: 0x0001
+FieldSize = 0x70
+; uint8                               Size: 0x0001
+ByteOffset = 0x71
+; uint8                               Size: 0x0001
+ByteMask = 0x72
+; uint8                               Size: 0x0001
+FieldMask = 0x73
+UEP_TotalSize = 0x78
+
+[FByteProperty]
+; Total Size: 0x78
+; UEnum*                              Size: 0x0008
+Enum = 0x70
+UEP_TotalSize = 0x78
+
+[FClassProperty]
+; Total Size: 0x80
+; UClass*                             Size: 0x0008
+MetaClass = 0x78
+UEP_TotalSize = 0x80
+
+[FDelegateProperty]
+; Total Size: 0x78
+; UFunction*                          Size: 0x0008
+SignatureFunction = 0x70
+UEP_TotalSize = 0x78
+
+[FInterfaceProperty]
+; Total Size: 0x78
+; UClass*                             Size: 0x0008
+InterfaceClass = 0x70
+UEP_TotalSize = 0x78
+
+[UDataTable]
+; Total Size: 0x80
+; UScriptStruct*                      Size: 0x0008
+RowStruct = 0x28
+; TMap<FName, unsigned char *>        Size: 0x0050
+RowMap = 0x30
+UEP_TotalSize = 0x80
+

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_15_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_15_Template.ini
@@ -790,9 +790,9 @@ UEP_TotalSize = 0x250
 CppType = 0x30
 ; TArray<TPair<FName,__int64>,FDefaultAllocator> Size: 0x0010
 Names = 0x40
-; UEnum::ECppForm                     Size: 0x0008
+; UEnum::ECppForm                     Size: 0x0004  Padding: 0x4
 CppForm = 0x50
-; std::function<void(int32)>*         Size: 0x0008
+; std::function<FText(int32)>*        Size: 0x0008
 EnumDisplayNameFn = 0x58
 UEP_TotalSize = 0x60
 

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_16_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_16_Template.ini
@@ -800,7 +800,7 @@ CppType = 0x30
 Names = 0x40
 ; UEnum::ECppForm                     Size: 0x0004  Padding: 0x4
 CppForm = 0x50
-; std::function<void(int32)>*         Size: 0x0008
+; std::function<FText(int32)>*        Size: 0x0008
 EnumDisplayNameFn = 0x58
 UEP_TotalSize = 0x60
 

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_17_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_17_Template.ini
@@ -72,7 +72,7 @@ bIsPlayInEditorViewport = 0x74:1:1:4
 bDisableWorldRendering = 0x74:2:1:4
 ; TEnumAsByte<enum ESplitScreenType::Type> Size: 0x0001  Padding: 0x7
 ActiveSplitscreenType = 0x78
-; UWorld*                             Size: 0x0010
+; UWorld*                             Size: 0x0008  Padding: 0x8
 World = 0x80
 ; bool                                Size: 0x0001  Padding: 0x3
 bSuppressTransitionMessage = 0x90
@@ -578,7 +578,7 @@ bWaitingOnOnlineSubsystem = 0x281
 AudioDeviceHandle = 0x284
 ; TArray<UWorld * *,FDefaultAllocator> Size: 0x0010
 ExternalReferences = 0x288
-; UWorld*                             Size: 0x0010
+; UWorld*                             Size: 0x0008
 ThisCurrentWorld = 0x298
 UEP_TotalSize = 0x2A0
 
@@ -802,7 +802,7 @@ CppType = 0x30
 Names = 0x40
 ; UEnum::ECppForm                     Size: 0x0004  Padding: 0x4
 CppForm = 0x50
-; std::function<void(int32)>*         Size: 0x0008
+; std::function<FText(int32)>*        Size: 0x0008
 EnumDisplayNameFn = 0x58
 UEP_TotalSize = 0x60
 

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_18_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_18_Template.ini
@@ -264,7 +264,7 @@ HUDClass = 0x398
 SpectatorClass = 0x3A8
 ; AGameSession*                       Size: 0x0008  Padding: 0x8
 GameSession = 0x3B8
-; FText                               Size: 0x0008  Padding: 0x10
+; FText                               Size: 0x0018
 DefaultPlayerName = 0x3C8
 ; uint32                              Size: 0x0004
 bUseSeamlessTravel = 0x3E0:0:1:4
@@ -570,7 +570,7 @@ RunAsDedicated = 0x270
 bWaitingOnOnlineSubsystem = 0x271
 ; uint32                              Size: 0x0004
 AudioDeviceHandle = 0x274
-; TArray<UWorld * *,FDefaultAllocator> Size: 0x0004  Padding: 0xC
+; TArray<UWorld * *,FDefaultAllocator> Size: 0x0010
 ExternalReferences = 0x278
 ; UWorld*                             Size: 0x0008
 ThisCurrentWorld = 0x288
@@ -706,8 +706,8 @@ bIsTearingDown = 0x990:10:1:4
 bKismetScriptError = 0x990:11:1:4
 ; uint32                              Size: 0x0004
 bDebugPauseExecution = 0x990:12:1:4
-; uint32                              Size: 0x001C
-bIsCameraMoveableWhenPaused = 0x990:13:1:28
+; uint32                              Size: 0x0004
+bIsCameraMoveableWhenPaused = 0x990:13:1:4
 ; uint32                              Size: 0x0004
 bAllowAudioPlayback = 0x990:14:1:4
 ; uint32                              Size: 0x0004
@@ -788,7 +788,7 @@ CppType = 0x30
 Names = 0x40
 ; UEnum::ECppForm                     Size: 0x0004  Padding: 0x4
 CppForm = 0x50
-; std::function<void(int32)>*         Size: 0x0008
+; std::function<FText(int32)>*        Size: 0x0008
 EnumDisplayNameFn = 0x58
 UEP_TotalSize = 0x60
 

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_19_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_19_Template.ini
@@ -14,9 +14,9 @@ UEP_TotalSize = 0x28
 
 [UScriptStruct::ICppStructOps]
 ; Total Size: 0x10
-; const int32                         Size: 0x0010
+; const int32                         Size: 0x0004
 Size = 0x8
-; const int32                         Size: 0x0010
+; const int32                         Size: 0x0004
 Alignment = 0xC
 UEP_TotalSize = 0x10
 
@@ -788,7 +788,7 @@ CppType = 0x30
 Names = 0x40
 ; UEnum::ECppForm                     Size: 0x0004  Padding: 0x4
 CppForm = 0x50
-; std::function<void(int32)>*         Size: 0x0008
+; std::function<FText(int32)>*        Size: 0x0008
 EnumDisplayNameFn = 0x58
 UEP_TotalSize = 0x60
 

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_20_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_20_Template.ini
@@ -802,7 +802,7 @@ CppType = 0x30
 Names = 0x40
 ; UEnum::ECppForm                     Size: 0x0004  Padding: 0x4
 CppForm = 0x50
-; std::function<void(int32)>*         Size: 0x0008
+; std::function<FText(int32)>*        Size: 0x0008
 EnumDisplayNameFn = 0x58
 UEP_TotalSize = 0x60
 

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_21_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_21_Template.ini
@@ -160,7 +160,7 @@ UEP_TotalSize = 0x1B0
 
 [TUObjectArray]
 ; Total Size: 0x20
-; FUObjectItem**                      Size: 0x000C
+; FUObjectItem**                      Size: 0x0008
 Objects = 0x0
 ; FUObjectItem*                       Size: 0x0008
 PreAllocatedObjects = 0x8
@@ -810,7 +810,7 @@ CppType = 0x30
 Names = 0x40
 ; UEnum::ECppForm                     Size: 0x0004  Padding: 0x4
 CppForm = 0x50
-; std::function<void(int32)>*         Size: 0x0008
+; std::function<FText(int32)>*        Size: 0x0008
 EnumDisplayNameFn = 0x58
 UEP_TotalSize = 0x60
 

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_22_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_22_Template.ini
@@ -78,7 +78,7 @@ bSuppressTransitionMessage = 0x88
 ViewModeIndex = 0x8C
 ; FEngineShowFlags                    Size: 0x0008
 EngineShowFlags = 0x90
-; FViewport*                          Size: 0x0010
+; FViewport*                          Size: 0x0008
 Viewport = 0x98
 ; FViewportFrame*                     Size: 0x0008
 ViewportFrame = 0xA0
@@ -160,7 +160,7 @@ UEP_TotalSize = 0x130
 
 [TUObjectArray]
 ; Total Size: 0x20
-; FUObjectItem**                      Size: 0x0010
+; FUObjectItem**                      Size: 0x0008
 Objects = 0x0
 ; FUObjectItem*                       Size: 0x0008
 PreAllocatedObjects = 0x8
@@ -396,7 +396,7 @@ bActorIsBeingDestroyed = 0x84:2:1:1
 bActorWantsDestroyDuringBeginPlay = 0x84:3:1:1
 ; AActor::EActorBeginPlayState        Size: 0x0001
 ActorHasBegunPlay = 0x84:4:2:1
-; TEnumAsByte<enum ENetRole>          Size: 0x0010
+; TEnumAsByte<enum ENetRole>          Size: 0x0001  Padding: 0x2
 RemoteRole = 0x85
 ; FRepMovement                        Size: 0x0034
 ReplicatedMovement = 0x88
@@ -412,7 +412,7 @@ AttachmentReplication = 0xC8
 Owner = 0x108
 ; FName                               Size: 0x0008
 NetDriverName = 0x110
-; TEnumAsByte<enum ENetRole>          Size: 0x0010
+; TEnumAsByte<enum ENetRole>          Size: 0x0001
 Role = 0x118
 ; TEnumAsByte<enum ENetDormancy>      Size: 0x0001
 NetDormancy = 0x119
@@ -502,9 +502,9 @@ UEP_TotalSize = 0x48
 CachedUniqueNetId = 0x48
 ; UGameViewportClient*                Size: 0x0008
 ViewportClient = 0x70
-; FVector2D                           Size: 0x0010
+; FVector2D                           Size: 0x0008
 Origin = 0x78
-; FVector2D                           Size: 0x0010
+; FVector2D                           Size: 0x0008
 Size = 0x80
 ; FVector                             Size: 0x000C
 LastViewLocation = 0x88
@@ -796,7 +796,7 @@ CppType = 0x30
 Names = 0x40
 ; UEnum::ECppForm                     Size: 0x0004  Padding: 0x4
 CppForm = 0x50
-; std::function<void(int32)>*         Size: 0x0008
+; std::function<FText(int32)>*        Size: 0x0008
 EnumDisplayNameFn = 0x58
 UEP_TotalSize = 0x60
 

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_23_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_23_Template.ini
@@ -686,7 +686,7 @@ bShouldForceUnloadStreamingLevels = 0x11E:6:1:1
 bShouldForceVisibleStreamingLevels = 0x11E:7:1:1
 ; uint8                               Size: 0x0001  Padding: 0x8
 bMaterialParameterCollectionInstanceNeedsDeferredUpdate = 0x11F:0:1:1
-; AGameModeBase*                      Size: 0x1008
+; AGameModeBase*                      Size: 0x0008  Padding: 0x38
 AuthorityGameMode = 0x128
 ; int32                               Size: 0x0004
 ActiveLevelCollectionIndex = 0x168
@@ -770,7 +770,7 @@ ClassUnique = 0xB0:0:31:4
 bCooked = 0xB0:31:1:4
 ; EClassFlags                         Size: 0x0004
 ClassFlags = 0xB4
-; EClassCastFlags                     Size: 0x0004  Padding: 0x4
+; EClassCastFlags                     Size: 0x0008
 ClassCastFlags = 0xB8
 ; UClass*                             Size: 0x0008
 ClassWithin = 0xC0
@@ -802,7 +802,7 @@ CppType = 0x30
 Names = 0x40
 ; UEnum::ECppForm                     Size: 0x0004  Padding: 0x4
 CppForm = 0x50
-; std::function<void(int32)>*         Size: 0x0008
+; std::function<FText(int32)>*        Size: 0x0008
 EnumDisplayNameFn = 0x58
 UEP_TotalSize = 0x60
 

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_24_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_24_Template.ini
@@ -444,7 +444,7 @@ NetPriority = 0x110
 LastRenderTime = 0x114
 ; TArray<AActor *,TSizedDefaultAllocator<32> > Size: 0x0010
 Children = 0x120
-; USceneComponent*                    Size: 0x0040
+; USceneComponent*                    Size: 0x0008
 RootComponent = 0x130
 ; TArray<AMatineeActor *,TSizedDefaultAllocator<32> > Size: 0x0010
 ControllingMatineeActors = 0x138
@@ -508,9 +508,9 @@ UEP_TotalSize = 0x48
 CachedUniqueNetId = 0x48
 ; UGameViewportClient*                Size: 0x0008
 ViewportClient = 0x70
-; FVector2D                           Size: 0x0010
+; FVector2D                           Size: 0x0008
 Origin = 0x78
-; FVector2D                           Size: 0x0010
+; FVector2D                           Size: 0x0008
 Size = 0x80
 ; FVector                             Size: 0x000C
 LastViewLocation = 0x88
@@ -812,7 +812,7 @@ CppType = 0x30
 Names = 0x40
 ; UEnum::ECppForm                     Size: 0x0004  Padding: 0x4
 CppForm = 0x50
-; std::function<void(int32)>*         Size: 0x0008
+; std::function<FText(int32)>*        Size: 0x0008
 EnumDisplayNameFn = 0x58
 UEP_TotalSize = 0x60
 

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_25_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_25_Template.ini
@@ -14,9 +14,9 @@ UEP_TotalSize = 0x28
 
 [UScriptStruct::ICppStructOps]
 ; Total Size: 0x10
-; const int32                         Size: 0x0008
+; const int32                         Size: 0x0004
 Size = 0x8
-; const int32                         Size: 0x0008
+; const int32                         Size: 0x0004
 Alignment = 0xC
 UEP_TotalSize = 0x10
 
@@ -50,7 +50,7 @@ RefLink = 0x78
 DestructorLink = 0x80
 ; FProperty*                          Size: 0x0008
 PostConstructLink = 0x88
-; TArray<UObject *,TSizedDefaultAllocator<32> > Size: 0x0008  Padding: 0x8
+; TArray<UObject *,TSizedDefaultAllocator<32> > Size: 0x0010
 ScriptAndPropertyObjectReferences = 0x90
 ; TArray<TTuple<TFieldPath<FField>,int>,TSizedDefaultAllocator<32> >* Size: 0x0008
 UnresolvedScriptProperties = 0xA0
@@ -454,13 +454,13 @@ RootComponent = 0x130
 ControllingMatineeActors = 0x138
 ; FTimerHandle                        Size: 0x0008
 TimerHandle_LifeSpanExpired = 0x148
-; TArray<FName,TSizedDefaultAllocator<32> > Size: 0x0040
+; TArray<FName,TSizedDefaultAllocator<32> > Size: 0x0010
 Layers = 0x150
 ; TWeakObjectPtr<UChildActorComponent,FWeakObjectPtr> Size: 0x0008
 ParentComponent = 0x160
 ; uint8                               Size: 0x0001  Padding: 0x7
 bActorIsBeingConstructed = 0x168:0:1:1
-; TArray<FName,TSizedDefaultAllocator<32> > Size: 0x0040
+; TArray<FName,TSizedDefaultAllocator<32> > Size: 0x0010
 Tags = 0x170
 ; FTakeAnyDamageSignature             Size: 0x0001
 OnTakeAnyDamage = 0x180
@@ -618,7 +618,7 @@ TravelType = 0xC8
 LastURL = 0xD0
 ; FURL                                Size: 0x0068  Padding: 0x18
 LastRemoteURL = 0x138
-; TArray<FName,TSizedDefaultAllocator<32> > Size: 0x0040
+; TArray<FName,TSizedDefaultAllocator<32> > Size: 0x0010  Padding: 0x10
 LevelsToLoadForPendingMapChange = 0x1B8
 ; FString                             Size: 0x0010
 PendingMapChangeFailureDescription = 0x1D8
@@ -656,9 +656,9 @@ UEP_TotalSize = 0xC0
 
 [UWorld]
 ; Total Size: 0x710
-; TArray<UObject *,TSizedDefaultAllocator<32> > Size: 0x0008  Padding: 0x8
+; TArray<UObject *,TSizedDefaultAllocator<32> > Size: 0x0010
 ExtraReferencedObjects = 0x68
-; TArray<UObject *,TSizedDefaultAllocator<32> > Size: 0x0008  Padding: 0x8
+; TArray<UObject *,TSizedDefaultAllocator<32> > Size: 0x0010
 PerModuleDataObjects = 0x78
 ; TArray<AActor *,TSizedDefaultAllocator<32> > Size: 0x0010  Padding: 0x38
 LevelSequenceActors = 0x88
@@ -766,7 +766,7 @@ NextSwitchCountdown = 0x55C
 NumStreamingLevelsBeingLoaded = 0x56A
 ; FString                             Size: 0x0010
 NextURL = 0x570
-; TArray<FName,TSizedDefaultAllocator<32> > Size: 0x0040
+; TArray<FName,TSizedDefaultAllocator<32> > Size: 0x0010
 PreparingLevelNames = 0x580
 ; FName                               Size: 0x0008
 CommittedPersistentLevelName = 0x590
@@ -814,7 +814,7 @@ ClassUnique = 0xC8:0:31:4
 bCooked = 0xC8:31:1:4
 ; EClassFlags                         Size: 0x0004
 ClassFlags = 0xCC
-; EClassCastFlags                     Size: 0x0004  Padding: 0x4
+; EClassCastFlags                     Size: 0x0008
 ClassCastFlags = 0xD0
 ; UClass*                             Size: 0x0008
 ClassWithin = 0xD8
@@ -852,7 +852,7 @@ CppType = 0x30
 Names = 0x40
 ; UEnum::ECppForm                     Size: 0x0004  Padding: 0x4
 CppForm = 0x50
-; std::function<void(int32)>*         Size: 0x0008
+; std::function<FText(int32)>*        Size: 0x0008
 EnumDisplayNameFn = 0x58
 UEP_TotalSize = 0x60
 

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_26_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_26_Template.ini
@@ -154,7 +154,7 @@ ObjObjects = 0x10
 UObjectCreateListeners = 0xE0
 ; TArray<FUObjectArray::FUObjectDeleteListener *,TSizedDefaultAllocator<32> > Size: 0x0010  Padding: 0x28
 UObjectDeleteListeners = 0xF0
-; FThreadSafeCounter                  Size: 0x0008
+; FThreadSafeCounter                  Size: 0x0004
 MasterSerialNumber = 0x128
 UEP_TotalSize = 0x130
 
@@ -162,7 +162,7 @@ UEP_TotalSize = 0x130
 ; Total Size: 0x20
 ; FUObjectItem**                      Size: 0x0008
 Objects = 0x0
-; FUObjectItem*                       Size: 0x0001  Padding: 0x7
+; FUObjectItem*                       Size: 0x0008
 PreAllocatedObjects = 0x8
 ; int32                               Size: 0x0004
 MaxElements = 0x10
@@ -282,7 +282,7 @@ ServerStatReplicatorClass = 0x270
 GameSession = 0x278
 ; AServerStatReplicator*              Size: 0x0008
 ServerStatReplicator = 0x288
-; FText                               Size: 0x0008  Padding: 0x10
+; FText                               Size: 0x0018
 DefaultPlayerName = 0x290
 ; uint32                              Size: 0x0004
 bUseSeamlessTravel = 0x2A8:0:1:4
@@ -512,9 +512,9 @@ UEP_TotalSize = 0x48
 CachedUniqueNetId = 0x48
 ; UGameViewportClient*                Size: 0x0008
 ViewportClient = 0x70
-; FVector2D                           Size: 0x0010
+; FVector2D                           Size: 0x0008
 Origin = 0x78
-; FVector2D                           Size: 0x0010
+; FVector2D                           Size: 0x0008
 Size = 0x80
 ; FVector                             Size: 0x000C
 LastViewLocation = 0x88
@@ -544,7 +544,7 @@ SuperClass = 0x20
 DefaultObject = 0x28
 ; std::function<FField*(const void*, const void*, EObjectFlags)>* Size: 0x0008
 ConstructFn = 0x30
-; FThreadSafeCounter                  Size: 0x0008
+; FThreadSafeCounter                  Size: 0x0004
 UnqiueNameIndexCounter = 0x38
 UEP_TotalSize = 0x40
 
@@ -810,8 +810,8 @@ ClassVTableHelperCtorCaller = 0xB8
 ClassAddReferencedObjects = 0xC0
 ; uint32                              Size: 0x0004
 ClassUnique = 0xC8:0:31:4
-; uint32                              Size: 0x0001  Padding: 0x3
-bCooked = 0xC8:31:1:1
+; uint32                              Size: 0x0004
+bCooked = 0xC8:31:1:4
 ; EClassFlags                         Size: 0x0004
 ClassFlags = 0xCC
 ; EClassCastFlags                     Size: 0x0008
@@ -854,7 +854,7 @@ Names = 0x40
 CppForm = 0x50
 ; EEnumFlags                          Size: 0x0004
 EnumFlags = 0x54
-; std::function<void(int32)>*         Size: 0x0008
+; std::function<FText(int32)>*        Size: 0x0008
 EnumDisplayNameFn = 0x58
 UEP_TotalSize = 0x60
 

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_27_CasePreserving_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_27_CasePreserving_Template.ini
@@ -150,13 +150,13 @@ MaxObjectsNotConsideredByGC = 0x8
 OpenForDisregardForGC = 0xC
 ; FChunkedFixedUObjectArray           Size: 0x0020  Padding: 0x28
 ObjObjects = 0x10
-; TArray<int,TSizedDefaultAllocator<32> > Size: 0x0004  Padding: 0xC
+; TArray<int,TSizedDefaultAllocator<32> > Size: 0x0010
 ObjAvailableList = 0x58
 ; TArray<FUObjectArray::FUObjectCreateListener *,TSizedDefaultAllocator<32> > Size: 0x0010
 UObjectCreateListeners = 0x68
-; TArray<FUObjectArray::FUObjectDeleteListener *,TSizedDefaultAllocator<32> > Size: 0x0004  Padding: 0x34
+; TArray<FUObjectArray::FUObjectDeleteListener *,TSizedDefaultAllocator<32> > Size: 0x0010  Padding: 0x28
 UObjectDeleteListeners = 0x78
-; FThreadSafeCounter                  Size: 0x0008
+; FThreadSafeCounter                  Size: 0x0004
 MasterSerialNumber = 0xB0
 UEP_TotalSize = 0xB8
 
@@ -548,7 +548,7 @@ SuperClass = 0x28
 DefaultObject = 0x30
 ; std::function<FField*(const void*, const void*, EObjectFlags)>* Size: 0x0008
 ConstructFn = 0x38
-; FThreadSafeCounter                  Size: 0x0008
+; FThreadSafeCounter                  Size: 0x0004
 UnqiueNameIndexCounter = 0x40
 UEP_TotalSize = 0x48
 
@@ -858,7 +858,7 @@ Names = 0x48
 CppForm = 0x58
 ; EEnumFlags                          Size: 0x0004
 EnumFlags = 0x5C
-; std::function<void(int32)>*         Size: 0x0008
+; std::function<FText(int32)>*        Size: 0x0008
 EnumDisplayNameFn = 0x60
 UEP_TotalSize = 0x68
 

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_27_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_4_27_Template.ini
@@ -6,7 +6,7 @@ ObjectFlags = 0x8
 InternalIndex = 0xC
 ; UClass*                             Size: 0x0008
 ClassPrivate = 0x10
-; FName                               Size: 0x0004  Padding: 0x4
+; FName                               Size: 0x0008
 NamePrivate = 0x18
 ; UObject*                            Size: 0x0008
 OuterPrivate = 0x20
@@ -96,7 +96,7 @@ Window = 0xF8
 ViewportOverlayWidget = 0x108
 ; TWeakPtr<IGameLayerManager,0>       Size: 0x0010
 GameLayerManagerPtr = 0x118
-; FName                               Size: 0x0004  Padding: 0x4
+; FName                               Size: 0x0008
 CurrentBufferVisualizationMode = 0x128
 ; TWeakPtr<SWindow,0>                 Size: 0x0010
 HighResScreenshotDialog = 0x130
@@ -180,8 +180,8 @@ UEP_TotalSize = 0x20
 ; Total Size: 0x98
 ; uint8                               Size: 0x0001
 ArIsLoading = 0x28:0:1:1
-; uint8                               Size: 0x0008
-ArIsSaving = 0x28:1:1:8
+; uint8                               Size: 0x0001
+ArIsSaving = 0x28:1:1:1
 ; uint8                               Size: 0x0001
 ArIsTransacting = 0x28:2:1:1
 ; uint8                               Size: 0x0001
@@ -196,8 +196,8 @@ ArForceUnicode = 0x28:6:1:1
 ArIsPersistent = 0x28:7:1:1
 ; uint8                               Size: 0x0001
 ArIsError = 0x29:0:1:1
-; uint8                               Size: 0x0008
-ArIsCriticalError = 0x29:1:1:8
+; uint8                               Size: 0x0001
+ArIsCriticalError = 0x29:1:1:1
 ; uint8                               Size: 0x0001
 ArContainsCode = 0x29:2:1:1
 ; uint8                               Size: 0x0001
@@ -212,8 +212,8 @@ ArIgnoreArchetypeRef = 0x29:6:1:1
 ArNoDelta = 0x29:7:1:1
 ; uint8                               Size: 0x0001
 ArNoIntraPropertyDelta = 0x2A:0:1:1
-; uint8                               Size: 0x0008
-ArIgnoreOuterRef = 0x2A:1:1:8
+; uint8                               Size: 0x0001
+ArIgnoreOuterRef = 0x2A:1:1:1
 ; uint8                               Size: 0x0001
 ArIgnoreClassGeneratedByRef = 0x2A:2:1:1
 ; uint8                               Size: 0x0001
@@ -228,8 +228,8 @@ ArIsModifyingWeakAndStrongReferences = 0x2A:6:1:1
 ArIsCountingMemory = 0x2A:7:1:1
 ; uint8                               Size: 0x0001
 ArShouldSkipBulkData = 0x2B:0:1:1
-; uint8                               Size: 0x0008
-ArIsFilterEditorOnly = 0x2B:1:1:8
+; uint8                               Size: 0x0001
+ArIsFilterEditorOnly = 0x2B:1:1:1
 ; uint8                               Size: 0x0001
 ArIsSaveGame = 0x2B:2:1:1
 ; uint8                               Size: 0x0001
@@ -296,7 +296,7 @@ UEP_TotalSize = 0x2C0
 
 [AGameMode]
 ; Total Size: 0x308
-; FName                               Size: 0x0004  Padding: 0x4
+; FName                               Size: 0x0008
 MatchState = 0x2C0
 ; uint32                              Size: 0x0004
 bDelayedStart = 0x2C8:0:1:4
@@ -328,8 +328,8 @@ UEP_TotalSize = 0x308
 PrimaryActorTick = 0x28
 ; uint8                               Size: 0x0001
 bNetTemporary = 0x58:0:1:1
-; uint8                               Size: 0x0008
-bNetStartup = 0x58:1:1:8
+; uint8                               Size: 0x0001
+bNetStartup = 0x58:1:1:1
 ; uint8                               Size: 0x0001
 bOnlyRelevantToOwner = 0x58:2:1:1
 ; uint8                               Size: 0x0001
@@ -344,8 +344,8 @@ bTearOff = 0x58:6:1:1
 bForceNetAddressable = 0x58:7:1:1
 ; uint8                               Size: 0x0001
 bExchangedRoles = 0x59:0:1:1
-; uint8                               Size: 0x0008
-bNetLoadOnClient = 0x59:1:1:8
+; uint8                               Size: 0x0001
+bNetLoadOnClient = 0x59:1:1:1
 ; uint8                               Size: 0x0001
 bNetUseOwnerRelevancy = 0x59:2:1:1
 ; uint8                               Size: 0x0001
@@ -360,8 +360,8 @@ bAllowTickBeforeBeginPlay = 0x59:6:1:1
 bAutoDestroyWhenFinished = 0x59:7:1:1
 ; uint8                               Size: 0x0001
 bCanBeDamaged = 0x5A:0:1:1
-; uint8                               Size: 0x0008
-bBlockInput = 0x5A:1:1:8
+; uint8                               Size: 0x0001
+bBlockInput = 0x5A:1:1:1
 ; uint8                               Size: 0x0001
 bCollideWhenPlacing = 0x5A:2:1:1
 ; uint8                               Size: 0x0001
@@ -376,8 +376,8 @@ bEnableAutoLODGeneration = 0x5A:6:1:1
 bIsEditorOnlyActor = 0x5A:7:1:1
 ; uint8                               Size: 0x0001
 bActorSeamlessTraveled = 0x5B:0:1:1
-; uint8                               Size: 0x0008
-bReplicates = 0x5B:1:1:8
+; uint8                               Size: 0x0001
+bReplicates = 0x5B:1:1:1
 ; uint8                               Size: 0x0001
 bCanBeInCluster = 0x5B:2:1:1
 ; uint8                               Size: 0x0001
@@ -392,8 +392,8 @@ bActorInitialized = 0x5B:6:1:1
 bActorBeginningPlayFromLevelStreaming = 0x5B:7:1:1
 ; uint8                               Size: 0x0001
 bTickFunctionsRegistered = 0x5C:0:1:1
-; uint8                               Size: 0x0008
-bHasDeferredComponentRegistration = 0x5C:1:1:8
+; uint8                               Size: 0x0001
+bHasDeferredComponentRegistration = 0x5C:1:1:1
 ; uint8                               Size: 0x0001
 bRunningUserConstructionScript = 0x5C:2:1:1
 ; uint8                               Size: 0x0001
@@ -422,7 +422,7 @@ CreationTime = 0x9C
 AttachmentReplication = 0xA0
 ; AActor*                             Size: 0x0008
 Owner = 0xE0
-; FName                               Size: 0x0004  Padding: 0x4
+; FName                               Size: 0x0008
 NetDriverName = 0xE8
 ; TEnumAsByte<enum ENetRole>          Size: 0x0001
 Role = 0xF0
@@ -520,7 +520,7 @@ ViewportClient = 0x70
 Origin = 0x78
 ; FVector2D                           Size: 0x0008
 Size = 0x80
-; FVector                             Size: 0x0004  Padding: 0x8
+; FVector                             Size: 0x000C
 LastViewLocation = 0x88
 ; TEnumAsByte<enum EAspectRatioAxisConstraint> Size: 0x0001  Padding: 0xB
 AspectRatioAxisConstraint = 0x94
@@ -534,13 +534,13 @@ UEP_TotalSize = 0x258
 
 [FFieldClass]
 ; Total Size: 0x40
-; FName                               Size: 0x0004  Padding: 0x4
+; FName                               Size: 0x0008
 Name = 0x0
 ; uint64                              Size: 0x0008
 Id = 0x8
 ; uint64                              Size: 0x0008
 CastFlags = 0x10
-; EClassFlags                         Size: 0x0018
+; EClassFlags                         Size: 0x0004  Padding: 0x4
 ClassFlags = 0x18
 ; FFieldClass*                        Size: 0x0008
 SuperClass = 0x20
@@ -560,7 +560,7 @@ ClassPrivate = 0x8
 Owner = 0x10
 ; FField*                             Size: 0x0008
 Next = 0x20
-; FName                               Size: 0x0004  Padding: 0x4
+; FName                               Size: 0x0008
 NamePrivate = 0x28
 ; EObjectFlags                        Size: 0x0004
 FlagsPrivate = 0x30
@@ -584,7 +584,7 @@ PropertyFlags = 0x40
 RepIndex = 0x48
 ; int32                               Size: 0x0004
 Offset_Internal = 0x4C
-; FName                               Size: 0x0004  Padding: 0x4
+; FName                               Size: 0x0008
 RepNotifyFunc = 0x50
 ; FProperty*                          Size: 0x0008
 PropertyLinkNext = 0x58
@@ -610,7 +610,7 @@ UEP_TotalSize = 0x80
 
 [FWorldContext]
 ; Total Size: 0x288
-; FName                               Size: 0x0004  Padding: 0x4
+; FName                               Size: 0x0008
 ContextHandle = 0xB0
 ; FString                             Size: 0x0010
 TravelURL = 0xB8
@@ -672,8 +672,8 @@ StreamingLevelsPrefix = 0xC0
 ViewLocationsRenderedLastFrame = 0xF8
 ; uint8                               Size: 0x0001
 bWorldWasLoadedThisTick = 0x10B:0:1:1
-; uint8                               Size: 0x0008
-bTriggerPostLoadMap = 0x10B:1:1:8
+; uint8                               Size: 0x0001
+bTriggerPostLoadMap = 0x10B:1:1:1
 ; uint8                               Size: 0x0001
 bInTick = 0x10B:2:1:1
 ; uint8                               Size: 0x0001
@@ -688,8 +688,8 @@ bIsWorldInitialized = 0x10B:6:1:1
 bIsLevelStreamingFrozen = 0x10B:7:1:1
 ; uint8                               Size: 0x0001
 bDoDelayedUpdateCullDistanceVolumes = 0x10C:0:1:1
-; uint8                               Size: 0x0008
-bIsRunningConstructionScript = 0x10C:1:1:8
+; uint8                               Size: 0x0001
+bIsRunningConstructionScript = 0x10C:1:1:1
 ; uint8                               Size: 0x0001
 bShouldSimulatePhysics = 0x10C:2:1:1
 ; uint8                               Size: 0x0001
@@ -704,8 +704,8 @@ bRequestedBlockOnAsyncLoading = 0x10C:6:1:1
 bActorsInitialized = 0x10C:7:1:1
 ; uint8                               Size: 0x0001
 bBegunPlay = 0x10D:0:1:1
-; uint8                               Size: 0x0008
-bMatchStarted = 0x10D:1:1:8
+; uint8                               Size: 0x0001
+bMatchStarted = 0x10D:1:1:1
 ; uint8                               Size: 0x0001
 bPlayersOnly = 0x10D:2:1:1
 ; uint8                               Size: 0x0001
@@ -720,8 +720,8 @@ bKismetScriptError = 0x10D:6:1:1
 bDebugPauseExecution = 0x10D:7:1:1
 ; uint8                               Size: 0x0001
 bIsCameraMoveableWhenPaused = 0x10E:0:1:1
-; uint8                               Size: 0x0008
-bAllowAudioPlayback = 0x10E:1:1:8
+; uint8                               Size: 0x0001
+bAllowAudioPlayback = 0x10E:1:1:1
 ; uint8                               Size: 0x0001
 bAreConstraintsDirty = 0x10E:2:1:1
 ; uint8                               Size: 0x0001
@@ -762,7 +762,7 @@ AudioTimeSeconds = 0x5AC
 DeltaTimeSeconds = 0x5B0
 ; float                               Size: 0x0004  Padding: 0x18
 PauseDelay = 0x5B4
-; FVector                             Size: 0x0004  Padding: 0x8
+; FVector                             Size: 0x000C
 OriginOffsetThisFrame = 0x5D0
 ; float                               Size: 0x0004  Padding: 0xA
 NextSwitchCountdown = 0x5DC
@@ -772,7 +772,7 @@ NumStreamingLevelsBeingLoaded = 0x5EA
 NextURL = 0x5F0
 ; TArray<FName,TSizedDefaultAllocator<32> > Size: 0x0010
 PreparingLevelNames = 0x600
-; FName                               Size: 0x0004  Padding: 0x4
+; FName                               Size: 0x0008
 CommittedPersistentLevelName = 0x610
 ; uint32                              Size: 0x0004
 bMarkedObjectsPendingKill = 0x618:0:1:4
@@ -816,7 +816,7 @@ ClassAddReferencedObjects = 0xC0
 ClassUnique = 0xC8:0:31:4
 ; uint32                              Size: 0x0004
 bCooked = 0xC8:31:1:4
-; EClassFlags                         Size: 0x0018
+; EClassFlags                         Size: 0x0004
 ClassFlags = 0xCC
 ; EClassCastFlags                     Size: 0x0008
 ClassCastFlags = 0xD0
@@ -824,7 +824,7 @@ ClassCastFlags = 0xD0
 ClassWithin = 0xD8
 ; UObject*                            Size: 0x0008
 ClassGeneratedBy = 0xE0
-; FName                               Size: 0x0004  Padding: 0x14
+; FName                               Size: 0x0008  Padding: 0x10
 ClassConfigName = 0xE8
 ; TArray<UField *,TSizedDefaultAllocator<32> > Size: 0x0010
 NetFields = 0x100
@@ -858,7 +858,7 @@ Names = 0x40
 CppForm = 0x50
 ; EEnumFlags                          Size: 0x0004
 EnumFlags = 0x54
-; std::function<void(int32)>*         Size: 0x0008
+; std::function<FText(int32)>*        Size: 0x0008
 EnumDisplayNameFn = 0x58
 UEP_TotalSize = 0x60
 
@@ -960,8 +960,8 @@ RowStruct = 0x28
 RowMap = 0x30
 ; uint8                               Size: 0x0001
 bStripFromClientBuilds = 0x80:0:1:1
-; uint8                               Size: 0x0008
-bIgnoreExtraFields = 0x80:1:1:8
+; uint8                               Size: 0x0001
+bIgnoreExtraFields = 0x80:1:1:1
 ; uint8                               Size: 0x0001  Padding: 0x7
 bIgnoreMissingFields = 0x80:2:1:1
 ; FString                             Size: 0x0010

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_5_00_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_5_00_Template.ini
@@ -1,6 +1,6 @@
 [UObjectBase]
 ; Total Size: 0x28
-; EObjectFlags                        Size: 0x0008
+; EObjectFlags                        Size: 0x0004
 ObjectFlags = 0x8
 ; int32                               Size: 0x0004
 InternalIndex = 0xC
@@ -66,12 +66,12 @@ DebugProperties = 0x48
 SplitscreenInfo = 0x58
 ; int32                               Size: 0x0004
 MaxSplitscreenPlayers = 0x68
-; uint32                              Size: 0x0010
-bShowTitleSafeZone = 0x6C:0:1:16
+; uint32                              Size: 0x0004
+bShowTitleSafeZone = 0x6C:0:1:4
 ; uint32                              Size: 0x0004
 bIsPlayInEditorViewport = 0x6C:1:1:4
-; uint32                              Size: 0x0010
-bDisableWorldRendering = 0x6C:2:1:16
+; uint32                              Size: 0x0004
+bDisableWorldRendering = 0x6C:2:1:4
 ; TEnumAsByte<enum ESplitScreenType::Type> Size: 0x0001  Padding: 0x7
 ActiveSplitscreenType = 0x70
 ; TObjectPtr<UWorld>                  Size: 0x0008  Padding: 0x8
@@ -90,7 +90,7 @@ ViewportFrame = 0xF0
 AudioDeviceHandle = 0xF8
 ; bool                                Size: 0x0001  Padding: 0x3
 bHasAudioFocus = 0xFC
-; TWeakPtr<SWindow,1>                 Size: 0x0008  Padding: 0x8
+; TWeakPtr<SWindow,1>                 Size: 0x0010
 Window = 0x100
 ; TWeakPtr<SOverlay,1>                Size: 0x0010
 ViewportOverlayWidget = 0x110
@@ -104,7 +104,7 @@ CurrentNaniteVisualizationMode = 0x138
 CurrentLumenVisualizationMode = 0x140
 ; FName                               Size: 0x0008
 CurrentVirtualShadowMapVisualizationMode = 0x148
-; TWeakPtr<SWindow,1>                 Size: 0x0008  Padding: 0x8
+; TWeakPtr<SWindow,1>                 Size: 0x0010
 HighResScreenshotDialog = 0x150
 ; TMap<FName, void *>                 Size: 0x0050
 HardwareCursorCache = 0x160
@@ -162,7 +162,7 @@ ObjAvailableList = 0x58
 UObjectCreateListeners = 0x68
 ; TArray<FUObjectArray::FUObjectDeleteListener *,TSizedDefaultAllocator<32> > Size: 0x0010  Padding: 0x28
 UObjectDeleteListeners = 0x78
-; FThreadSafeCounter                  Size: 0x0008
+; FThreadSafeCounter                  Size: 0x0004
 MasterSerialNumber = 0xB0
 UEP_TotalSize = 0xB8
 
@@ -190,8 +190,8 @@ ArIsLoading = 0x28:0:1:1
 ArIsLoadingFromCookedPackage = 0x28:1:1:1
 ; uint8                               Size: 0x0001
 ArIsSaving = 0x28:2:1:1
-; uint8                               Size: 0x0004
-ArIsTransacting = 0x28:3:1:4
+; uint8                               Size: 0x0001
+ArIsTransacting = 0x28:3:1:1
 ; uint8                               Size: 0x0001
 ArIsTextFormat = 0x28:4:1:1
 ; uint8                               Size: 0x0001
@@ -206,8 +206,8 @@ ArIsPersistent = 0x29:0:1:1
 ArIsError = 0x29:1:1:1
 ; uint8                               Size: 0x0001
 ArIsCriticalError = 0x29:2:1:1
-; uint8                               Size: 0x0004
-ArShouldSkipCompilingAssets = 0x29:3:1:4
+; uint8                               Size: 0x0001
+ArShouldSkipCompilingAssets = 0x29:3:1:1
 ; uint8                               Size: 0x0001
 ArContainsCode = 0x29:4:1:1
 ; uint8                               Size: 0x0001
@@ -222,8 +222,8 @@ ArIgnoreArchetypeRef = 0x2A:0:1:1
 ArNoDelta = 0x2A:1:1:1
 ; uint8                               Size: 0x0001
 ArNoIntraPropertyDelta = 0x2A:2:1:1
-; uint8                               Size: 0x0004
-ArIgnoreOuterRef = 0x2A:3:1:4
+; uint8                               Size: 0x0001
+ArIgnoreOuterRef = 0x2A:3:1:1
 ; uint8                               Size: 0x0001
 ArIgnoreClassGeneratedByRef = 0x2A:4:1:1
 ; uint8                               Size: 0x0001
@@ -238,8 +238,8 @@ ArIsModifyingWeakAndStrongReferences = 0x2B:0:1:1
 ArIsCountingMemory = 0x2B:1:1:1
 ; uint8                               Size: 0x0001
 ArShouldSkipBulkData = 0x2B:2:1:1
-; uint8                               Size: 0x0004
-ArIsFilterEditorOnly = 0x2B:3:1:4
+; uint8                               Size: 0x0001
+ArIsFilterEditorOnly = 0x2B:3:1:1
 ; uint8                               Size: 0x0001
 ArIsSaveGame = 0x2B:4:1:1
 ; uint8                               Size: 0x0001
@@ -296,20 +296,20 @@ GameSession = 0x2D0
 ServerStatReplicator = 0x2E0
 ; FText                               Size: 0x0018
 DefaultPlayerName = 0x2E8
-; uint32                              Size: 0x0010
-bUseSeamlessTravel = 0x300:0:1:16
+; uint32                              Size: 0x0004
+bUseSeamlessTravel = 0x300:0:1:4
 ; uint32                              Size: 0x0004
 bStartPlayersAsSpectators = 0x300:1:1:4
-; uint32                              Size: 0x0010
-bPauseable = 0x300:2:1:16
+; uint32                              Size: 0x0004
+bPauseable = 0x300:2:1:4
 UEP_TotalSize = 0x318
 
 [AGameMode]
 ; Total Size: 0x360
 ; FName                               Size: 0x0008
 MatchState = 0x318
-; uint32                              Size: 0x0010
-bDelayedStart = 0x320:0:1:16
+; uint32                              Size: 0x0004
+bDelayedStart = 0x320:0:1:4
 ; int32                               Size: 0x0004
 NumSpectators = 0x324
 ; int32                               Size: 0x0004
@@ -334,7 +334,7 @@ UEP_TotalSize = 0x360
 
 [AActor]
 ; Total Size: 0x278
-; FActorTickFunction                  Size: 0x0008  Padding: 0x28
+; FActorTickFunction                  Size: 0x0030
 PrimaryActorTick = 0x28
 ; uint8                               Size: 0x0001
 bNetTemporary = 0x58:0:1:1
@@ -342,8 +342,8 @@ bNetTemporary = 0x58:0:1:1
 bNetStartup = 0x58:1:1:1
 ; uint8                               Size: 0x0001
 bOnlyRelevantToOwner = 0x58:2:1:1
-; uint8                               Size: 0x0004
-bAlwaysRelevant = 0x58:3:1:4
+; uint8                               Size: 0x0001
+bAlwaysRelevant = 0x58:3:1:1
 ; uint8                               Size: 0x0001
 bReplicateMovement = 0x58:4:1:1
 ; uint8                               Size: 0x0001
@@ -358,8 +358,8 @@ bTearOff = 0x59:0:1:1
 bForceNetAddressable = 0x59:1:1:1
 ; uint8                               Size: 0x0001
 bExchangedRoles = 0x59:2:1:1
-; uint8                               Size: 0x0004
-bNetLoadOnClient = 0x59:3:1:4
+; uint8                               Size: 0x0001
+bNetLoadOnClient = 0x59:3:1:1
 ; uint8                               Size: 0x0001
 bNetUseOwnerRelevancy = 0x59:4:1:1
 ; uint8                               Size: 0x0001
@@ -374,8 +374,8 @@ bAllowTickBeforeBeginPlay = 0x5A:0:1:1
 bAutoDestroyWhenFinished = 0x5A:1:1:1
 ; uint8                               Size: 0x0001
 bCanBeDamaged = 0x5A:2:1:1
-; uint8                               Size: 0x0004
-bBlockInput = 0x5A:3:1:4
+; uint8                               Size: 0x0001
+bBlockInput = 0x5A:3:1:1
 ; uint8                               Size: 0x0001
 bCollideWhenPlacing = 0x5A:4:1:1
 ; uint8                               Size: 0x0001
@@ -390,8 +390,8 @@ bEnableAutoLODGeneration = 0x5B:0:1:1
 bIsEditorOnlyActor = 0x5B:1:1:1
 ; uint8                               Size: 0x0001
 bActorSeamlessTraveled = 0x5B:2:1:1
-; uint8                               Size: 0x0004
-bReplicates = 0x5B:3:1:4
+; uint8                               Size: 0x0001
+bReplicates = 0x5B:3:1:1
 ; uint8                               Size: 0x0001
 bCanBeInCluster = 0x5B:4:1:1
 ; uint8                               Size: 0x0001
@@ -406,8 +406,8 @@ bActorInitialized = 0x5C:0:1:1
 bActorBeginningPlayFromLevelStreaming = 0x5C:1:1:1
 ; uint8                               Size: 0x0001
 bTickFunctionsRegistered = 0x5C:2:1:1
-; uint8                               Size: 0x0004
-bHasDeferredComponentRegistration = 0x5C:3:1:4
+; uint8                               Size: 0x0001
+bHasDeferredComponentRegistration = 0x5C:3:1:1
 ; uint8                               Size: 0x0001
 bRunningUserConstructionScript = 0x5C:4:1:1
 ; uint8                               Size: 0x0001
@@ -532,8 +532,8 @@ CachedUniqueNetId = 0x48
 ViewportClient = 0x78
 ; TEnumAsByte<enum EAspectRatioAxisConstraint> Size: 0x0001  Padding: 0xF
 AspectRatioAxisConstraint = 0xB8
-; uint32                              Size: 0x0010  Padding: 0x8
-bSentSplitJoin = 0xC8:0:1:16
+; uint32                              Size: 0x0004  Padding: 0x14
+bSentSplitJoin = 0xC8:0:1:4
 ; int32                               Size: 0x0004  Padding: 0x1C
 ControllerId = 0xE0
 ; FPlatformUserId                     Size: 0x0004  Padding: 0xE4
@@ -558,7 +558,7 @@ SuperClass = 0x20
 DefaultObject = 0x28
 ; std::function<FField*(const void*, const void*, EObjectFlags)>* Size: 0x0008
 ConstructFn = 0x30
-; FThreadSafeCounter                  Size: 0x0008
+; FThreadSafeCounter                  Size: 0x0004
 UnqiueNameIndexCounter = 0x38
 UEP_TotalSize = 0x40
 
@@ -572,7 +572,7 @@ Owner = 0x10
 Next = 0x20
 ; FName                               Size: 0x0008
 NamePrivate = 0x28
-; EObjectFlags                        Size: 0x0008
+; EObjectFlags                        Size: 0x0004
 FlagsPrivate = 0x30
 UEP_TotalSize = 0x38
 
@@ -634,8 +634,8 @@ LastRemoteURL = 0x128
 LevelsToLoadForPendingMapChange = 0x1A8
 ; FString                             Size: 0x0010
 PendingMapChangeFailureDescription = 0x1C8
-; uint32                              Size: 0x0010  Padding: 0x18
-bShouldCommitPendingMapChange = 0x1D8:0:1:16
+; uint32                              Size: 0x0004  Padding: 0x24
+bShouldCommitPendingMapChange = 0x1D8:0:1:4
 ; TObjectPtr<UGameViewportClient>     Size: 0x0008  Padding: 0x18
 GameViewport = 0x200
 ; int32                               Size: 0x0004  Padding: 0x4
@@ -686,8 +686,8 @@ bWorldWasLoadedThisTick = 0x113:0:1:1
 bTriggerPostLoadMap = 0x113:1:1:1
 ; uint8                               Size: 0x0001
 bInTick = 0x113:2:1:1
-; uint8                               Size: 0x0004
-bIsBuilt = 0x113:3:1:4
+; uint8                               Size: 0x0001
+bIsBuilt = 0x113:3:1:1
 ; uint8                               Size: 0x0001
 bTickNewlySpawned = 0x113:4:1:1
 ; uint8                               Size: 0x0001
@@ -702,8 +702,8 @@ bDoDelayedUpdateCullDistanceVolumes = 0x114:0:1:1
 bIsRunningConstructionScript = 0x114:1:1:1
 ; uint8                               Size: 0x0001
 bShouldSimulatePhysics = 0x114:2:1:1
-; uint8                               Size: 0x0004
-bDropDetail = 0x114:3:1:4
+; uint8                               Size: 0x0001
+bDropDetail = 0x114:3:1:1
 ; uint8                               Size: 0x0001
 bAggressiveLOD = 0x114:4:1:1
 ; uint8                               Size: 0x0001
@@ -718,8 +718,8 @@ bBegunPlay = 0x115:0:1:1
 bMatchStarted = 0x115:1:1:1
 ; uint8                               Size: 0x0001
 bPlayersOnly = 0x115:2:1:1
-; uint8                               Size: 0x0004
-bPlayersOnlyPending = 0x115:3:1:4
+; uint8                               Size: 0x0001
+bPlayersOnlyPending = 0x115:3:1:1
 ; uint8                               Size: 0x0001
 bStartup = 0x115:4:1:1
 ; uint8                               Size: 0x0001
@@ -734,8 +734,8 @@ bIsCameraMoveableWhenPaused = 0x116:0:1:1
 bAllowAudioPlayback = 0x116:1:1:1
 ; uint8                               Size: 0x0001
 bAreConstraintsDirty = 0x116:2:1:1
-; uint8                               Size: 0x0004
-bRequiresHitProxies = 0x116:3:1:4
+; uint8                               Size: 0x0001
+bRequiresHitProxies = 0x116:3:1:1
 ; uint8                               Size: 0x0001
 bShouldTick = 0x116:4:1:1
 ; uint8                               Size: 0x0001
@@ -792,8 +792,8 @@ NextURL = 0x640
 PreparingLevelNames = 0x650
 ; FName                               Size: 0x0008
 CommittedPersistentLevelName = 0x660
-; uint32                              Size: 0x0010
-bMarkedObjectsPendingKill = 0x668:0:1:16
+; uint32                              Size: 0x0004
+bMarkedObjectsPendingKill = 0x668:0:1:4
 ; uint32                              Size: 0x0004
 CleanupWorldTag = 0x66C
 UEP_TotalSize = 0x800
@@ -854,9 +854,9 @@ ClassDefaultObject = 0x110
 SparseClassData = 0x118
 ; UScriptStruct*                      Size: 0x0008
 SparseClassDataStruct = 0x120
-; TMap<FName, UFunction *>            Size: 0x0010  Padding: 0x40
+; TMap<FName, UFunction *>            Size: 0x0050
 FuncMap = 0x128
-; TMap<FName, UFunction *>            Size: 0x0010  Padding: 0x48
+; TMap<FName, UFunction *>            Size: 0x0050  Padding: 0x8
 SuperFuncMap = 0x178
 ; TArray<FImplementedInterface,TSizedDefaultAllocator<32> > Size: 0x0010
 Interfaces = 0x1D0
@@ -876,7 +876,7 @@ Names = 0x40
 CppForm = 0x50
 ; EEnumFlags                          Size: 0x0004
 EnumFlags = 0x54
-; std::function<void(int32)>*         Size: 0x0008
+; std::function<FText(int32)>*        Size: 0x0008
 EnumDisplayNameFn = 0x58
 UEP_TotalSize = 0x60
 

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_5_01_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_5_01_Template.ini
@@ -14,9 +14,9 @@ UEP_TotalSize = 0x28
 
 [UScriptStruct::ICppStructOps]
 ; Total Size: 0x10
-; const int32                         Size: 0x0008
+; const int32                         Size: 0x0004
 Size = 0x8
-; const int32                         Size: 0x0008
+; const int32                         Size: 0x0004
 Alignment = 0xC
 UEP_TotalSize = 0x10
 
@@ -34,7 +34,7 @@ UEP_TotalSize = 0x10
 SuperStruct = 0x40
 ; UField*                             Size: 0x0008
 Children = 0x48
-; FField*                             Size: 0x0001  Padding: 0x7
+; FField*                             Size: 0x0008
 ChildProperties = 0x50
 ; int32                               Size: 0x0004
 PropertiesSize = 0x58
@@ -80,7 +80,7 @@ World = 0x78
 bSuppressTransitionMessage = 0x88
 ; int32                               Size: 0x0004  Padding: 0x4
 ViewModeIndex = 0xB0
-; FEngineShowFlags                    Size: 0x0004  Padding: 0x2C
+; FEngineShowFlags                    Size: 0x0030
 EngineShowFlags = 0xB8
 ; FViewport*                          Size: 0x0008
 Viewport = 0xE8
@@ -562,7 +562,7 @@ CastFlags = 0x10
 ClassFlags = 0x18
 ; FFieldClass*                        Size: 0x0008
 SuperClass = 0x20
-; FField*                             Size: 0x0001  Padding: 0x7
+; FField*                             Size: 0x0008
 DefaultObject = 0x28
 ; std::function<FField*(const void*, const void*, EObjectFlags)>* Size: 0x0008
 ConstructFn = 0x30
@@ -576,7 +576,7 @@ UEP_TotalSize = 0x40
 ClassPrivate = 0x8
 ; FFieldVariant                       Size: 0x0010
 Owner = 0x10
-; FField*                             Size: 0x0001  Padding: 0x7
+; FField*                             Size: 0x0008
 Next = 0x20
 ; FName                               Size: 0x0008
 NamePrivate = 0x28
@@ -892,7 +892,7 @@ Names = 0x40
 CppForm = 0x50
 ; EEnumFlags                          Size: 0x0004
 EnumFlags = 0x54
-; std::function<void(int32)>*         Size: 0x0008
+; std::function<FText(int32)>*        Size: 0x0008
 EnumDisplayNameFn = 0x58
 ; FName                               Size: 0x0008
 EnumPackage = 0x60

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_5_02_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_5_02_Template.ini
@@ -8,7 +8,7 @@ InternalIndex = 0xC
 ClassPrivate = 0x10
 ; FName                               Size: 0x0008
 NamePrivate = 0x18
-; UObject*                            Size: 0x000C
+; UObject*                            Size: 0x0008
 OuterPrivate = 0x20
 UEP_TotalSize = 0x28
 
@@ -674,7 +674,7 @@ PIEAccumulatedTickSeconds = 0x25C
 GarbageObjectsToVerify = 0x260
 ; TArray<UWorld * *,TSizedDefaultAllocator<32> > Size: 0x0010
 ExternalReferences = 0x2B0
-; UWorld*                             Size: 0x000C
+; UWorld*                             Size: 0x0008
 ThisCurrentWorld = 0x2C0
 UEP_TotalSize = 0x2C8
 
@@ -870,11 +870,11 @@ ClassWithin = 0xE0
 ClassConfigName = 0xE8
 ; TArray<UField *,TSizedDefaultAllocator<32> > Size: 0x0010
 NetFields = 0x100
-; UObject*                            Size: 0x000C
+; UObject*                            Size: 0x0008
 ClassDefaultObject = 0x110
 ; void*                               Size: 0x0008
 SparseClassData = 0x118
-; UScriptStruct*                      Size: 0x0004  Padding: 0x4
+; UScriptStruct*                      Size: 0x0008
 SparseClassDataStruct = 0x120
 ; TMap<FName, UFunction *>            Size: 0x0050  Padding: 0x8
 FuncMap = 0x128
@@ -896,7 +896,7 @@ Names = 0x40
 CppForm = 0x50
 ; EEnumFlags                          Size: 0x0004
 EnumFlags = 0x54
-; std::function<void(int32)>*         Size: 0x0008
+; std::function<FText(int32)>*        Size: 0x0008
 EnumDisplayNameFn = 0x58
 ; FName                               Size: 0x0008
 EnumPackage = 0x60
@@ -904,7 +904,7 @@ UEP_TotalSize = 0x68
 
 [FStructProperty]
 ; Total Size: 0x80
-; UScriptStruct*                      Size: 0x0004
+; UScriptStruct*                      Size: 0x0008
 Struct = 0x78
 UEP_TotalSize = 0x80
 

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_5_03_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_5_03_Template.ini
@@ -896,7 +896,7 @@ Names = 0x40
 CppForm = 0x50
 ; EEnumFlags                          Size: 0x0001  Padding: 0x3
 EnumFlags = 0x54
-; std::function<void(int32)>*         Size: 0x0008
+; std::function<FText(int32)>*        Size: 0x0008
 EnumDisplayNameFn = 0x58
 ; FName                               Size: 0x0008
 EnumPackage = 0x60

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_5_04_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_5_04_Template.ini
@@ -1,6 +1,6 @@
 [UObjectBase]
 ; Total Size: 0x28
-; EObjectFlags                        Size: 0x0010
+; EObjectFlags                        Size: 0x0004
 ObjectFlags = 0x8
 ; int32                               Size: 0x0004
 InternalIndex = 0xC
@@ -278,7 +278,7 @@ UEP_TotalSize = 0x90
 
 [AGameModeBase]
 ; Total Size: 0x328
-; FString                             Size: 0x0004  Padding: 0xC
+; FString                             Size: 0x0010
 OptionsString = 0x290
 ; TSubclassOf<AGameSession>           Size: 0x0008  Padding: 0x10
 GameSessionClass = 0x2A0
@@ -588,7 +588,7 @@ Owner = 0x10
 Next = 0x18
 ; FName                               Size: 0x0008
 NamePrivate = 0x20
-; EObjectFlags                        Size: 0x0010
+; EObjectFlags                        Size: 0x0004
 FlagsPrivate = 0x28
 UEP_TotalSize = 0x30
 
@@ -638,7 +638,7 @@ UEP_TotalSize = 0x78
 ; Total Size: 0x2C8
 ; FName                               Size: 0x0008
 ContextHandle = 0xA0
-; FString                             Size: 0x0004  Padding: 0xC
+; FString                             Size: 0x0010
 TravelURL = 0xA8
 ; uint8                               Size: 0x0001  Padding: 0x7
 TravelType = 0xB8
@@ -648,7 +648,7 @@ LastURL = 0xC0
 LastRemoteURL = 0x128
 ; TArray<FName,TSizedDefaultAllocator<32> > Size: 0x0010  Padding: 0x10
 LevelsToLoadForPendingMapChange = 0x1A8
-; FString                             Size: 0x0004  Padding: 0xC
+; FString                             Size: 0x0010
 PendingMapChangeFailureDescription = 0x1C8
 ; uint32                              Size: 0x0004  Padding: 0x24
 bShouldCommitPendingMapChange = 0x1D8:0:1:4
@@ -656,7 +656,7 @@ bShouldCommitPendingMapChange = 0x1D8:0:1:4
 GameViewport = 0x200
 ; int32                               Size: 0x0004  Padding: 0x4
 PIEInstance = 0x220
-; FString                             Size: 0x0004  Padding: 0x10
+; FString                             Size: 0x0010  Padding: 0x4
 PIEPrefix = 0x228
 ; bool                                Size: 0x0001
 RunAsDedicated = 0x23C
@@ -666,7 +666,7 @@ bWaitingOnOnlineSubsystem = 0x23D
 bIsPrimaryPIEInstance = 0x23E
 ; uint32                              Size: 0x0004  Padding: 0x4
 AudioDeviceID = 0x240
-; FString                             Size: 0x0004  Padding: 0xC
+; FString                             Size: 0x0010
 CustomDescription = 0x248
 ; float                               Size: 0x0004
 PIEFixedTickSeconds = 0x258
@@ -696,7 +696,7 @@ UEP_TotalSize = 0xC0
 ExtraReferencedObjects = 0x68
 ; TArray<TObjectPtr<UObject>,TSizedDefaultAllocator<32> > Size: 0x0010  Padding: 0x40
 PerModuleDataObjects = 0x78
-; FString                             Size: 0x0004  Padding: 0xC
+; FString                             Size: 0x0010
 StreamingLevelsPrefix = 0xC8
 ; TOptional<bool>                     Size: 0x0002
 bSupportsMakingVisibleTransactionRequests = 0xD8
@@ -812,7 +812,7 @@ PauseDelay = 0x6E8
 NextSwitchCountdown = 0x720
 ; uint16                              Size: 0x0002  Padding: 0x4
 NumStreamingLevelsBeingLoaded = 0x73A
-; FString                             Size: 0x0004  Padding: 0xC
+; FString                             Size: 0x0010
 NextURL = 0x740
 ; TArray<FName,TSizedDefaultAllocator<32> > Size: 0x0010
 PreparingLevelNames = 0x750
@@ -892,7 +892,7 @@ UEP_TotalSize = 0x200
 
 [UEnum]
 ; Total Size: 0x68
-; FString                             Size: 0x0004  Padding: 0xC
+; FString                             Size: 0x0010
 CppType = 0x30
 ; TArray<TTuple<FName,__int64>,TSizedDefaultAllocator<32> > Size: 0x0010
 Names = 0x40
@@ -900,7 +900,7 @@ Names = 0x40
 CppForm = 0x50
 ; EEnumFlags                          Size: 0x0001  Padding: 0x3
 EnumFlags = 0x54
-; std::function<void(int32)>*         Size: 0x0008
+; std::function<FText(int32)>*        Size: 0x0008
 EnumDisplayNameFn = 0x58
 ; FName                               Size: 0x0008
 EnumPackage = 0x60
@@ -1008,7 +1008,7 @@ bStripFromClientBuilds = 0x80:0:1:1
 bIgnoreExtraFields = 0x80:1:1:1
 ; uint8                               Size: 0x0001  Padding: 0x7
 bIgnoreMissingFields = 0x80:2:1:1
-; FString                             Size: 0x0004
+; FString                             Size: 0x0010
 ImportKeyField = 0x88
 UEP_TotalSize = 0xB0
 

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_5_05_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_5_05_Template.ini
@@ -908,7 +908,7 @@ CppForm = 0x50
 EnumFlags = 0x51
 ; FName                               Size: 0x0008  Padding: 0x4
 EnumPackage = 0x54
-; std::function<void(int32)>*         Size: 0x0008
+; std::function<FText(int32)>*        Size: 0x0008
 EnumDisplayNameFn = 0x60
 UEP_TotalSize = 0x68
 

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_5_06_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_5_06_Template.ini
@@ -14,9 +14,9 @@ UEP_TotalSize = 0x28
 
 [UScriptStruct::ICppStructOps]
 ; Total Size: 0x10
-; const int32                         Size: 0x0008
+; const int32                         Size: 0x0004
 Size = 0x8
-; const int32                         Size: 0x0008
+; const int32                         Size: 0x0004
 Alignment = 0xC
 UEP_TotalSize = 0x10
 
@@ -42,7 +42,7 @@ PropertiesSize = 0x58
 MinAlignment = 0x5C
 ; std::atomic<unsigned short>         Size: 0x0002
 StructStateFlags = 0x5E
-; TArray<unsigned char,TSizedDefaultAllocator<32> > Size: 0x0004  Padding: 0xC
+; TArray<unsigned char,TSizedDefaultAllocator<32> > Size: 0x0010
 Script = 0x60
 ; FProperty*                          Size: 0x0008
 PropertyLink = 0x70
@@ -920,7 +920,7 @@ CppForm = 0x50
 EnumFlags = 0x51
 ; FName                               Size: 0x0008  Padding: 0x4
 EnumPackage = 0x54
-; std::function<void(int32)>*         Size: 0x0008
+; std::function<FText(int32)>*        Size: 0x0008
 EnumDisplayNameFn = 0x60
 UEP_TotalSize = 0x68
 

--- a/assets/MemberVarLayoutTemplates/MemberVariableLayout_5_07_Template.ini
+++ b/assets/MemberVarLayoutTemplates/MemberVariableLayout_5_07_Template.ini
@@ -16,9 +16,9 @@ UEP_TotalSize = 0x28
 ; Total Size: 0x10
 ; const UE::CoreUObject::Private::FStructOpsFakeVTable* Size: 0x0008
 FakeVPtr = 0x0
-; const int32                         Size: 0x0008
+; const int32                         Size: 0x0004
 Size = 0x8
-; const int32                         Size: 0x0008
+; const int32                         Size: 0x0004
 Alignment = 0xC
 UEP_TotalSize = 0x10
 
@@ -940,7 +940,7 @@ CppForm = 0x58
 EnumFlags = 0x59
 ; FName                               Size: 0x0008  Padding: 0x4
 EnumPackage = 0x5C
-; std::function<void(int32)>*         Size: 0x0008
+; std::function<FText(int32)>*        Size: 0x0008
 EnumDisplayNameFn = 0x68
 UEP_TotalSize = 0x70
 

--- a/assets/VTableLayoutTemplates/VTableLayout_4_07_Template.ini
+++ b/assets/VTableLayoutTemplates/VTableLayout_4_07_Template.ini
@@ -1,0 +1,1056 @@
+[UObjectBase]
+; void* __vecDelDtor(uint32)
+__vecDelDtor
+; void RegisterDependencies()
+RegisterDependencies
+; void DeferredRegister(UClass*, const wchar_t*, const wchar_t*)
+DeferredRegister
+
+[UObjectBaseUtility]
+; void* __vecDelDtor(uint32)
+__vecDelDtor
+
+[UObject]
+; void* __vecDelDtor(uint32)
+__vecDelDtor
+; FString GetDetailedInfoInternal() const
+GetDetailedInfoInternal
+; void PostInitProperties()
+PostInitProperties
+; bool PreSaveRoot(const wchar_t*, TArray<FString,FDefaultAllocator>&)
+PreSaveRoot
+; void PostSaveRoot(bool)
+PostSaveRoot
+; void PreSave()
+PreSave
+; bool Modify(bool)
+Modify
+; void PostLoad()
+PostLoad
+; void PostLoadSubobjects(FObjectInstancingGraph*)
+PostLoadSubobjects
+; void BeginDestroy()
+BeginDestroy
+; bool IsReadyForFinishDestroy()
+IsReadyForFinishDestroy
+; void FinishDestroy()
+FinishDestroy
+; void Serialize(FArchive&)
+Serialize
+; void ShutdownAfterError()
+ShutdownAfterError
+; void PostInterpChange(UProperty*)
+PostInterpChange
+; void PostRename(UObject*, const FName)
+PostRename
+; void PostDuplicate(bool)
+PostDuplicate
+; bool NeedsLoadForClient() const
+NeedsLoadForClient
+; bool NeedsLoadForServer() const
+NeedsLoadForServer
+; bool NeedsLoadForEditorGame() const
+NeedsLoadForEditorGame
+; void ExportCustomProperties(FOutputDevice&, uint32)
+ExportCustomProperties
+; void ImportCustomProperties(const wchar_t*, FFeedbackContext*)
+ImportCustomProperties
+; void PostEditImport()
+PostEditImport
+; void PostReloadConfig(UProperty*)
+PostReloadConfig
+; bool Rename(const wchar_t*, UObject*, uint32)
+Rename
+; FString GetDesc()
+GetDesc
+; UWorld* GetWorld() const
+GetWorld
+; bool GetNativePropertyValues(TMap<FString, FString>&, uint32) const
+GetNativePropertyValues
+; uint64 GetResourceSize(EResourceSizeMode::Type)
+GetResourceSize
+; FName GetExporterName()
+GetExporterName
+; bool IsLocalizedResource()
+IsLocalizedResource
+; FRestoreForUObjectOverwrite* GetRestoreForUObjectOverwrite()
+GetRestoreForUObjectOverwrite
+; bool AreNativePropertiesIdenticalTo(UObject*) const
+AreNativePropertiesIdenticalTo
+; void GetAssetRegistryTags(TArray<UObject::FAssetRegistryTag,FDefaultAllocator>&) const
+GetAssetRegistryTags
+; bool IsAsset() const
+IsAsset
+; bool IsSafeForRootSet() const
+IsSafeForRootSet
+; void TagSubobjects(EObjectFlags)
+TagSubobjects
+; void GetLifetimeReplicatedProps(TArray<FLifetimeProperty,FDefaultAllocator>&) const
+GetLifetimeReplicatedProps
+; bool IsNameStableForNetworking() const
+IsNameStableForNetworking
+; bool IsFullNameStableForNetworking() const
+IsFullNameStableForNetworking
+; bool IsSupportedForNetworking() const
+IsSupportedForNetworking
+; void GetSubobjectsWithStableNamesForNetworking(TArray<UObject *,FDefaultAllocator>&)
+GetSubobjectsWithStableNamesForNetworking
+; void PreNetReceive()
+PreNetReceive
+; void PostNetReceive()
+PostNetReceive
+; void BeginCacheForCookedPlatformData(const ITargetPlatform*)
+BeginCacheForCookedPlatformData
+; void ClearCachedCookedPlatformData(const ITargetPlatform*)
+ClearCachedCookedPlatformData
+; void ClearAllCachedCookedPlatformData()
+ClearAllCachedCookedPlatformData
+; bool IsCachedCookedPlatformDataLoaded(const ITargetPlatform*)
+IsCachedCookedPlatformDataLoaded
+; void ProcessEvent(UFunction*, void*)
+ProcessEvent
+; int32 GetFunctionCallspace(UFunction*, void*, FFrame*)
+GetFunctionCallspace
+; bool CallRemoteFunction(UFunction*, void*, FOutParmRec*, FFrame*)
+CallRemoteFunction
+; bool ProcessConsoleExec(const wchar_t*, FOutputDevice&, UObject*)
+ProcessConsoleExec
+; UClass* RegenerateClass(UClass*, UObject*, TArray<UObject *,FDefaultAllocator>&)
+RegenerateClass
+; void MarkAsEditorOnlySubobject()
+MarkAsEditorOnlySubobject
+; void ExecuteUbergraph(int32)
+ExecuteUbergraph
+; bool CheckDefaultSubobjectsInternal()
+CheckDefaultSubobjectsInternal
+
+[UScriptStruct::ICppStructOps]
+; void* __vecDelDtor(uint32)
+__vecDelDtor
+; bool HasNoopConstructor()
+HasNoopConstructor
+; bool HasZeroConstructor()
+HasZeroConstructor
+; void Construct(void*)
+Construct
+; bool HasDestructor()
+HasDestructor
+; void Destruct(void*)
+Destruct
+; bool HasSerializer()
+HasSerializer
+; bool Serialize(FArchive&, void*)
+Serialize
+; bool HasPostSerialize()
+HasPostSerialize
+; void PostSerialize(const FArchive&, void*)
+PostSerialize
+; bool HasNetSerializer()
+HasNetSerializer
+; bool NetSerialize(FArchive&, UPackageMap*, bool&, void*)
+NetSerialize
+; bool HasNetDeltaSerializer()
+HasNetDeltaSerializer
+; bool NetDeltaSerialize(FNetDeltaSerializeInfo&, void*)
+NetDeltaSerialize
+; bool IsPlainOldData()
+IsPlainOldData
+; bool HasCopy()
+HasCopy
+; bool Copy(void*, const void*, int32)
+Copy
+; bool HasIdentical()
+HasIdentical
+; bool Identical(const void*, const void*, uint32, bool&)
+Identical
+; bool HasExportTextItem()
+HasExportTextItem
+; bool ExportTextItem(FString&, const void*, const void*, UObject*, int32, UObject*)
+ExportTextItem
+; bool HasImportTextItem()
+HasImportTextItem
+; bool ImportTextItem(const wchar_t*&, void*, int32, UObject*, FOutputDevice*)
+ImportTextItem
+; bool HasAddStructReferencedObjects()
+HasAddStructReferencedObjects
+; std::function<void(const void*, void*)>* AddStructReferencedObjects()
+AddStructReferencedObjects
+; bool HasSerializeFromMismatchedTag()
+HasSerializeFromMismatchedTag
+; bool SerializeFromMismatchedTag(const FPropertyTag&, FArchive&, void*)
+SerializeFromMismatchedTag
+; bool HasMessageHandling()
+HasMessageHandling
+
+[FOutputDevice]
+; void* __vecDelDtor(uint32)
+__vecDelDtor
+; void Serialize(const wchar_t*, ELogVerbosity::Type, const FName&)
+Serialize
+; void Flush()
+Flush
+; void TearDown()
+TearDown
+; bool CanBeUsedOnAnyThread() const
+CanBeUsedOnAnyThread
+
+[UStruct]
+; void* __vecDelDtor(uint32)
+__vecDelDtor
+; UStruct* GetInheritanceSuper() const
+GetInheritanceSuper
+; void Link(FArchive&, bool)
+Link
+; void SerializeBin(FArchive&, void*, int32) const
+SerializeBin
+; void SerializeTaggedProperties(FArchive&, uint8*, UStruct*, uint8*, const UObject*) const
+SerializeTaggedProperties
+; void InitializeStruct(void*, int32) const
+InitializeStruct
+; void DestroyStruct(void*, int32) const
+DestroyStruct
+; EExprToken SerializeExpr(int32&, FArchive&)
+SerializeExpr
+; const wchar_t* GetPrefixCPP() const
+GetPrefixCPP
+; void SetSuperStruct(UStruct*)
+SetSuperStruct
+; FString PropertyNameToDisplayName(FName) const
+PropertyNameToDisplayName
+
+[UGameViewportClient]
+; void* __vecDelDtor(uint32)
+__vecDelDtor
+; void SSSwapControllers()
+SSSwapControllers
+; void ShowTitleSafeArea()
+ShowTitleSafeArea
+; void SetConsoleTarget(int32)
+SetConsoleTarget
+; void Init(FWorldContext&, UGameInstance*)
+Init
+; void AddViewportWidgetContent(TSharedRef<SWidget,0>, const int32)
+AddViewportWidgetContent
+; void RemoveViewportWidgetContent(TSharedRef<SWidget,0>)
+RemoveViewportWidgetContent
+; void DetachViewportClient()
+DetachViewportClient
+; void Tick(float)
+Tick
+; void SetViewportFrame(FViewportFrame*)
+SetViewportFrame
+; void SetViewport(FViewport*)
+SetViewport
+; void SetDropDetail(float)
+SetDropDetail
+; FString ConsoleCommand(const FString&)
+ConsoleCommand
+; ULocalPlayer* SetupInitialLocalPlayer(FString&)
+SetupInitialLocalPlayer
+; ULocalPlayer* CreatePlayer(int32, FString&, bool)
+CreatePlayer
+; bool RemovePlayer(ULocalPlayer*)
+RemovePlayer
+; void UpdateActiveSplitscreenType()
+UpdateActiveSplitscreenType
+; void LayoutPlayers()
+LayoutPlayers
+; void GetSubtitleRegion(FVector2D&, FVector2D&)
+GetSubtitleRegion
+; void DrawTitleSafeArea(UCanvas*)
+DrawTitleSafeArea
+; void PostRender(UCanvas*)
+PostRender
+; void DrawTransition(UCanvas*)
+DrawTransition
+; void DrawTransitionMessage(UCanvas*, const FString&)
+DrawTransitionMessage
+; void NotifyPlayerAdded(int32, ULocalPlayer*)
+NotifyPlayerAdded
+; void PeekTravelFailureMessages(UWorld*, ETravelFailure::Type, const FString&)
+PeekTravelFailureMessages
+; void PeekNetworkFailureMessages(UWorld*, UNetDriver*, ENetworkFailure::Type, const FString&)
+PeekNetworkFailureMessages
+; void VerifyPathRenderingComponents()
+VerifyPathRenderingComponents
+
+[FMalloc]
+; void* __vecDelDtor(uint32)
+__vecDelDtor
+; void InitializeStatsMetadata()
+InitializeStatsMetadata
+; void* Malloc(uint64, uint32)
+Malloc
+; void* Realloc(void*, uint64, uint32)
+Realloc
+; void Free(void*)
+Free
+; void UpdateStats()
+UpdateStats
+; void GetAllocatorStats(FGenericMemoryStats&)
+GetAllocatorStats
+; void DumpAllocatorStats(FOutputDevice&)
+DumpAllocatorStats
+; bool IsInternallyThreadSafe() const
+IsInternallyThreadSafe
+; bool ValidateHeap()
+ValidateHeap
+; bool GetAllocationSize(void*, uint64&)
+GetAllocationSize
+; const wchar_t* GetDescriptiveName()
+GetDescriptiveName
+
+[FArchive]
+; void* __vecDelDtor(uint32)
+__vecDelDtor
+; FArchive& operator<<(FStringAssetReference&)
+operator<<__Ref_FStringAssetReference
+; FArchive& operator<<(FAssetPtr&)
+operator<<__Ref_FAssetPtr
+; FArchive& operator<<(FLazyObjectPtr&)
+operator<<__Ref_FLazyObjectPtr
+; FArchive& operator<<(UObject*&)
+operator<<__Ptr_Ref_UObject
+; FArchive& operator<<(FName&)
+operator<<__Ref_FName
+; void Serialize(void*, int64)
+Serialize
+; void SerializeBits(void*, int64)
+SerializeBits
+; void SerializeInt(uint32&, uint32)
+SerializeInt
+; void SerializeIntPacked(uint32&)
+SerializeIntPacked
+; void Preload(UObject*)
+Preload
+; void CountBytes(uint64, uint64)
+CountBytes
+; FString GetArchiveName() const
+GetArchiveName
+; ULinker* GetLinker()
+GetLinker
+; int64 Tell()
+Tell
+; int64 TotalSize()
+TotalSize
+; bool AtEnd()
+AtEnd
+; void Seek(int64)
+Seek
+; void AttachBulkData(UObject*, FUntypedBulkData*)
+AttachBulkData
+; void DetachBulkData(FUntypedBulkData*, bool)
+DetachBulkData
+; bool Precache(int64, int64)
+Precache
+; void FlushCache()
+FlushCache
+; bool SetCompressionMap(TArray<FCompressedChunk,FDefaultAllocator>*, ECompressionFlags)
+SetCompressionMap
+; void Flush()
+Flush
+; bool Close()
+Close
+; bool GetError()
+GetError
+; void MarkScriptSerializationStart(const UObject*)
+MarkScriptSerializationStart
+; void MarkScriptSerializationEnd(const UObject*)
+MarkScriptSerializationEnd
+; void IndicateSerializationMismatch()
+IndicateSerializationMismatch
+; bool IsCloseComplete(bool&)
+IsCloseComplete
+; bool IsFilterEditorOnly()
+IsFilterEditorOnly
+; void SetFilterEditorOnly(bool)
+SetFilterEditorOnly
+; bool IsSaveGame()
+IsSaveGame
+; bool UseToResolveEnumerators() const
+UseToResolveEnumerators
+; bool ShouldSkipProperty(const UProperty*) const
+ShouldSkipProperty
+
+[AGameMode]
+; void* __vecDelDtor(uint32)
+__vecDelDtor
+; bool HasMatchStarted() const
+HasMatchStarted
+; bool IsMatchInProgress() const
+IsMatchInProgress
+; bool HasMatchEnded() const
+HasMatchEnded
+; void StartPlay()
+StartPlay
+; void PostSeamlessTravel()
+PostSeamlessTravel
+; void StartMatch()
+StartMatch
+; void EndMatch()
+EndMatch
+; void StartToLeaveMap()
+StartToLeaveMap
+; void RestartGame()
+RestartGame
+; void ReturnToMainMenuHost()
+ReturnToMainMenuHost
+; void AbortMatch()
+AbortMatch
+; void SetMatchState(FName)
+SetMatchState
+; void HandleMatchIsWaitingToStart()
+HandleMatchIsWaitingToStart
+; bool ReadyToStartMatch()
+ReadyToStartMatch
+; void HandleMatchHasStarted()
+HandleMatchHasStarted
+; bool ReadyToEndMatch()
+ReadyToEndMatch
+; void HandleMatchHasEnded()
+HandleMatchHasEnded
+; void HandleLeavingMap()
+HandleLeavingMap
+; void HandleMatchAborted()
+HandleMatchAborted
+; void SetBandwidthLimit(float)
+SetBandwidthLimit
+; bool ShouldReset(AActor*)
+ShouldReset
+; void ResetLevel()
+ResetLevel
+; void InitGame(const FString&, const FString&, FString&)
+InitGame
+; void InitGameState()
+InitGameState
+; FString GetNetworkNumber()
+GetNetworkNumber
+; int32 GetNumPlayers()
+GetNumPlayers
+; bool SetPause(APlayerController*, TBaseDelegate<bool>)
+SetPause
+; void ClearPause()
+ClearPause
+; FString GetDefaultGameClassPath(const FString&, const FString&, const FString&) const
+GetDefaultGameClassPath
+; TSubclassOf<AGameMode> GetGameModeClass(const FString&, const FString&, const FString&) const
+GetGameModeClass
+; TSubclassOf<AGameSession> GetGameSessionClass() const
+GetGameSessionClass
+; void NotifyPendingConnectionLost()
+NotifyPendingConnectionLost
+; bool GetTravelType()
+GetTravelType
+; void ProcessServerTravel(const FString&, bool)
+ProcessServerTravel
+; APlayerController* ProcessClientTravel(FString&, FGuid, bool, bool)
+ProcessClientTravel
+; void PreLogin(const FString&, const FString&, const TSharedPtr<FUniqueNetId,0>&, FString&)
+PreLogin
+; APlayerController* Login(UPlayer*, const FString&, const FString&, const TSharedPtr<FUniqueNetId,0>&, FString&)
+Login
+; void PostLogin(APlayerController*)
+PostLogin
+; void K2_PostLogin(APlayerController*)
+K2_PostLogin
+; APlayerController* SpawnPlayerController(const FVector&, const FRotator&)
+SpawnPlayerController
+; bool MustSpectate(APlayerController*) const
+MustSpectate
+; UClass* GetDefaultPawnClassForController(AController*)
+GetDefaultPawnClassForController
+; void InitStartSpot(AActor*, AController*)
+InitStartSpot
+; void AddPlayerStart(APlayerStart*)
+AddPlayerStart
+; void RemovePlayerStart(APlayerStart*)
+RemovePlayerStart
+; APawn* SpawnDefaultPawnFor(AController*, AActor*)
+SpawnDefaultPawnFor
+; void ReplicateStreamingStatus(APlayerController*)
+ReplicateStreamingStatus
+; void GenericPlayerInitialization(AController*)
+GenericPlayerInitialization
+; void StartNewPlayer(APlayerController*)
+StartNewPlayer
+; void Logout(AController*)
+Logout
+; void SetPlayerDefaults(APawn*)
+SetPlayerDefaults
+; bool CanSpectate(APlayerController*, APlayerState*)
+CanSpectate
+; void ChangeName(AController*, const FString&, bool)
+ChangeName
+; void SendPlayer(APlayerController*, const FString&)
+SendPlayer
+; void Broadcast(AActor*, const FString&, FName)
+Broadcast
+; void BroadcastLocalized(AActor*, TSubclassOf<ULocalMessage>, int32, APlayerState*, APlayerState*, UObject*)
+BroadcastLocalized
+; bool ShouldSpawnAtStartSpot(AController*)
+ShouldSpawnAtStartSpot
+; AActor* FindPlayerStart(AController*, const FString&)
+FindPlayerStart
+; AActor* ChoosePlayerStart(AController*)
+ChoosePlayerStart
+; bool PlayerCanRestart(APlayerController*)
+PlayerCanRestart
+; void UpdateGameplayMuteList(APlayerController*)
+UpdateGameplayMuteList
+; bool AllowCheats(APlayerController*)
+AllowCheats
+; bool AllowPausing(APlayerController*)
+AllowPausing
+; void PreCommitMapChange(const FString&, const FString&)
+PreCommitMapChange
+; void PostCommitMapChange()
+PostCommitMapChange
+; void AddInactivePlayer(APlayerState*, APlayerController*)
+AddInactivePlayer
+; bool FindInactivePlayer(APlayerController*)
+FindInactivePlayer
+; void OverridePlayerState(APlayerController*, APlayerState*)
+OverridePlayerState
+; void GetSeamlessTravelActorList(bool, TArray<AActor *,FDefaultAllocator>&)
+GetSeamlessTravelActorList
+; FString GetRedirectURL(const FString&) const
+GetRedirectURL
+; void SwapPlayerControllers(APlayerController*, APlayerController*)
+SwapPlayerControllers
+; void HandleSeamlessTravelPlayer(AController*&)
+HandleSeamlessTravelPlayer
+; void SetSeamlessTravelViewTarget(APlayerController*)
+SetSeamlessTravelViewTarget
+; void MatineeCancelled()
+MatineeCancelled
+; void RestartPlayer(AController*)
+RestartPlayer
+; void DefaultTimer()
+DefaultTimer
+; FString InitNewPlayer(APlayerController*, const TSharedPtr<FUniqueNetId,0>&, const FString&, const FString&)
+InitNewPlayer
+
+[AActor]
+; void* __vecDelDtor(uint32)
+__vecDelDtor
+; bool HasNetOwner() const
+HasNetOwner
+; void OnRep_AttachmentReplication()
+OnRep_AttachmentReplication
+; bool ReplicateSubobjects(UActorChannel*, FOutBunch*, FReplicationFlags*)
+ReplicateSubobjects
+; void OnSubobjectCreatedFromReplication(UObject*)
+OnSubobjectCreatedFromReplication
+; void OnSubobjectDestroyFromReplication(UObject*)
+OnSubobjectDestroyFromReplication
+; void PreReplication(IRepChangedPropertyTracker&)
+PreReplication
+; void OnRep_Instigator()
+OnRep_Instigator
+; void EnableInput(APlayerController*)
+EnableInput
+; void DisableInput(APlayerController*)
+DisableInput
+; FVector GetVelocity() const
+GetVelocity
+; void SetActorHiddenInGame(bool)
+SetActorHiddenInGame
+; void K2_DestroyActor()
+K2_DestroyActor
+; void AddTickPrerequisiteActor(AActor*)
+AddTickPrerequisiteActor
+; void AddTickPrerequisiteComponent(UActorComponent*)
+AddTickPrerequisiteComponent
+; void RemoveTickPrerequisiteActor(AActor*)
+RemoveTickPrerequisiteActor
+; void RemoveTickPrerequisiteComponent(UActorComponent*)
+RemoveTickPrerequisiteComponent
+; void ReceiveBeginPlay()
+ReceiveBeginPlay
+; void BeginPlay()
+BeginPlay
+; void ReceiveAnyDamage(float, const UDamageType*, AController*, AActor*)
+ReceiveAnyDamage
+; void ReceiveRadialDamage(float, const UDamageType*, FVector, const FHitResult&, AController*, AActor*)
+ReceiveRadialDamage
+; void ReceivePointDamage(float, const UDamageType*, FVector, FVector, UPrimitiveComponent*, FName, FVector, AController*, AActor*)
+ReceivePointDamage
+; void ReceiveTick(float)
+ReceiveTick
+; void ReceiveActorBeginOverlap(AActor*)
+ReceiveActorBeginOverlap
+; void ReceiveActorEndOverlap(AActor*)
+ReceiveActorEndOverlap
+; void ReceiveActorBeginCursorOver()
+ReceiveActorBeginCursorOver
+; void ReceiveActorEndCursorOver()
+ReceiveActorEndCursorOver
+; void ReceiveActorOnClicked()
+ReceiveActorOnClicked
+; void ReceiveActorOnReleased()
+ReceiveActorOnReleased
+; void ReceiveActorOnInputTouchBegin(const ETouchIndex::Type)
+ReceiveActorOnInputTouchBegin
+; void ReceiveActorOnInputTouchEnd(const ETouchIndex::Type)
+ReceiveActorOnInputTouchEnd
+; void ReceiveActorOnInputTouchEnter(const ETouchIndex::Type)
+ReceiveActorOnInputTouchEnter
+; void ReceiveActorOnInputTouchLeave(const ETouchIndex::Type)
+ReceiveActorOnInputTouchLeave
+; void ReceiveInput(const FString&, float, FVector, bool, bool)
+ReceiveInput
+; void ReceiveHit(UPrimitiveComponent*, AActor*, UPrimitiveComponent*, bool, FVector, FVector, FVector, const FHitResult&)
+ReceiveHit
+; void SetLifeSpan(float)
+SetLifeSpan
+; float GetLifeSpan() const
+GetLifeSpan
+; void UserConstructionScript()
+UserConstructionScript
+; void ReceiveDestroyed()
+ReceiveDestroyed
+; void ReceiveEndPlay(EEndPlayReason::Type)
+ReceiveEndPlay
+; void GatherCurrentMovement()
+GatherCurrentMovement
+; void ApplyWorldOffset(const FVector&, bool)
+ApplyWorldOffset
+; bool IsLevelBoundsRelevant() const
+IsLevelBoundsRelevant
+; float GetNetPriority(const FVector&, const FVector&, APlayerController*, UActorChannel*, float, bool)
+GetNetPriority
+; bool GetNetDormancy(const FVector&, const FVector&, APlayerController*, UActorChannel*, float, bool)
+GetNetDormancy
+; void OnActorChannelOpen(FInBunch&, UNetConnection*)
+OnActorChannelOpen
+; void OnSerializeNewActor(FOutBunch&)
+OnSerializeNewActor
+; void OnNetCleanup(UNetConnection*)
+OnNetCleanup
+; void TickActor(float, ELevelTick, FActorTickFunction&)
+TickActor
+; void PostActorCreated()
+PostActorCreated
+; void LifeSpanExpired()
+LifeSpanExpired
+; void PostNetInit()
+PostNetInit
+; void OnRep_ReplicatedMovement()
+OnRep_ReplicatedMovement
+; void PostNetReceiveLocation()
+PostNetReceiveLocation
+; void PostNetReceiveLocationAndRotation()
+PostNetReceiveLocationAndRotation
+; void PostNetReceiveVelocity(const FVector&)
+PostNetReceiveVelocity
+; void PostNetReceivePhysicState()
+PostNetReceivePhysicState
+; bool CheckStillInWorld()
+CheckStillInWorld
+; void Tick(float)
+Tick
+; bool ShouldTickIfViewportsOnly() const
+ShouldTickIfViewportsOnly
+; bool IsNetRelevantFor(const APlayerController*, const AActor*, const FVector&) const
+IsNetRelevantFor
+; bool IsRelevancyOwnerFor(AActor*, AActor*, AActor*)
+IsRelevancyOwnerFor
+; void PreInitializeComponents()
+PreInitializeComponents
+; void PostInitializeComponents()
+PostInitializeComponents
+; UPlayer* GetNetOwningPlayer()
+GetNetOwningPlayer
+; UNetConnection* GetNetConnection()
+GetNetConnection
+; void RegisterAllComponents()
+RegisterAllComponents
+; void PostRegisterAllComponents()
+PostRegisterAllComponents
+; void UnregisterAllComponents()
+UnregisterAllComponents
+; void PostUnregisterAllComponents()
+PostUnregisterAllComponents
+; void ReregisterAllComponents()
+ReregisterAllComponents
+; void MarkComponentsAsPendingKill()
+MarkComponentsAsPendingKill
+; void InvalidateLightingCacheDetailed(bool)
+InvalidateLightingCacheDetailed
+; bool TeleportTo(const FVector&, const FRotator&, bool, bool)
+TeleportTo
+; void TeleportSucceeded(bool)
+TeleportSucceeded
+; void ClearCrossLevelReferences()
+ClearCrossLevelReferences
+; void EndPlay(const EEndPlayReason::Type)
+EndPlay
+; bool IsBasedOnActor(const AActor*) const
+IsBasedOnActor
+; bool IsAttachedTo(const AActor*) const
+IsAttachedTo
+; void RerunConstructionScripts()
+RerunConstructionScripts
+; void OnConstruction(const FTransform&)
+OnConstruction
+; void RegisterActorTickFunctions(bool)
+RegisterActorTickFunctions
+; AActor* GetAttachParentActor() const
+GetAttachParentActor
+; FName GetAttachParentSocketName() const
+GetAttachParentSocketName
+; void GetAttachedActors(TArray<AActor *,FDefaultAllocator>&) const
+GetAttachedActors
+; void Destroyed()
+Destroyed
+; void FellOutOfWorld(const UDamageType&)
+FellOutOfWorld
+; void OutsideWorldBounds()
+OutsideWorldBounds
+; FBox GetComponentsBoundingBox(bool) const
+GetComponentsBoundingBox
+; void GetComponentsBoundingCylinder(float&, float&, bool) const
+GetComponentsBoundingCylinder
+; void GetSimpleCollisionCylinder(float&, float&) const
+GetSimpleCollisionCylinder
+; bool IsRootComponentCollisionRegistered() const
+IsRootComponentCollisionRegistered
+; void TornOff()
+TornOff
+; ECollisionResponse GetComponentsCollisionResponseToChannel(ECollisionChannel) const
+GetComponentsCollisionResponseToChannel
+; bool CanBeBaseForCharacter(APawn*) const
+CanBeBaseForCharacter
+; float TakeDamage(float, const FDamageEvent&, AController*, AActor*)
+TakeDamage
+; float InternalTakeRadialDamage(float, const FRadialDamageEvent&, AController*, AActor*)
+InternalTakeRadialDamage
+; float InternalTakePointDamage(float, const FPointDamageEvent&, AController*, AActor*)
+InternalTakePointDamage
+; void BecomeViewTarget(APlayerController*)
+BecomeViewTarget
+; void EndViewTarget(APlayerController*)
+EndViewTarget
+; void K2_OnBecomeViewTarget(APlayerController*)
+K2_OnBecomeViewTarget
+; void K2_OnEndViewTarget(APlayerController*)
+K2_OnEndViewTarget
+; void CalcCamera(float, FMinimalViewInfo&)
+CalcCamera
+; FString GetHumanReadableName() const
+GetHumanReadableName
+; void Reset()
+Reset
+; float GetLastRenderTime() const
+GetLastRenderTime
+; void ForceNetRelevant()
+ForceNetRelevant
+; void ForceNetUpdate()
+ForceNetUpdate
+; void PrestreamTextures(float, bool, int32)
+PrestreamTextures
+; void GetActorEyesViewPoint(FVector&, FRotator&) const
+GetActorEyesViewPoint
+; FVector GetTargetLocation(AActor*) const
+GetTargetLocation
+; void PostRenderFor(APlayerController*, UCanvas*, FVector, FVector)
+PostRenderFor
+; UActorComponent* FindComponentByClass(const TSubclassOf<UActorComponent>) const
+FindComponentByClass
+; UActorComponent* GetComponentByClass(TSubclassOf<UActorComponent>)
+GetComponentByClass
+; bool IsComponentRelevantForNavigation(UActorComponent*) const
+IsComponentRelevantForNavigation
+; void DisplayDebug(UCanvas*, const FDebugDisplayInfo&, float&, float&)
+DisplayDebug
+
+[UPlayer]
+; void* __vecDelDtor(uint32)
+__vecDelDtor
+; void SwitchController(APlayerController*)
+SwitchController
+; void HandleDisconnect(UWorld*, UNetDriver*)
+HandleDisconnect
+
+[UEngine]
+; void* __vecDelDtor(uint32)
+__vecDelDtor
+; void WorldAdded(UWorld*)
+WorldAdded
+; void WorldDestroyed(UWorld*)
+WorldDestroyed
+; bool IsInitialized() const
+IsInitialized
+; void Init(IEngineLoop*)
+Init
+; void PreExit()
+PreExit
+; void ShutdownAudioDevice()
+ShutdownAudioDevice
+; void Tick(float, bool)
+Tick
+; float GetMaxTickRate(float, bool) const
+GetMaxTickRate
+; void UpdateRunningAverageDeltaTime(float, bool)
+UpdateRunningAverageDeltaTime
+; void OnLostFocusPause(bool)
+OnLostFocusPause
+; bool ShouldThrottleCPUUsage() const
+ShouldThrottleCPUUsage
+; bool IsHardwareSurveyRequired()
+IsHardwareSurveyRequired
+; void OnHardwareSurveyComplete(const FHardwareSurveyResults&)
+OnHardwareSurveyComplete
+; bool ShouldDrawBrushWireframe(AActor*)
+ShouldDrawBrushWireframe
+; bool GetMapBuildCancelled() const
+GetMapBuildCancelled
+; void SetMapBuildCancelled(bool)
+SetMapBuildCancelled
+; bool GetPropertyColorationColor(UObject*, FColor&)
+GetPropertyColorationColor
+; bool AllowSelectTranslucent() const
+AllowSelectTranslucent
+; bool OnlyLoadEditorVisibleLevelsInPIE() const
+OnlyLoadEditorVisibleLevelsInPIE
+; int32 GetSpriteCategoryIndex(const FName&)
+GetSpriteCategoryIndex
+; void TickFPSChart(float)
+TickFPSChart
+; void StartFPSChart()
+StartFPSChart
+; void StopFPSChart()
+StopFPSChart
+; void DumpFPSChart(const FString&, bool)
+DumpFPSChart
+; void DumpFPSChartToHTML(float, float, int32, const FString&)
+DumpFPSChartToHTML
+; void DumpFPSChartToLog(float, float, int32, const FString&)
+DumpFPSChartToLog
+; void DumpFPSChartToStatsLog(float, float, int32, const FString&)
+DumpFPSChartToStatsLog
+; void DumpFrameTimesToStatsLog(float, float, int32, const FString&)
+DumpFrameTimesToStatsLog
+; void ProcessToggleFreezeCommand(UWorld*)
+ProcessToggleFreezeCommand
+; void ProcessToggleFreezeStreamingCommand(UWorld*)
+ProcessToggleFreezeStreamingCommand
+; FAudioDevice* GetAudioDevice()
+GetAudioDevice
+; bool IsSettingUpPlayWorld() const
+IsSettingUpPlayWorld
+; TSharedPtr<SViewport,0> GetGameViewportWidget() const
+GetGameViewportWidget
+; void FocusNextPIEWorld(UWorld*, bool)
+FocusNextPIEWorld
+; UGameViewportClient* GetNextPIEViewport(UGameViewportClient*)
+GetNextPIEViewport
+; void RemapGamepadControllerIdForPIE(UGameViewportClient*, int32&)
+RemapGamepadControllerIdForPIE
+; void NotifyToolsOfObjectReplacement(const TMap<UObject *, UObject *>&)
+NotifyToolsOfObjectReplacement
+; bool UseSound() const
+UseSound
+; UWorld* CreatePIEWorldByDuplication(FWorldContext&, UWorld*, FString&)
+CreatePIEWorldByDuplication
+; bool InitializeAudioDevice()
+InitializeAudioDevice
+; bool InitializeHMDDevice()
+InitializeHMDDevice
+; void RecordHMDAnalytics()
+RecordHMDAnalytics
+; void InitializeObjectReferences()
+InitializeObjectReferences
+; void InitializeRunningAverageDeltaTime()
+InitializeRunningAverageDeltaTime
+; void SpawnServerActors(UWorld*)
+SpawnServerActors
+; void HandleNetworkFailure(UWorld*, UNetDriver*, ENetworkFailure::Type, const FString&)
+HandleNetworkFailure
+; void HandleTravelFailure(UWorld*, ETravelFailure::Type, const FString&)
+HandleTravelFailure
+; bool NetworkRemapPath(UPendingNetGame*, FString&, bool)
+NetworkRemapPath__Ptr_UPendingNetGame__Ref_FString__bool
+; bool NetworkRemapPath(UWorld*, FString&, bool)
+NetworkRemapPath__Ptr_UWorld__Ref_FString__bool
+; bool HandleOpenCommand(const wchar_t*, FOutputDevice&, UWorld*)
+HandleOpenCommand
+; bool HandleTravelCommand(const wchar_t*, FOutputDevice&, UWorld*)
+HandleTravelCommand
+; bool HandleStreamMapCommand(const wchar_t*, FOutputDevice&, UWorld*)
+HandleStreamMapCommand
+; bool HandleServerTravelCommand(const wchar_t*, FOutputDevice&, UWorld*)
+HandleServerTravelCommand
+; bool HandleSayCommand(const wchar_t*, FOutputDevice&, UWorld*)
+HandleSayCommand
+; bool HandleDisconnectCommand(const wchar_t*, FOutputDevice&, UWorld*)
+HandleDisconnectCommand
+; bool HandleReconnectCommand(const wchar_t*, FOutputDevice&, UWorld*)
+HandleReconnectCommand
+; EBrowseReturnVal::Type Browse(FWorldContext&, FURL, FString&)
+Browse
+; bool LoadMap(FWorldContext&, FURL, UPendingNetGame*, FString&)
+LoadMap
+; void RedrawViewports(bool)
+RedrawViewports
+; void TriggerStreamingDataRebuild()
+TriggerStreamingDataRebuild
+; void LoadMapRedrawViewports()
+LoadMapRedrawViewports
+; void CancelAllPending()
+CancelAllPending
+; void CancelPending(UNetDriver*)
+CancelPending__Ptr_UNetDriver
+; void CancelPending(FWorldContext&)
+CancelPending__Ref_FWorldContext
+; void CancelPending(UWorld*, UPendingNetGame*)
+CancelPending__Ptr_UWorld__Ptr_UPendingNetGame
+; bool WorldIsPIEInNewViewport(UWorld*)
+WorldIsPIEInNewViewport
+; void VerifyLoadMapWorldCleanup()
+VerifyLoadMapWorldCleanup
+; void DestroyWorldContext(UWorld*)
+DestroyWorldContext
+; bool AreEditorAnalyticsEnabled() const
+AreEditorAnalyticsEnabled
+; void CreateStartupAnalyticsAttributes(TArray<FAnalyticsEventAttribute,FDefaultAllocator>&) const
+CreateStartupAnalyticsAttributes
+; void MovePendingLevel(FWorldContext&)
+MovePendingLevel
+; void HandleNetworkFailure_NotifyGameInstance(UWorld*, UNetDriver*, ENetworkFailure::Type)
+HandleNetworkFailure_NotifyGameInstance
+; void HandleTravelFailure_NotifyGameInstance(UWorld*, ETravelFailure::Type)
+HandleTravelFailure_NotifyGameInstance
+
+[ULocalPlayer]
+; void* __vecDelDtor(uint32)
+__vecDelDtor
+; TSubclassOf<UOnlineSession> GetOnlineSessionClass()
+GetOnlineSessionClass
+; void PlayerAdded(UGameViewportClient*, int32)
+PlayerAdded
+; void InitOnlineSession()
+InitOnlineSession
+; void PlayerRemoved()
+PlayerRemoved
+; bool SpawnPlayActor(const FString&, FString&, UWorld*)
+SpawnPlayActor
+; void SendSplitJoin()
+SendSplitJoin
+; void SetControllerId(int32)
+SetControllerId
+; FString GetNickname() const
+GetNickname
+; FString GetGameLoginOptions() const
+GetGameLoginOptions
+
+[UField]
+; void* __vecDelDtor(uint32)
+__vecDelDtor
+; void AddCppProperty(UProperty*)
+AddCppProperty
+; void Bind()
+Bind
+
+[FProperty]
+; void* __vecDelDtor(uint32)
+__vecDelDtor
+; FString GetCPPMacroType(FString&) const
+GetCPPMacroType
+; bool PassCPPArgsByRef() const
+PassCPPArgsByRef
+; FString GetCPPType(FString*, uint32) const
+GetCPPType
+; FString GetCPPTypeForwardDeclaration() const
+GetCPPTypeForwardDeclaration
+; void LinkInternal(FArchive&)
+LinkInternal
+; bool Identical(const void*, const void*, uint32) const
+Identical
+; void SerializeItem(FArchive&, void*, int32, const void*) const
+SerializeItem
+; bool NetSerializeItem(FArchive&, UPackageMap*, void*, TArray<unsigned char,FDefaultAllocator>*) const
+NetSerializeItem
+; void ExportTextItem(FString&, const void*, const void*, UObject*, int32, UObject*) const
+ExportTextItem
+; const wchar_t* ImportText_Internal(const wchar_t*, void*, int32, UObject*, FOutputDevice*) const
+ImportText_Internal
+; void CopyValuesInternal(void*, const void*, int32) const
+CopyValuesInternal
+; void CopySingleValueToScriptVM(void*, const void*) const
+CopySingleValueToScriptVM
+; void CopyCompleteValueToScriptVM(void*, const void*) const
+CopyCompleteValueToScriptVM
+; void CopySingleValueFromScriptVM(void*, const void*) const
+CopySingleValueFromScriptVM
+; void CopyCompleteValueFromScriptVM(void*, const void*) const
+CopyCompleteValueFromScriptVM
+; void ClearValueInternal(void*) const
+ClearValueInternal
+; void DestroyValueInternal(void*) const
+DestroyValueInternal
+; void InitializeValueInternal(void*) const
+InitializeValueInternal
+; FName GetID() const
+GetID
+; bool IsLocalized() const
+IsLocalized
+; void InstanceSubobjects(void*, const void*, UObject*, FObjectInstancingGraph*)
+InstanceSubobjects
+; int32 GetMinAlignment() const
+GetMinAlignment
+; bool ContainsObjectReference() const
+ContainsObjectReference
+; bool ContainsWeakObjectReference() const
+ContainsWeakObjectReference
+; void EmitReferenceInfo(UClass&, int32)
+EmitReferenceInfo
+; bool SameType(const UProperty*) const
+SameType
+
+[FNumericProperty]
+; void* __vecDelDtor(uint32)
+__vecDelDtor
+; bool IsFloatingPoint() const
+IsFloatingPoint
+; bool IsInteger() const
+IsInteger
+; UEnum* GetIntPropertyEnum() const
+GetIntPropertyEnum
+; void SetIntPropertyValue(void*, int64) const
+SetIntPropertyValue_C__Ptr_void__int64
+; void SetIntPropertyValue(void*, uint64) const
+SetIntPropertyValue_C__Ptr_void__uint64
+; void SetFloatingPointPropertyValue(void*, double) const
+SetFloatingPointPropertyValue
+; void SetNumericPropertyValueFromString(void*, const wchar_t*) const
+SetNumericPropertyValueFromString
+; int64 GetSignedIntPropertyValue(const void*) const
+GetSignedIntPropertyValue
+; uint64 GetUnsignedIntPropertyValue(const void*) const
+GetUnsignedIntPropertyValue
+; double GetFloatingPointPropertyValue(const void*) const
+GetFloatingPointPropertyValue
+; FString GetNumericPropertyValueToString(const void*) const
+GetNumericPropertyValueToString
+
+[FMulticastDelegateProperty]
+; void* __vecDelDtor(uint32)
+__vecDelDtor
+
+[FObjectPropertyBase]
+; void* __vecDelDtor(uint32)
+__vecDelDtor
+; UObject* GetObjectPropertyValue(const void*) const
+GetObjectPropertyValue
+; void SetObjectPropertyValue(void*, UObject*) const
+SetObjectPropertyValue
+; bool AllowCrossLevel() const
+AllowCrossLevel
+; void CheckValidObject(void*) const
+CheckValidObject
+
+[UDataTable]
+; void* __vecDelDtor(uint32)
+__vecDelDtor
+

--- a/assets/VTableLayoutTemplates/VTableLayout_4_08_Template.ini
+++ b/assets/VTableLayoutTemplates/VTableLayout_4_08_Template.ini
@@ -9,14 +9,6 @@ DeferredRegister
 [UObjectBaseUtility]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
-; bool CanBeClusterRoot() const
-CanBeClusterRoot
-; bool CanBeInCluster() const
-CanBeInCluster
-; void CreateCluster()
-CreateCluster
-; void OnClusterMarkedAsPendingKill()
-OnClusterMarkedAsPendingKill
 
 [UObject]
 ; void* __vecDelDtor(uint32)
@@ -25,16 +17,14 @@ __vecDelDtor
 GetDetailedInfoInternal
 ; void PostInitProperties()
 PostInitProperties
-; void PostCDOContruct()
-PostCDOContruct
-; bool PreSaveRoot(const wchar_t*)
+; bool PreSaveRoot(const wchar_t*, TArray<FString,FDefaultAllocator>&)
 PreSaveRoot
 ; void PostSaveRoot(bool)
 PostSaveRoot
-; void PreSave(const ITargetPlatform*)
+; void PreSave()
 PreSave
-; bool IsReadyForAsyncPostLoad() const
-IsReadyForAsyncPostLoad
+; bool Modify(bool)
+Modify
 ; void PostLoad()
 PostLoad
 ; void PostLoadSubobjects(FObjectInstancingGraph*)
@@ -45,81 +35,59 @@ BeginDestroy
 IsReadyForFinishDestroy
 ; void FinishDestroy()
 FinishDestroy
-; void Serialize(FStructuredArchiveRecord)
-Serialize__FStructuredArchiveRecord
 ; void Serialize(FArchive&)
-Serialize__Ref_FArchive
+Serialize
 ; void ShutdownAfterError()
 ShutdownAfterError
-; void PostInterpChange(FProperty*)
+; void PostInterpChange(UProperty*)
 PostInterpChange
 ; void PostRename(UObject*, const FName)
 PostRename
-; void PreDuplicate(FObjectDuplicationParameters&)
-PreDuplicate
-; void PostDuplicate(EDuplicateMode::Type)
-PostDuplicate__EDuplicateMode_Type
 ; void PostDuplicate(bool)
-PostDuplicate__bool
+PostDuplicate
 ; bool NeedsLoadForClient() const
 NeedsLoadForClient
 ; bool NeedsLoadForServer() const
 NeedsLoadForServer
-; bool NeedsLoadForTargetPlatform(const ITargetPlatform*) const
-NeedsLoadForTargetPlatform
 ; bool NeedsLoadForEditorGame() const
 NeedsLoadForEditorGame
-; bool IsEditorOnly() const
-IsEditorOnly
-; bool HasNonEditorOnlyReferences() const
-HasNonEditorOnlyReferences
 ; bool IsPostLoadThreadSafe() const
 IsPostLoadThreadSafe
-; bool IsDestructionThreadSafe() const
-IsDestructionThreadSafe
-; void GetPreloadDependencies(TArray<UObject *,TSizedDefaultAllocator<32> >&)
-GetPreloadDependencies
-; void GetPrestreamPackages(TArray<UObject *,TSizedDefaultAllocator<32> >&)
-GetPrestreamPackages
 ; void ExportCustomProperties(FOutputDevice&, uint32)
 ExportCustomProperties
 ; void ImportCustomProperties(const wchar_t*, FFeedbackContext*)
 ImportCustomProperties
 ; void PostEditImport()
 PostEditImport
-; void PostReloadConfig(FProperty*)
+; void PostReloadConfig(UProperty*)
 PostReloadConfig
 ; bool Rename(const wchar_t*, UObject*, uint32)
 Rename
 ; FString GetDesc()
 GetDesc
-; UScriptStruct* GetSparseClassDataStruct() const
-GetSparseClassDataStruct
 ; UWorld* GetWorld() const
 GetWorld
 ; bool GetNativePropertyValues(TMap<FString, FString>&, uint32) const
 GetNativePropertyValues
-; void GetResourceSizeEx(FResourceSizeEx&)
-GetResourceSizeEx
+; uint64 GetResourceSize(EResourceSizeMode::Type)
+GetResourceSize
 ; FName GetExporterName()
 GetExporterName
+; bool IsLocalizedResource()
+IsLocalizedResource
 ; FRestoreForUObjectOverwrite* GetRestoreForUObjectOverwrite()
 GetRestoreForUObjectOverwrite
 ; bool AreNativePropertiesIdenticalTo(UObject*) const
 AreNativePropertiesIdenticalTo
-; void GetAssetRegistryTags(TArray<UObject::FAssetRegistryTag,TSizedDefaultAllocator<32> >&) const
-GetAssetRegistryTags_C__Ref_TArray_UObject_FAssetRegistryTag_FDefaultAllocator_
+; void GetAssetRegistryTags(TArray<UObject::FAssetRegistryTag,FDefaultAllocator>&) const
+GetAssetRegistryTags
 ; bool IsAsset() const
 IsAsset
-; FPrimaryAssetId GetPrimaryAssetId() const
-GetPrimaryAssetId
-; bool IsLocalizedResource() const
-IsLocalizedResource
 ; bool IsSafeForRootSet() const
 IsSafeForRootSet
 ; void TagSubobjects(EObjectFlags)
 TagSubobjects
-; void GetLifetimeReplicatedProps(TArray<FLifetimeProperty,TSizedDefaultAllocator<32> >&) const
+; void GetLifetimeReplicatedProps(TArray<FLifetimeProperty,FDefaultAllocator>&) const
 GetLifetimeReplicatedProps
 ; bool IsNameStableForNetworking() const
 IsNameStableForNetworking
@@ -127,42 +95,26 @@ IsNameStableForNetworking
 IsFullNameStableForNetworking
 ; bool IsSupportedForNetworking() const
 IsSupportedForNetworking
-; void GetSubobjectsWithStableNamesForNetworking(TArray<UObject *,TSizedDefaultAllocator<32> >&)
+; void GetSubobjectsWithStableNamesForNetworking(TArray<UObject *,FDefaultAllocator>&)
 GetSubobjectsWithStableNamesForNetworking
 ; void PreNetReceive()
 PreNetReceive
 ; void PostNetReceive()
 PostNetReceive
-; void PostRepNotifies()
-PostRepNotifies
-; void PreDestroyFromReplication()
-PreDestroyFromReplication
-; void BuildSubobjectMapping(UObject*, TMap<UObject *, UObject *>&) const
-BuildSubobjectMapping
-; const wchar_t* GetConfigOverridePlatform() const
-GetConfigOverridePlatform
-; void OverridePerObjectConfigSection(FString&)
-OverridePerObjectConfigSection
 ; void ProcessEvent(UFunction*, void*)
 ProcessEvent
-; int32 GetFunctionCallspace(UFunction*, FFrame*)
+; int32 GetFunctionCallspace(UFunction*, void*, FFrame*)
 GetFunctionCallspace
 ; bool CallRemoteFunction(UFunction*, void*, FOutParmRec*, FFrame*)
 CallRemoteFunction
 ; bool ProcessConsoleExec(const wchar_t*, FOutputDevice&, UObject*)
 ProcessConsoleExec
-; UClass* RegenerateClass(UClass*, UObject*)
+; UClass* RegenerateClass(UClass*, UObject*, TArray<UObject *,FDefaultAllocator>&)
 RegenerateClass
 ; void MarkAsEditorOnlySubobject()
 MarkAsEditorOnlySubobject
-; bool CheckDefaultSubobjectsInternal() const
+; bool CheckDefaultSubobjectsInternal()
 CheckDefaultSubobjectsInternal
-; void ValidateGeneratedRepEnums(const TArray<FRepRecord,TSizedDefaultAllocator<32> >&) const
-ValidateGeneratedRepEnums
-; void SetNetPushIdDynamic(const int32)
-SetNetPushIdDynamic
-; int32 GetNetPushIdDynamic() const
-GetNetPushIdDynamic
 
 [UScriptStruct::ICppStructOps]
 ; void* __vecDelDtor(uint32)
@@ -173,38 +125,26 @@ HasNoopConstructor
 HasZeroConstructor
 ; void Construct(void*)
 Construct
-; void ConstructForTests(void*)
-ConstructForTests
 ; bool HasDestructor()
 HasDestructor
 ; void Destruct(void*)
 Destruct
 ; bool HasSerializer()
 HasSerializer
-; bool HasStructuredSerializer()
-HasStructuredSerializer
-; bool Serialize(FStructuredArchiveSlot, void*)
-Serialize__FStructuredArchiveSlot__Ptr_void
 ; bool Serialize(FArchive&, void*)
-Serialize__Ref_FArchive__Ptr_void
+Serialize
 ; bool HasPostSerialize()
 HasPostSerialize
 ; void PostSerialize(const FArchive&, void*)
 PostSerialize
 ; bool HasNetSerializer()
 HasNetSerializer
-; bool HasNetSharedSerialization()
-HasNetSharedSerialization
 ; bool NetSerialize(FArchive&, UPackageMap*, bool&, void*)
 NetSerialize
 ; bool HasNetDeltaSerializer()
 HasNetDeltaSerializer
 ; bool NetDeltaSerialize(FNetDeltaSerializeInfo&, void*)
 NetDeltaSerialize
-; bool HasPostScriptConstruct()
-HasPostScriptConstruct
-; void PostScriptConstruct(void*)
-PostScriptConstruct
 ; bool IsPlainOldData()
 IsPlainOldData
 ; bool HasCopy()
@@ -225,44 +165,24 @@ HasImportTextItem
 ImportTextItem
 ; bool HasAddStructReferencedObjects()
 HasAddStructReferencedObjects
-; std::function<void(void*, void*)>* AddStructReferencedObjects()
+; std::function<void(const void*, void*)>* AddStructReferencedObjects()
 AddStructReferencedObjects
 ; bool HasSerializeFromMismatchedTag()
 HasSerializeFromMismatchedTag
-; bool HasStructuredSerializeFromMismatchedTag()
-HasStructuredSerializeFromMismatchedTag
 ; bool SerializeFromMismatchedTag(const FPropertyTag&, FArchive&, void*)
 SerializeFromMismatchedTag
-; bool StructuredSerializeFromMismatchedTag(const FPropertyTag&, FStructuredArchiveSlot, void*)
-StructuredSerializeFromMismatchedTag
-; bool HasGetTypeHash()
-HasGetTypeHash
-; uint32 GetStructTypeHash(const void*)
-GetStructTypeHash
-; EPropertyFlags GetComputedPropertyFlags() const
-GetComputedPropertyFlags
-; bool IsAbstract() const
-IsAbstract
 
 [FOutputDevice]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
-; void Serialize(const wchar_t*, ELogVerbosity::Type, const FName&, const double)
-Serialize__Ptr_C_wchar_t__ELogVerbosity_Type__Ref_C_FName__C_double
 ; void Serialize(const wchar_t*, ELogVerbosity::Type, const FName&)
-Serialize__Ptr_C_wchar_t__ELogVerbosity_Type__Ref_C_FName
+Serialize
 ; void Flush()
 Flush
 ; void TearDown()
 TearDown
-; void Dump(FArchive&)
-Dump
-; bool IsMemoryOnly() const
-IsMemoryOnly
 ; bool CanBeUsedOnAnyThread() const
 CanBeUsedOnAnyThread
-; bool CanBeUsedOnMultipleThreads() const
-CanBeUsedOnMultipleThreads
 
 [UStruct]
 ; void* __vecDelDtor(uint32)
@@ -271,40 +191,24 @@ __vecDelDtor
 GetInheritanceSuper
 ; void Link(FArchive&, bool)
 Link
-; void SerializeBin(FStructuredArchiveSlot, void*) const
-SerializeBin_C__FStructuredArchiveSlot__Ptr_void
 ; void SerializeBin(FArchive&, void*) const
-SerializeBin_C__Ref_FArchive__Ptr_void
-; void SerializeTaggedProperties(FStructuredArchiveSlot, uint8*, UStruct*, uint8*, const UObject*) const
-SerializeTaggedProperties_C__FStructuredArchiveSlot__Ptr_uint8__Ptr_UStruct__Ptr_uint8__Ptr_C_UObject
+SerializeBin
 ; void SerializeTaggedProperties(FArchive&, uint8*, UStruct*, uint8*, const UObject*) const
-SerializeTaggedProperties_C__Ref_FArchive__Ptr_uint8__Ptr_UStruct__Ptr_uint8__Ptr_C_UObject
+SerializeTaggedProperties
 ; void InitializeStruct(void*, int32) const
 InitializeStruct
 ; void DestroyStruct(void*, int32) const
 DestroyStruct
-; FProperty* CustomFindProperty(const FName) const
-CustomFindProperty
 ; EExprToken SerializeExpr(int32&, FArchive&)
 SerializeExpr
 ; const wchar_t* GetPrefixCPP() const
 GetPrefixCPP
 ; void SetSuperStruct(UStruct*)
 SetSuperStruct
+; void SerializeSuperStruct(FArchive&)
+SerializeSuperStruct
 ; FString PropertyNameToDisplayName(FName) const
 PropertyNameToDisplayName
-; FString GetAuthoredNameForField(const FField*) const
-GetAuthoredNameForField_C__Ptr_C_FField
-; FString GetAuthoredNameForField(const UField*) const
-GetAuthoredNameForField_C__Ptr_C_UField
-; bool IsStructTrashed() const
-IsStructTrashed
-; FName FindPropertyNameFromGuid(const FGuid&) const
-FindPropertyNameFromGuid
-; FGuid FindPropertyGuidFromName(const FName) const
-FindPropertyGuidFromName
-; bool ArePropertyGuidsAvailable() const
-ArePropertyGuidsAvailable
 
 [UGameViewportClient]
 ; void* __vecDelDtor(uint32)
@@ -317,8 +221,6 @@ ShowTitleSafeArea
 SetConsoleTarget
 ; void Init(FWorldContext&, UGameInstance*, bool)
 Init
-; void FinalizeViews(FSceneViewFamily*, const TMap<ULocalPlayer *, FSceneView *>&)
-FinalizeViews
 ; void AddViewportWidgetContent(TSharedRef<SWidget,0>, const int32)
 AddViewportWidgetContent
 ; void RemoveViewportWidgetContent(TSharedRef<SWidget,0>)
@@ -339,10 +241,12 @@ SetViewport
 SetDropDetail
 ; FString ConsoleCommand(const FString&)
 ConsoleCommand
-; bool GetMousePosition(FVector2D&) const
-GetMousePosition
 ; ULocalPlayer* SetupInitialLocalPlayer(FString&)
 SetupInitialLocalPlayer
+; ULocalPlayer* CreatePlayer(int32, FString&, bool)
+CreatePlayer
+; bool RemovePlayer(ULocalPlayer*)
+RemovePlayer
 ; void UpdateActiveSplitscreenType()
 UpdateActiveSplitscreenType
 ; void LayoutPlayers()
@@ -371,28 +275,14 @@ VerifyPathRenderingComponents
 [FMalloc]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
-; void* Malloc(uint64, uint32)
-Malloc
-; void* TryMalloc(uint64, uint32)
-TryMalloc
-; void* Realloc(void*, uint64, uint32)
-Realloc
-; void* TryRealloc(void*, uint64, uint32)
-TryRealloc
-; void Free(void*)
-Free
-; uint64 QuantizeSize(uint64, uint32)
-QuantizeSize
-; bool GetAllocationSize(void*, uint64&)
-GetAllocationSize
-; void Trim(bool)
-Trim
-; void SetupTLSCachesOnCurrentThread()
-SetupTLSCachesOnCurrentThread
-; void ClearAndDisableTLSCachesOnCurrentThread()
-ClearAndDisableTLSCachesOnCurrentThread
 ; void InitializeStatsMetadata()
 InitializeStatsMetadata
+; void* Malloc(uint64, uint32)
+Malloc
+; void* Realloc(void*, uint64, uint32)
+Realloc
+; void Free(void*)
+Free
 ; void UpdateStats()
 UpdateStats
 ; void GetAllocatorStats(FGenericMemoryStats&)
@@ -403,30 +293,24 @@ DumpAllocatorStats
 IsInternallyThreadSafe
 ; bool ValidateHeap()
 ValidateHeap
+; bool GetAllocationSize(void*, uint64&)
+GetAllocationSize
 ; const wchar_t* GetDescriptiveName()
 GetDescriptiveName
 
 [FArchive]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
-; FArchive& operator<<(FWeakObjectPtr&)
-operator<<__Ref_FWeakObjectPtr
-; FArchive& operator<<(FSoftObjectPath&)
-operator<<__Ref_FSoftObjectPath
-; FArchive& operator<<(FSoftObjectPtr&)
-operator<<__Ref_FSoftObjectPtr
+; FArchive& operator<<(FStringAssetReference&)
+operator<<__Ref_FStringAssetReference
+; FArchive& operator<<(FAssetPtr&)
+operator<<__Ref_FAssetPtr
 ; FArchive& operator<<(FLazyObjectPtr&)
 operator<<__Ref_FLazyObjectPtr
-; FArchive& operator<<(FField*&)
-operator<<__Ptr_Ref_FField
 ; FArchive& operator<<(UObject*&)
 operator<<__Ptr_Ref_UObject
-; FArchive& operator<<(FText&)
-operator<<__Ref_FText
 ; FArchive& operator<<(FName&)
 operator<<__Ref_FName
-; void ForceBlueprintFinalization()
-ForceBlueprintFinalization
 ; void Serialize(void*, int64)
 Serialize
 ; void SerializeBits(void*, int64)
@@ -437,52 +321,6 @@ SerializeInt
 SerializeIntPacked
 ; void Preload(UObject*)
 Preload
-; void Seek(int64)
-Seek
-; void AttachBulkData(UObject*, FUntypedBulkData*)
-AttachBulkData
-; void DetachBulkData(FUntypedBulkData*, bool)
-DetachBulkData
-; bool IsProxyOf(FArchive*) const
-IsProxyOf
-; bool Precache(int64, int64)
-Precache
-; void FlushCache()
-FlushCache
-; bool SetCompressionMap(TArray<FCompressedChunk,TSizedDefaultAllocator<32> >*, ECompressionFlags)
-SetCompressionMap
-; void Flush()
-Flush
-; bool Close()
-Close
-; void MarkScriptSerializationStart(const UObject*)
-MarkScriptSerializationStart
-; void MarkScriptSerializationEnd(const UObject*)
-MarkScriptSerializationEnd
-; void MarkSearchableName(const UObject*, const FName&) const
-MarkSearchableName
-; void UsingCustomVersion(const FGuid&)
-UsingCustomVersion
-; FArchive* GetCacheableArchive()
-GetCacheableArchive
-; void PushSerializedProperty(FProperty*, const bool)
-PushSerializedProperty
-; void PopSerializedProperty(FProperty*, const bool)
-PopSerializedProperty
-; bool AttachExternalReadDependency(TFunction<bool __cdecl(double)>&)
-AttachExternalReadDependency
-; bool IsUsingEventDrivenLoader() const
-IsUsingEventDrivenLoader
-; void PushFileRegionType(EFileRegionType)
-PushFileRegionType
-; void PopFileRegionType()
-PopFileRegionType
-
-[FArchiveState]
-; void* __vecDelDtor(uint32)
-__vecDelDtor
-; FArchiveState& GetInnermostState()
-GetInnermostState
 ; void CountBytes(uint64, uint64)
 CountBytes
 ; FString GetArchiveName() const
@@ -495,204 +333,92 @@ Tell
 TotalSize
 ; bool AtEnd()
 AtEnd
-; UObject* GetArchetypeFromLoader(const UObject*)
-GetArchetypeFromLoader
-; const FCustomVersionContainer& GetCustomVersions() const
-GetCustomVersions
-; void SetCustomVersions(const FCustomVersionContainer&)
-SetCustomVersions
-; void ResetCustomVersions()
-ResetCustomVersions
+; void Seek(int64)
+Seek
+; void AttachBulkData(UObject*, FUntypedBulkData*)
+AttachBulkData
+; void DetachBulkData(FUntypedBulkData*, bool)
+DetachBulkData
+; bool Precache(int64, int64)
+Precache
+; void FlushCache()
+FlushCache
+; bool SetCompressionMap(TArray<FCompressedChunk,FDefaultAllocator>*, ECompressionFlags)
+SetCompressionMap
+; void Flush()
+Flush
+; bool Close()
+Close
+; bool GetError()
+GetError
+; void MarkScriptSerializationStart(const UObject*)
+MarkScriptSerializationStart
+; void MarkScriptSerializationEnd(const UObject*)
+MarkScriptSerializationEnd
+; void IndicateSerializationMismatch()
+IndicateSerializationMismatch
+; bool IsCloseComplete(bool&)
+IsCloseComplete
+; bool IsFilterEditorOnly()
+IsFilterEditorOnly
 ; void SetFilterEditorOnly(bool)
 SetFilterEditorOnly
+; bool IsSaveGame()
+IsSaveGame
 ; bool UseToResolveEnumerators() const
 UseToResolveEnumerators
-; bool ShouldSkipProperty(const FProperty*) const
+; bool ShouldSkipProperty(const UProperty*) const
 ShouldSkipProperty
-; void SetSerializedProperty(FProperty*)
-SetSerializedProperty
-; void SetSerializedPropertyChain(const FArchiveSerializedPropertyChain*, FProperty*)
-SetSerializedPropertyChain
-; void SetSerializeContext(FUObjectSerializeContext*)
-SetSerializeContext
-; FUObjectSerializeContext* GetSerializeContext()
-GetSerializeContext
-; void Reset()
-Reset
-; void SetIsLoading(bool)
-SetIsLoading
-; void SetIsSaving(bool)
-SetIsSaving
-; void SetIsTransacting(bool)
-SetIsTransacting
-; void SetIsTextFormat(bool)
-SetIsTextFormat
-; void SetWantBinaryPropertySerialization(bool)
-SetWantBinaryPropertySerialization
-; void SetUseUnversionedPropertySerialization(bool)
-SetUseUnversionedPropertySerialization
-; void SetForceUnicode(bool)
-SetForceUnicode
-; void SetIsPersistent(bool)
-SetIsPersistent
-; void SetUE4Ver(int32)
-SetUE4Ver
-; void SetLicenseeUE4Ver(int32)
-SetLicenseeUE4Ver
-; void SetEngineVer(const FEngineVersionBase&)
-SetEngineVer
-; void SetEngineNetVer(const uint32)
-SetEngineNetVer
-; void SetGameNetVer(const uint32)
-SetGameNetVer
-
-[AGameModeBase]
-; void* __vecDelDtor(uint32)
-__vecDelDtor
-; void InitializeHUDForPlayer_Implementation(APlayerController*)
-InitializeHUDForPlayer_Implementation
-; void InitStartSpot_Implementation(AActor*, AController*)
-InitStartSpot_Implementation
-; APawn* SpawnDefaultPawnAtTransform_Implementation(AController*, const FTransform&)
-SpawnDefaultPawnAtTransform_Implementation
-; APawn* SpawnDefaultPawnFor_Implementation(AController*, AActor*)
-SpawnDefaultPawnFor_Implementation
-; bool PlayerCanRestart_Implementation(APlayerController*)
-PlayerCanRestart_Implementation
-; AActor* FindPlayerStart_Implementation(AController*, const FString&)
-FindPlayerStart_Implementation
-; AActor* ChoosePlayerStart_Implementation(AController*)
-ChoosePlayerStart_Implementation
-; bool CanSpectate_Implementation(APlayerController*, APlayerState*)
-CanSpectate_Implementation
-; bool MustSpectate_Implementation(APlayerController*) const
-MustSpectate_Implementation
-; void HandleStartingNewPlayer_Implementation(APlayerController*)
-HandleStartingNewPlayer_Implementation
-; bool ShouldReset_Implementation(AActor*)
-ShouldReset_Implementation
-; UClass* GetDefaultPawnClassForController_Implementation(AController*)
-GetDefaultPawnClassForController_Implementation
-; void InitGame(const FString&, const FString&, FString&)
-InitGame
-; void InitGameState()
-InitGameState
-; TSubclassOf<AGameSession> GetGameSessionClass() const
-GetGameSessionClass
-; int32 GetNumPlayers()
-GetNumPlayers
-; int32 GetNumSpectators()
-GetNumSpectators
-; void StartPlay()
-StartPlay
-; bool HasMatchStarted() const
-HasMatchStarted
-; bool HasMatchEnded() const
-HasMatchEnded
-; bool SetPause(APlayerController*, TDelegate<bool __cdecl(void),FDefaultDelegateUserPolicy>)
-SetPause
-; bool ClearPause()
-ClearPause
-; bool AllowPausing(APlayerController*)
-AllowPausing
-; bool IsPaused() const
-IsPaused
-; void ResetLevel()
-ResetLevel
-; void ReturnToMainMenuHost()
-ReturnToMainMenuHost
-; bool CanServerTravel(const FString&, bool)
-CanServerTravel
-; void ProcessServerTravel(const FString&, bool)
-ProcessServerTravel
-; void GetSeamlessTravelActorList(bool, TArray<AActor *,TSizedDefaultAllocator<32> >&)
-GetSeamlessTravelActorList
-; void SwapPlayerControllers(APlayerController*, APlayerController*)
-SwapPlayerControllers
-; TSubclassOf<APlayerController> GetPlayerControllerClassToSpawnForSeamlessTravel(APlayerController*)
-GetPlayerControllerClassToSpawnForSeamlessTravel
-; void HandleSeamlessTravelPlayer(AController*&)
-HandleSeamlessTravelPlayer
-; void PostSeamlessTravel()
-PostSeamlessTravel
-; void StartToLeaveMap()
-StartToLeaveMap
-; void GameWelcomePlayer(UNetConnection*, FString&)
-GameWelcomePlayer
-; void PreLogin(const FString&, const FString&, const FUniqueNetIdRepl&, FString&)
-PreLogin
-; APlayerController* Login(UPlayer*, ENetRole, const FString&, const FString&, const FUniqueNetIdRepl&, FString&)
-Login
-; void PostLogin(APlayerController*)
-PostLogin
-; void Logout(AController*)
-Logout
-; APlayerController* SpawnPlayerController(ENetRole, const FVector&, const FRotator&)
-SpawnPlayerController__ENetRole__Ref_C_FVector__Ref_C_FRotator
-; APlayerController* SpawnPlayerController(ENetRole, const FString&)
-SpawnPlayerController__ENetRole__Ref_C_FString
-; APlayerController* SpawnReplayPlayerController(ENetRole, const FVector&, const FRotator&)
-SpawnReplayPlayerController
-; void ChangeName(AController*, const FString&, bool)
-ChangeName
-; void RestartPlayer(AController*)
-RestartPlayer
-; void RestartPlayerAtPlayerStart(AController*, AActor*)
-RestartPlayerAtPlayerStart
-; void RestartPlayerAtTransform(AController*, const FTransform&)
-RestartPlayerAtTransform
-; void SetPlayerDefaults(APawn*)
-SetPlayerDefaults
-; bool AllowCheats(APlayerController*)
-AllowCheats
-; bool IsHandlingReplays()
-IsHandlingReplays
-; bool SpawnPlayerFromSimulate(const FVector&, const FRotator&)
-SpawnPlayerFromSimulate
-; bool ShouldStartInCinematicMode(APlayerController*, bool&, bool&, bool&, bool&)
-ShouldStartInCinematicMode
-; void UpdateGameplayMuteList(APlayerController*)
-UpdateGameplayMuteList
-; FString InitNewPlayer(APlayerController*, const FUniqueNetIdRepl&, const FString&, const FString&)
-InitNewPlayer
-; void GenericPlayerInitialization(AController*)
-GenericPlayerInitialization
-; void ReplicateStreamingStatus(APlayerController*)
-ReplicateStreamingStatus
-; bool ShouldSpawnAtStartSpot(AController*)
-ShouldSpawnAtStartSpot
-; void FinishRestartPlayer(AController*, const FRotator&)
-FinishRestartPlayer
-; APlayerController* ProcessClientTravel(FString&, bool, bool)
-ProcessClientTravel__Ref_FString__bool__bool
-; APlayerController* ProcessClientTravel(FString&, FGuid, bool, bool)
-ProcessClientTravel__Ref_FString__FGuid__bool__bool
-; void InitSeamlessTravelPlayer(AController*)
-InitSeamlessTravelPlayer
-; APlayerController* SpawnPlayerControllerCommon(ENetRole, const FVector&, const FRotator&, TSubclassOf<APlayerController>)
-SpawnPlayerControllerCommon
 
 [AGameMode]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
+; bool PlayerCanRestart_Implementation(APlayerController*)
+PlayerCanRestart_Implementation
+; AActor* ChoosePlayerStart_Implementation(AController*)
+ChoosePlayerStart_Implementation
+; AActor* FindPlayerStart_Implementation(AController*, const FString&)
+FindPlayerStart_Implementation
+; bool CanSpectate_Implementation(APlayerController*, APlayerState*)
+CanSpectate_Implementation
+; APawn* SpawnDefaultPawnFor_Implementation(AController*, AActor*)
+SpawnDefaultPawnFor_Implementation
+; void InitStartSpot_Implementation(AActor*, AController*)
+InitStartSpot_Implementation
+; UClass* GetDefaultPawnClassForController_Implementation(AController*)
+GetDefaultPawnClassForController_Implementation
+; bool MustSpectate_Implementation(APlayerController*) const
+MustSpectate_Implementation
+; bool ShouldReset_Implementation(AActor*)
+ShouldReset_Implementation
 ; bool ReadyToEndMatch_Implementation()
 ReadyToEndMatch_Implementation
 ; bool ReadyToStartMatch_Implementation()
 ReadyToStartMatch_Implementation
+; bool HasMatchStarted() const
+HasMatchStarted
 ; bool IsMatchInProgress() const
 IsMatchInProgress
+; bool HasMatchEnded() const
+HasMatchEnded
+; void StartPlay()
+StartPlay
+; void PostSeamlessTravel()
+PostSeamlessTravel
 ; void StartMatch()
 StartMatch
 ; void EndMatch()
 EndMatch
+; void StartToLeaveMap()
+StartToLeaveMap
 ; void RestartGame()
 RestartGame
+; void ReturnToMainMenuHost()
+ReturnToMainMenuHost
 ; void AbortMatch()
 AbortMatch
 ; void SetMatchState(FName)
 SetMatchState
-; void OnMatchStateSet()
-OnMatchStateSet
 ; void HandleMatchIsWaitingToStart()
 HandleMatchIsWaitingToStart
 ; void HandleMatchHasStarted()
@@ -703,66 +429,108 @@ HandleMatchHasEnded
 HandleLeavingMap
 ; void HandleMatchAborted()
 HandleMatchAborted
+; void SetBandwidthLimit(float)
+SetBandwidthLimit
+; void ResetLevel()
+ResetLevel
+; void InitGame(const FString&, const FString&, FString&)
+InitGame
+; void InitGameState()
+InitGameState
 ; FString GetNetworkNumber()
 GetNetworkNumber
+; int32 GetNumPlayers()
+GetNumPlayers
+; bool SetPause(APlayerController*, TBaseDelegate<bool>)
+SetPause
+; void ClearPause()
+ClearPause
 ; FString GetDefaultGameClassPath(const FString&, const FString&, const FString&) const
 GetDefaultGameClassPath
 ; TSubclassOf<AGameMode> GetGameModeClass(const FString&, const FString&, const FString&) const
 GetGameModeClass
+; TSubclassOf<AGameSession> GetGameSessionClass() const
+GetGameSessionClass
+; void NotifyPendingConnectionLost()
+NotifyPendingConnectionLost
 ; bool GetTravelType()
 GetTravelType
-; void SendPlayer(APlayerController*, const FString&)
-SendPlayer
+; void ProcessServerTravel(const FString&, bool)
+ProcessServerTravel
+; APlayerController* ProcessClientTravel(FString&, FGuid, bool, bool)
+ProcessClientTravel
+; void PreLogin(const FString&, const FString&, const TSharedPtr<FUniqueNetId,0>&, FString&)
+PreLogin
+; APlayerController* Login(UPlayer*, ENetRole, const FString&, const FString&, const TSharedPtr<FUniqueNetId,0>&, FString&)
+Login
+; void PostLogin(APlayerController*)
+PostLogin
+; APlayerController* SpawnPlayerController(ENetRole, const FVector&, const FRotator&)
+SpawnPlayerController
+; void ReplicateStreamingStatus(APlayerController*)
+ReplicateStreamingStatus
+; void GenericPlayerInitialization(AController*)
+GenericPlayerInitialization
 ; void StartNewPlayer(APlayerController*)
 StartNewPlayer
-; void Say(const FString&)
-Say
-; void SetBandwidthLimit(float)
-SetBandwidthLimit
+; void Logout(AController*)
+Logout
+; void SetPlayerDefaults(APawn*)
+SetPlayerDefaults
+; void ChangeName(AController*, const FString&, bool)
+ChangeName
+; void SendPlayer(APlayerController*, const FString&)
+SendPlayer
 ; void Broadcast(AActor*, const FString&, FName)
 Broadcast
 ; void BroadcastLocalized(AActor*, TSubclassOf<ULocalMessage>, int32, APlayerState*, APlayerState*, UObject*)
 BroadcastLocalized
+; bool ShouldSpawnAtStartSpot(AController*)
+ShouldSpawnAtStartSpot
+; void UpdateGameplayMuteList(APlayerController*)
+UpdateGameplayMuteList
+; bool AllowCheats(APlayerController*)
+AllowCheats
+; bool AllowPausing(APlayerController*)
+AllowPausing
+; void PreCommitMapChange(const FString&, const FString&)
+PreCommitMapChange
+; void PostCommitMapChange()
+PostCommitMapChange
 ; void AddInactivePlayer(APlayerState*, APlayerController*)
 AddInactivePlayer
 ; bool FindInactivePlayer(APlayerController*)
 FindInactivePlayer
 ; void OverridePlayerState(APlayerController*, APlayerState*)
 OverridePlayerState
+; void GetSeamlessTravelActorList(bool, TArray<AActor *,FDefaultAllocator>&)
+GetSeamlessTravelActorList
+; FString GetRedirectURL(const FString&) const
+GetRedirectURL
+; void SwapPlayerControllers(APlayerController*, APlayerController*)
+SwapPlayerControllers
+; void HandleSeamlessTravelPlayer(AController*&)
+HandleSeamlessTravelPlayer
 ; void SetSeamlessTravelViewTarget(APlayerController*)
 SetSeamlessTravelViewTarget
 ; void MatineeCancelled()
 MatineeCancelled
-; void PreCommitMapChange(const FString&, const FString&)
-PreCommitMapChange
-; void PostCommitMapChange()
-PostCommitMapChange
-; void NotifyPendingConnectionLost(const FUniqueNetIdRepl&)
-NotifyPendingConnectionLost
-; void HandleDisconnect(UWorld*, UNetDriver*)
-HandleDisconnect
+; void RestartPlayer(AController*)
+RestartPlayer
+; bool IsHandlingReplays()
+IsHandlingReplays
+; FString InitNewPlayer(APlayerController*, const TSharedPtr<FUniqueNetId,0>&, const FString&, const FString&)
+InitNewPlayer
 
 [AActor]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
-; void OnRep_ReplicateMovement()
-OnRep_ReplicateMovement
-; void TearOff()
-TearOff
+; UObject* _getUObject() const
+_getUObject
 ; bool HasNetOwner() const
 HasNetOwner
-; bool HasLocalNetOwner() const
-HasLocalNetOwner
-; void OnRep_Owner()
-OnRep_Owner
-; void SetReplicateMovement(bool)
-SetReplicateMovement
 ; void OnRep_AttachmentReplication()
 OnRep_AttachmentReplication
-; bool IsReplicationPausedForConnection(const FNetViewer&)
-IsReplicationPausedForConnection
-; void OnReplicationPausedChanged(bool)
-OnReplicationPausedChanged
 ; bool ReplicateSubobjects(UActorChannel*, FOutBunch*, FReplicationFlags*)
 ReplicateSubobjects
 ; void OnSubobjectCreatedFromReplication(UObject*)
@@ -771,10 +539,6 @@ OnSubobjectCreatedFromReplication
 OnSubobjectDestroyFromReplication
 ; void PreReplication(IRepChangedPropertyTracker&)
 PreReplication
-; void PreReplicationForReplay(IRepChangedPropertyTracker&)
-PreReplicationForReplay
-; void RewindForReplay()
-RewindForReplay
 ; void OnRep_Instigator()
 OnRep_Instigator
 ; void EnableInput(APlayerController*)
@@ -797,8 +561,6 @@ RemoveTickPrerequisiteActor
 RemoveTickPrerequisiteComponent
 ; void BeginPlay()
 BeginPlay
-; void EndPlay(const EEndPlayReason::Type)
-EndPlay
 ; void NotifyActorBeginOverlap(AActor*)
 NotifyActorBeginOverlap
 ; void NotifyActorEndOverlap(AActor*)
@@ -807,9 +569,9 @@ NotifyActorEndOverlap
 NotifyActorBeginCursorOver
 ; void NotifyActorEndCursorOver()
 NotifyActorEndCursorOver
-; void NotifyActorOnClicked(FKey)
+; void NotifyActorOnClicked()
 NotifyActorOnClicked
-; void NotifyActorOnReleased(FKey)
+; void NotifyActorOnReleased()
 NotifyActorOnReleased
 ; void NotifyActorOnInputTouchBegin(const ETouchIndex::Type)
 NotifyActorOnInputTouchBegin
@@ -827,22 +589,20 @@ SetLifeSpan
 GetLifeSpan
 ; void GatherCurrentMovement()
 GatherCurrentMovement
-; USceneComponent* GetDefaultAttachComponent() const
-GetDefaultAttachComponent
 ; void ApplyWorldOffset(const FVector&, bool)
 ApplyWorldOffset
 ; bool IsLevelBoundsRelevant() const
 IsLevelBoundsRelevant
+; float GetNetPriority(const FVector&, const FVector&, APlayerController*, UActorChannel*, float, bool)
+GetNetPriority__Ref_C_FVector__Ref_C_FVector__Ptr_APlayerController__Ptr_UActorChannel__float__bool
 ; float GetNetPriority(const FVector&, const FVector&, AActor*, AActor*, UActorChannel*, float, bool)
-GetNetPriority
-; float GetReplayPriority(const FVector&, const FVector&, AActor*, AActor*, UActorChannel* const, float)
-GetReplayPriority
+GetNetPriority__Ref_C_FVector__Ref_C_FVector__Ptr_AActor__Ptr_AActor__Ptr_UActorChannel__float__bool
+; bool GetNetDormancy(const FVector&, const FVector&, APlayerController*, AActor*, UActorChannel*, float, bool)
+GetNetDormancy__Ref_C_FVector__Ref_C_FVector__Ptr_APlayerController__Ptr_AActor__Ptr_UActorChannel__float__bool
 ; bool GetNetDormancy(const FVector&, const FVector&, AActor*, AActor*, UActorChannel*, float, bool)
-GetNetDormancy
+GetNetDormancy__Ref_C_FVector__Ref_C_FVector__Ptr_AActor__Ptr_AActor__Ptr_UActorChannel__float__bool
 ; void OnActorChannelOpen(FInBunch&, UNetConnection*)
 OnActorChannelOpen
-; bool UseShortConnectTimeout() const
-UseShortConnectTimeout
 ; void OnSerializeNewActor(FOutBunch&)
 OnSerializeNewActor
 ; void OnNetCleanup(UNetConnection*)
@@ -853,53 +613,45 @@ TickActor
 PostActorCreated
 ; void LifeSpanExpired()
 LifeSpanExpired
-; void PostNetReceiveRole()
-PostNetReceiveRole
 ; void PostNetInit()
 PostNetInit
 ; void OnRep_ReplicatedMovement()
 OnRep_ReplicatedMovement
+; void PostNetReceiveLocation()
+PostNetReceiveLocation
 ; void PostNetReceiveLocationAndRotation()
 PostNetReceiveLocationAndRotation
 ; void PostNetReceiveVelocity(const FVector&)
 PostNetReceiveVelocity
 ; void PostNetReceivePhysicState()
 PostNetReceivePhysicState
-; void SetOwner(AActor*)
-SetOwner
 ; bool CheckStillInWorld()
 CheckStillInWorld
 ; void Tick(float)
 Tick
 ; bool ShouldTickIfViewportsOnly() const
 ShouldTickIfViewportsOnly
+; bool IsNetRelevantFor(const APlayerController*, const AActor*, const FVector&) const
+IsNetRelevantFor_C__Ptr_C_APlayerController__Ptr_C_AActor__Ref_C_FVector
 ; bool IsNetRelevantFor(const AActor*, const AActor*, const FVector&) const
-IsNetRelevantFor
-; bool IsReplayRelevantFor(const AActor*, const AActor*, const FVector&, const float) const
-IsReplayRelevantFor
+IsNetRelevantFor_C__Ptr_C_AActor__Ptr_C_AActor__Ref_C_FVector
 ; bool IsRelevancyOwnerFor(const AActor*, const AActor*, const AActor*) const
 IsRelevancyOwnerFor
 ; void PreInitializeComponents()
 PreInitializeComponents
 ; void PostInitializeComponents()
 PostInitializeComponents
-; void DispatchPhysicsCollisionHit(const FRigidBodyCollisionInfo&, const FRigidBodyCollisionInfo&, const FCollisionImpactData&)
-DispatchPhysicsCollisionHit
 ; const AActor* GetNetOwner() const
 GetNetOwner
 ; UPlayer* GetNetOwningPlayer()
 GetNetOwningPlayer
 ; UNetConnection* GetNetConnection() const
 GetNetConnection
-; bool DestroyNetworkActorHandled()
-DestroyNetworkActorHandled
 ; void RegisterAllComponents()
 RegisterAllComponents
-; void PreRegisterAllComponents()
-PreRegisterAllComponents
 ; void PostRegisterAllComponents()
 PostRegisterAllComponents
-; void UnregisterAllComponents(bool)
+; void UnregisterAllComponents()
 UnregisterAllComponents
 ; void PostUnregisterAllComponents()
 PostUnregisterAllComponents
@@ -915,6 +667,8 @@ TeleportTo
 TeleportSucceeded
 ; void ClearCrossLevelReferences()
 ClearCrossLevelReferences
+; void EndPlay(const EEndPlayReason::Type)
+EndPlay
 ; bool IsBasedOnActor(const AActor*) const
 IsBasedOnActor
 ; bool IsAttachedTo(const AActor*) const
@@ -925,17 +679,21 @@ RerunConstructionScripts
 OnConstruction
 ; void RegisterActorTickFunctions(bool)
 RegisterActorTickFunctions
+; AActor* GetAttachParentActor() const
+GetAttachParentActor
+; FName GetAttachParentSocketName() const
+GetAttachParentSocketName
+; void GetAttachedActors(TArray<AActor *,FDefaultAllocator>&) const
+GetAttachedActors
 ; void Destroyed()
 Destroyed
 ; void FellOutOfWorld(const UDamageType&)
 FellOutOfWorld
 ; void OutsideWorldBounds()
 OutsideWorldBounds
-; FBox GetComponentsBoundingBox(bool, bool) const
+; FBox GetComponentsBoundingBox(bool) const
 GetComponentsBoundingBox
-; FBox CalculateComponentsBoundingBoxInLocalSpace(bool, bool) const
-CalculateComponentsBoundingBoxInLocalSpace
-; void GetComponentsBoundingCylinder(float&, float&, bool, bool) const
+; void GetComponentsBoundingCylinder(float&, float&, bool) const
 GetComponentsBoundingCylinder
 ; void GetSimpleCollisionCylinder(float&, float&) const
 GetSimpleCollisionCylinder
@@ -959,10 +717,6 @@ BecomeViewTarget
 EndViewTarget
 ; void CalcCamera(float, FMinimalViewInfo&)
 CalcCamera
-; bool HasActiveCameraComponent() const
-HasActiveCameraComponent
-; bool HasActivePawnControlCameraComponent() const
-HasActivePawnControlCameraComponent
 ; FString GetHumanReadableName() const
 GetHumanReadableName
 ; void Reset()
@@ -983,6 +737,8 @@ GetTargetLocation
 PostRenderFor
 ; UActorComponent* FindComponentByClass(const TSubclassOf<UActorComponent>) const
 FindComponentByClass
+; UActorComponent* GetComponentByClass(TSubclassOf<UActorComponent>)
+GetComponentByClass
 ; bool IsComponentRelevantForNavigation(UActorComponent*) const
 IsComponentRelevantForNavigation
 ; void DisplayDebug(UCanvas*, const FDebugDisplayInfo&, float&, float&)
@@ -991,48 +747,44 @@ DisplayDebug
 [UPlayer]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
+; UObject* _getUObject() const
+_getUObject
 ; void SwitchController(APlayerController*)
 SwitchController
+; void HandleDisconnect(UWorld*, UNetDriver*)
+HandleDisconnect
 
 [UEngine]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
+; UObject* _getUObject() const
+_getUObject
 ; void WorldAdded(UWorld*)
 WorldAdded
 ; void WorldDestroyed(UWorld*)
 WorldDestroyed
 ; bool IsInitialized() const
 IsInitialized
-; ERHIFeatureLevel::Type GetDefaultWorldFeatureLevel() const
-GetDefaultWorldFeatureLevel
 ; void Init(IEngineLoop*)
 Init
-; void Start()
-Start
 ; void PreExit()
 PreExit
-; void ReleaseAudioDeviceManager()
-ReleaseAudioDeviceManager
+; void ShutdownAudioDeviceManager()
+ShutdownAudioDeviceManager
 ; void Tick(float, bool)
 Tick
-; void UpdateTimeAndHandleMaxTickRate()
-UpdateTimeAndHandleMaxTickRate
-; double CorrectNegativeTimeDelta(double)
-CorrectNegativeTimeDelta
 ; float GetMaxTickRate(float, bool) const
 GetMaxTickRate
-; float GetMaxFPS() const
-GetMaxFPS
-; void SetMaxFPS(const float)
-SetMaxFPS
 ; void UpdateRunningAverageDeltaTime(float, bool)
 UpdateRunningAverageDeltaTime
-; bool IsAllowedFramerateSmoothing() const
-IsAllowedFramerateSmoothing
 ; void OnLostFocusPause(bool)
 OnLostFocusPause
 ; bool ShouldThrottleCPUUsage() const
 ShouldThrottleCPUUsage
+; bool IsHardwareSurveyRequired()
+IsHardwareSurveyRequired
+; void OnHardwareSurveyComplete(const FHardwareSurveyResults&)
+OnHardwareSurveyComplete
 ; bool ShouldDrawBrushWireframe(AActor*)
 ShouldDrawBrushWireframe
 ; bool GetMapBuildCancelled() const
@@ -1049,24 +801,32 @@ OnlyLoadEditorVisibleLevelsInPIE
 PreferToStreamLevelsInPIE
 ; int32 GetSpriteCategoryIndex(const FName&)
 GetSpriteCategoryIndex
-; void StartFPSChart(const FString&, bool)
+; void TickFPSChart(float)
+TickFPSChart
+; void StartFPSChart()
 StartFPSChart
-; void StopFPSChart(const FString&)
+; void StopFPSChart()
 StopFPSChart
+; void DumpFPSChart(const FString&, bool)
+DumpFPSChart
+; void DumpFPSChartToHTML(float, float, int32, const FString&)
+DumpFPSChartToHTML
+; void DumpFPSChartToLog(float, float, int32, const FString&)
+DumpFPSChartToLog
+; void DumpFPSChartToStatsLog(float, float, int32, const FString&)
+DumpFPSChartToStatsLog
+; void DumpFrameTimesToStatsLog(float, float, int32, const FString&)
+DumpFrameTimesToStatsLog
 ; void ProcessToggleFreezeCommand(UWorld*)
 ProcessToggleFreezeCommand
 ; void ProcessToggleFreezeStreamingCommand(UWorld*)
 ProcessToggleFreezeStreamingCommand
-; bool IsSplitScreen(UWorld*)
-IsSplitScreen
 ; bool IsSettingUpPlayWorld() const
 IsSettingUpPlayWorld
 ; TSharedPtr<SViewport,0> GetGameViewportWidget() const
 GetGameViewportWidget
 ; void FocusNextPIEWorld(UWorld*, bool)
 FocusNextPIEWorld
-; void ResetPIEAudioSetting(UWorld*)
-ResetPIEAudioSetting
 ; UGameViewportClient* GetNextPIEViewport(UGameViewportClient*)
 GetNextPIEViewport
 ; void RemapGamepadControllerIdForPIE(UGameViewportClient*, int32&)
@@ -1077,20 +837,14 @@ NotifyToolsOfObjectReplacement
 UseSound
 ; UWorld* CreatePIEWorldByDuplication(FWorldContext&, UWorld*, FString&)
 CreatePIEWorldByDuplication
-; bool Experimental_ShouldPreDuplicateMap(const FName) const
-Experimental_ShouldPreDuplicateMap
-; void InitializeAudioDeviceManager()
+; bool InitializeAudioDeviceManager()
 InitializeAudioDeviceManager
 ; bool InitializeHMDDevice()
 InitializeHMDDevice
-; bool InitializeEyeTrackingDevice()
-InitializeEyeTrackingDevice
 ; void RecordHMDAnalytics()
 RecordHMDAnalytics
 ; void InitializeObjectReferences()
 InitializeObjectReferences
-; void InitializePortalServices()
-InitializePortalServices
 ; void InitializeRunningAverageDeltaTime()
 InitializeRunningAverageDeltaTime
 ; void SpawnServerActors(UWorld*)
@@ -1099,14 +853,10 @@ SpawnServerActors
 HandleNetworkFailure
 ; void HandleTravelFailure(UWorld*, ETravelFailure::Type, const FString&)
 HandleTravelFailure
-; void HandleNetworkLagStateChanged(UWorld*, UNetDriver*, ENetworkLagState::Type)
-HandleNetworkLagStateChanged
 ; bool NetworkRemapPath(UPendingNetGame*, FString&, bool)
 NetworkRemapPath__Ptr_UPendingNetGame__Ref_FString__bool
-; bool NetworkRemapPath(UNetConnection*, FString&, bool)
-NetworkRemapPath__Ptr_UNetConnection__Ref_FString__bool
-; bool NetworkRemapPath(UNetDriver*, FString&, bool)
-NetworkRemapPath__Ptr_UNetDriver__Ref_FString__bool
+; bool NetworkRemapPath(UWorld*, FString&, bool)
+NetworkRemapPath__Ptr_UWorld__Ref_FString__bool
 ; bool HandleOpenCommand(const wchar_t*, FOutputDevice&, UWorld*)
 HandleOpenCommand
 ; bool HandleTravelCommand(const wchar_t*, FOutputDevice&, UWorld*)
@@ -1123,8 +873,6 @@ HandleDisconnectCommand
 HandleReconnectCommand
 ; EBrowseReturnVal::Type Browse(FWorldContext&, FURL, FString&)
 Browse
-; void TickWorldTravel(FWorldContext&, float)
-TickWorldTravel
 ; bool LoadMap(FWorldContext&, FURL, UPendingNetGame*, FString&)
 LoadMap
 ; void RedrawViewports(bool)
@@ -1149,18 +897,10 @@ VerifyLoadMapWorldCleanup
 DestroyWorldContext
 ; bool AreEditorAnalyticsEnabled() const
 AreEditorAnalyticsEnabled
-; void CreateStartupAnalyticsAttributes(TArray<FAnalyticsEventAttribute,TSizedDefaultAllocator<32> >&) const
+; void CreateStartupAnalyticsAttributes(TArray<FAnalyticsEventAttribute,FDefaultAllocator>&) const
 CreateStartupAnalyticsAttributes
-; bool IsAutosaving() const
-IsAutosaving
-; bool ShouldDoAsyncEndOfFrameTasks() const
-ShouldDoAsyncEndOfFrameTasks
 ; void MovePendingLevel(FWorldContext&)
 MovePendingLevel
-; bool ShouldShutdownWorldNetDriver()
-ShouldShutdownWorldNetDriver
-; void HandleBrowseToDefaultMapFailure(FWorldContext&, const FString&, const FString&)
-HandleBrowseToDefaultMapFailure
 ; void HandleNetworkFailure_NotifyGameInstance(UWorld*, UNetDriver*, ENetworkFailure::Type)
 HandleNetworkFailure_NotifyGameInstance
 ; void HandleTravelFailure_NotifyGameInstance(UWorld*, ETravelFailure::Type)
@@ -1169,10 +909,8 @@ HandleTravelFailure_NotifyGameInstance
 [ULocalPlayer]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
-; void GetViewPoint(FMinimalViewInfo&, EStereoscopicPass) const
-GetViewPoint
-; FSceneView* CalcSceneView(FSceneViewFamily*, FVector&, FRotator&, FViewport*, FViewElementDrawer*, EStereoscopicPass)
-CalcSceneView
+; TSubclassOf<UOnlineSession> GetOnlineSessionClass()
+GetOnlineSessionClass
 ; void PlayerAdded(UGameViewportClient*, int32)
 PlayerAdded
 ; void InitOnlineSession()
@@ -1181,7 +919,7 @@ InitOnlineSession
 PlayerRemoved
 ; bool SpawnPlayActor(const FString&, FString&, UWorld*)
 SpawnPlayActor
-; void SendSplitJoin(TArray<FString,TSizedDefaultAllocator<32> >&)
+; void SendSplitJoin()
 SendSplitJoin
 ; void SetControllerId(int32)
 SetControllerId
@@ -1189,37 +927,11 @@ SetControllerId
 GetNickname
 ; FString GetGameLoginOptions() const
 GetGameLoginOptions
-; bool GetProjectionData(FViewport*, EStereoscopicPass, FSceneViewProjectionData&) const
-GetProjectionData
-
-[FField]
-; void* __vecDelDtor(uint32)
-__vecDelDtor
-; void Serialize(FArchive&)
-Serialize
-; void PostLoad()
-PostLoad
-; void GetPreloadDependencies(TArray<UObject *,TSizedDefaultAllocator<32> >&)
-GetPreloadDependencies
-; void BeginDestroy()
-BeginDestroy
-; void AddReferencedObjects(FReferenceCollector&)
-AddReferencedObjects
-; void AddCppProperty(FProperty*)
-AddCppProperty
-; void Bind()
-Bind
-; void PostDuplicate(const FField&)
-PostDuplicate
-; FField* GetInnerFieldByName(const FName&)
-GetInnerFieldByName
-; void GetInnerFields(TArray<FField *,TSizedDefaultAllocator<32> >&)
-GetInnerFields
 
 [UField]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
-; void AddCppProperty(FProperty*)
+; void AddCppProperty(UProperty*)
 AddCppProperty
 ; void Bind()
 Bind
@@ -1237,16 +949,12 @@ GetCPPType
 GetCPPTypeForwardDeclaration
 ; void LinkInternal(FArchive&)
 LinkInternal
-; EConvertFromTypeResult ConvertFromType(const FPropertyTag&, FStructuredArchiveSlot, uint8*, UStruct*)
-ConvertFromType
 ; bool Identical(const void*, const void*, uint32) const
 Identical
-; void SerializeItem(FStructuredArchiveSlot, void*, const void*) const
+; void SerializeItem(FArchive&, void*, const void*) const
 SerializeItem
-; bool NetSerializeItem(FArchive&, UPackageMap*, void*, TArray<unsigned char,TSizedDefaultAllocator<32> >*) const
+; bool NetSerializeItem(FArchive&, UPackageMap*, void*, TArray<unsigned char,FDefaultAllocator>*) const
 NetSerializeItem
-; bool SupportsNetSharedSerialization() const
-SupportsNetSharedSerialization
 ; void ExportTextItem(FString&, const void*, const void*, UObject*, int32, UObject*) const
 ExportTextItem
 ; const wchar_t* ImportText_Internal(const wchar_t*, void*, int32, UObject*, FOutputDevice*) const
@@ -1275,11 +983,13 @@ GetID
 InstanceSubobjects
 ; int32 GetMinAlignment() const
 GetMinAlignment
-; bool ContainsObjectReference(TArray<FStructProperty const *,TSizedDefaultAllocator<32> >&, EPropertyObjectReferenceType) const
+; bool ContainsObjectReference() const
 ContainsObjectReference
-; void EmitReferenceInfo(UClass&, int32, TArray<FStructProperty const *,TSizedDefaultAllocator<32> >&)
+; bool ContainsWeakObjectReference() const
+ContainsWeakObjectReference
+; void EmitReferenceInfo(UClass&, int32)
 EmitReferenceInfo
-; bool SameType(const FProperty*) const
+; bool SameType(const UProperty*) const
 SameType
 
 [FNumericProperty]
@@ -1307,36 +1017,14 @@ GetUnsignedIntPropertyValue
 GetFloatingPointPropertyValue
 ; FString GetNumericPropertyValueToString(const void*) const
 GetNumericPropertyValueToString
-; bool CanHoldDoubleValueInternal(double) const
-CanHoldDoubleValueInternal
-; bool CanHoldSignedValueInternal(int64) const
-CanHoldSignedValueInternal
-; bool CanHoldUnsignedValueInternal(uint64) const
-CanHoldUnsignedValueInternal
 
 [FMulticastDelegateProperty]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
-; const TMulticastScriptDelegate<FWeakObjectPtr>* GetMulticastDelegate(const void*) const
-GetMulticastDelegate
-; void SetMulticastDelegate(void*, TMulticastScriptDelegate<FWeakObjectPtr>) const
-SetMulticastDelegate
-; void AddDelegate(TScriptDelegate<FWeakObjectPtr>, UObject*, void*) const
-AddDelegate
-; void RemoveDelegate(const TScriptDelegate<FWeakObjectPtr>&, UObject*, void*) const
-RemoveDelegate
-; void ClearDelegate(UObject*, void*) const
-ClearDelegate
-; TArray<TScriptDelegate<FWeakObjectPtr>,TSizedDefaultAllocator<32> >& GetInvocationList(const void*) const
-GetInvocationList
 
 [FObjectPropertyBase]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
-; FString GetCPPTypeCustom(FString*, uint32, const FString&) const
-GetCPPTypeCustom
-; UObject* LoadObjectPropertyValue(const void*) const
-LoadObjectPropertyValue
 ; UObject* GetObjectPropertyValue(const void*) const
 GetObjectPropertyValue
 ; void SetObjectPropertyValue(void*, UObject*) const
@@ -1346,45 +1034,9 @@ AllowCrossLevel
 ; void CheckValidObject(void*) const
 CheckValidObject
 
-[ITextData]
-; void* __vecDelDtor(uint32)
-__vecDelDtor
-; bool OwnsLocalizedString() const
-OwnsLocalizedString
-; const FString& GetDisplayString() const
-GetDisplayString
-; TSharedPtr<FString,1> GetLocalizedString() const
-GetLocalizedString
-; TSharedPtr<FString,1>& GetMutableLocalizedString()
-GetMutableLocalizedString
-; const FTextHistory& GetTextHistory() const
-GetTextHistory
-; FTextHistory& GetMutableTextHistory()
-GetMutableTextHistory
-; void PersistText()
-PersistText
-; uint16 GetGlobalHistoryRevision() const
-GetGlobalHistoryRevision
-; uint16 GetLocalHistoryRevision() const
-GetLocalHistoryRevision
-
 [UDataTable]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
-; TMap<FName, unsigned char *>& GetNonConstRowMap()
-GetNonConstRowMap
-; void AddRowInternal(FName, uint8*)
-AddRowInternal
-; const TMap<FName, unsigned char *>& GetRowMap()
-GetRowMap
-; const TMap<FName, unsigned char *>& GetRowMap() const
-GetRowMap_C
-; bool AllowDuplicateRowsOnImport() const
-AllowDuplicateRowsOnImport
-; void EmptyTable()
-EmptyTable
-; void RemoveRow(FName)
-RemoveRow
-; void AddRow(FName, const FTableRowBase&)
-AddRow
+; UObject* _getUObject() const
+_getUObject
 

--- a/assets/VTableLayoutTemplates/VTableLayout_4_09_Template.ini
+++ b/assets/VTableLayoutTemplates/VTableLayout_4_09_Template.ini
@@ -9,14 +9,6 @@ DeferredRegister
 [UObjectBaseUtility]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
-; bool CanBeClusterRoot() const
-CanBeClusterRoot
-; bool CanBeInCluster() const
-CanBeInCluster
-; void CreateCluster()
-CreateCluster
-; void OnClusterMarkedAsPendingKill()
-OnClusterMarkedAsPendingKill
 
 [UObject]
 ; void* __vecDelDtor(uint32)
@@ -25,16 +17,14 @@ __vecDelDtor
 GetDetailedInfoInternal
 ; void PostInitProperties()
 PostInitProperties
-; void PostCDOContruct()
-PostCDOContruct
-; bool PreSaveRoot(const wchar_t*)
+; bool PreSaveRoot(const wchar_t*, TArray<FString,FDefaultAllocator>&)
 PreSaveRoot
 ; void PostSaveRoot(bool)
 PostSaveRoot
-; void PreSave(const ITargetPlatform*)
+; void PreSave()
 PreSave
-; bool IsReadyForAsyncPostLoad() const
-IsReadyForAsyncPostLoad
+; bool Modify(bool)
+Modify
 ; void PostLoad()
 PostLoad
 ; void PostLoadSubobjects(FObjectInstancingGraph*)
@@ -45,81 +35,59 @@ BeginDestroy
 IsReadyForFinishDestroy
 ; void FinishDestroy()
 FinishDestroy
-; void Serialize(FStructuredArchiveRecord)
-Serialize__FStructuredArchiveRecord
 ; void Serialize(FArchive&)
-Serialize__Ref_FArchive
+Serialize
 ; void ShutdownAfterError()
 ShutdownAfterError
-; void PostInterpChange(FProperty*)
+; void PostInterpChange(UProperty*)
 PostInterpChange
 ; void PostRename(UObject*, const FName)
 PostRename
-; void PreDuplicate(FObjectDuplicationParameters&)
-PreDuplicate
-; void PostDuplicate(EDuplicateMode::Type)
-PostDuplicate__EDuplicateMode_Type
 ; void PostDuplicate(bool)
-PostDuplicate__bool
+PostDuplicate
 ; bool NeedsLoadForClient() const
 NeedsLoadForClient
 ; bool NeedsLoadForServer() const
 NeedsLoadForServer
-; bool NeedsLoadForTargetPlatform(const ITargetPlatform*) const
-NeedsLoadForTargetPlatform
 ; bool NeedsLoadForEditorGame() const
 NeedsLoadForEditorGame
-; bool IsEditorOnly() const
-IsEditorOnly
-; bool HasNonEditorOnlyReferences() const
-HasNonEditorOnlyReferences
 ; bool IsPostLoadThreadSafe() const
 IsPostLoadThreadSafe
-; bool IsDestructionThreadSafe() const
-IsDestructionThreadSafe
-; void GetPreloadDependencies(TArray<UObject *,TSizedDefaultAllocator<32> >&)
-GetPreloadDependencies
-; void GetPrestreamPackages(TArray<UObject *,TSizedDefaultAllocator<32> >&)
-GetPrestreamPackages
 ; void ExportCustomProperties(FOutputDevice&, uint32)
 ExportCustomProperties
 ; void ImportCustomProperties(const wchar_t*, FFeedbackContext*)
 ImportCustomProperties
 ; void PostEditImport()
 PostEditImport
-; void PostReloadConfig(FProperty*)
+; void PostReloadConfig(UProperty*)
 PostReloadConfig
 ; bool Rename(const wchar_t*, UObject*, uint32)
 Rename
 ; FString GetDesc()
 GetDesc
-; UScriptStruct* GetSparseClassDataStruct() const
-GetSparseClassDataStruct
 ; UWorld* GetWorld() const
 GetWorld
 ; bool GetNativePropertyValues(TMap<FString, FString>&, uint32) const
 GetNativePropertyValues
-; void GetResourceSizeEx(FResourceSizeEx&)
-GetResourceSizeEx
+; uint64 GetResourceSize(EResourceSizeMode::Type)
+GetResourceSize
 ; FName GetExporterName()
 GetExporterName
+; bool IsLocalizedResource()
+IsLocalizedResource
 ; FRestoreForUObjectOverwrite* GetRestoreForUObjectOverwrite()
 GetRestoreForUObjectOverwrite
 ; bool AreNativePropertiesIdenticalTo(UObject*) const
 AreNativePropertiesIdenticalTo
-; void GetAssetRegistryTags(TArray<UObject::FAssetRegistryTag,TSizedDefaultAllocator<32> >&) const
-GetAssetRegistryTags_C__Ref_TArray_UObject_FAssetRegistryTag_FDefaultAllocator_
+; void GetAssetRegistryTags(TArray<UObject::FAssetRegistryTag,FDefaultAllocator>&) const
+GetAssetRegistryTags
 ; bool IsAsset() const
 IsAsset
-; FPrimaryAssetId GetPrimaryAssetId() const
-GetPrimaryAssetId
-; bool IsLocalizedResource() const
-IsLocalizedResource
 ; bool IsSafeForRootSet() const
 IsSafeForRootSet
 ; void TagSubobjects(EObjectFlags)
 TagSubobjects
-; void GetLifetimeReplicatedProps(TArray<FLifetimeProperty,TSizedDefaultAllocator<32> >&) const
+; void GetLifetimeReplicatedProps(TArray<FLifetimeProperty,FDefaultAllocator>&) const
 GetLifetimeReplicatedProps
 ; bool IsNameStableForNetworking() const
 IsNameStableForNetworking
@@ -127,42 +95,32 @@ IsNameStableForNetworking
 IsFullNameStableForNetworking
 ; bool IsSupportedForNetworking() const
 IsSupportedForNetworking
-; void GetSubobjectsWithStableNamesForNetworking(TArray<UObject *,TSizedDefaultAllocator<32> >&)
+; void GetSubobjectsWithStableNamesForNetworking(TArray<UObject *,FDefaultAllocator>&)
 GetSubobjectsWithStableNamesForNetworking
 ; void PreNetReceive()
 PreNetReceive
 ; void PostNetReceive()
 PostNetReceive
-; void PostRepNotifies()
-PostRepNotifies
 ; void PreDestroyFromReplication()
 PreDestroyFromReplication
-; void BuildSubobjectMapping(UObject*, TMap<UObject *, UObject *>&) const
-BuildSubobjectMapping
-; const wchar_t* GetConfigOverridePlatform() const
-GetConfigOverridePlatform
-; void OverridePerObjectConfigSection(FString&)
-OverridePerObjectConfigSection
+; void SaveConfig(uint64, const wchar_t*, FConfigCacheIni*)
+SaveConfig
+; void LoadConfig(UClass*, const wchar_t*, uint32, UProperty*)
+LoadConfig
 ; void ProcessEvent(UFunction*, void*)
 ProcessEvent
-; int32 GetFunctionCallspace(UFunction*, FFrame*)
+; int32 GetFunctionCallspace(UFunction*, void*, FFrame*)
 GetFunctionCallspace
 ; bool CallRemoteFunction(UFunction*, void*, FOutParmRec*, FFrame*)
 CallRemoteFunction
 ; bool ProcessConsoleExec(const wchar_t*, FOutputDevice&, UObject*)
 ProcessConsoleExec
-; UClass* RegenerateClass(UClass*, UObject*)
+; UClass* RegenerateClass(UClass*, UObject*, TArray<UObject *,FDefaultAllocator>&)
 RegenerateClass
 ; void MarkAsEditorOnlySubobject()
 MarkAsEditorOnlySubobject
-; bool CheckDefaultSubobjectsInternal() const
+; bool CheckDefaultSubobjectsInternal()
 CheckDefaultSubobjectsInternal
-; void ValidateGeneratedRepEnums(const TArray<FRepRecord,TSizedDefaultAllocator<32> >&) const
-ValidateGeneratedRepEnums
-; void SetNetPushIdDynamic(const int32)
-SetNetPushIdDynamic
-; int32 GetNetPushIdDynamic() const
-GetNetPushIdDynamic
 
 [UScriptStruct::ICppStructOps]
 ; void* __vecDelDtor(uint32)
@@ -173,38 +131,26 @@ HasNoopConstructor
 HasZeroConstructor
 ; void Construct(void*)
 Construct
-; void ConstructForTests(void*)
-ConstructForTests
 ; bool HasDestructor()
 HasDestructor
 ; void Destruct(void*)
 Destruct
 ; bool HasSerializer()
 HasSerializer
-; bool HasStructuredSerializer()
-HasStructuredSerializer
-; bool Serialize(FStructuredArchiveSlot, void*)
-Serialize__FStructuredArchiveSlot__Ptr_void
 ; bool Serialize(FArchive&, void*)
-Serialize__Ref_FArchive__Ptr_void
+Serialize
 ; bool HasPostSerialize()
 HasPostSerialize
 ; void PostSerialize(const FArchive&, void*)
 PostSerialize
 ; bool HasNetSerializer()
 HasNetSerializer
-; bool HasNetSharedSerialization()
-HasNetSharedSerialization
 ; bool NetSerialize(FArchive&, UPackageMap*, bool&, void*)
 NetSerialize
 ; bool HasNetDeltaSerializer()
 HasNetDeltaSerializer
 ; bool NetDeltaSerialize(FNetDeltaSerializeInfo&, void*)
 NetDeltaSerialize
-; bool HasPostScriptConstruct()
-HasPostScriptConstruct
-; void PostScriptConstruct(void*)
-PostScriptConstruct
 ; bool IsPlainOldData()
 IsPlainOldData
 ; bool HasCopy()
@@ -225,44 +171,24 @@ HasImportTextItem
 ImportTextItem
 ; bool HasAddStructReferencedObjects()
 HasAddStructReferencedObjects
-; std::function<void(void*, void*)>* AddStructReferencedObjects()
+; std::function<void(const void*, void*)>* AddStructReferencedObjects()
 AddStructReferencedObjects
 ; bool HasSerializeFromMismatchedTag()
 HasSerializeFromMismatchedTag
-; bool HasStructuredSerializeFromMismatchedTag()
-HasStructuredSerializeFromMismatchedTag
 ; bool SerializeFromMismatchedTag(const FPropertyTag&, FArchive&, void*)
 SerializeFromMismatchedTag
-; bool StructuredSerializeFromMismatchedTag(const FPropertyTag&, FStructuredArchiveSlot, void*)
-StructuredSerializeFromMismatchedTag
-; bool HasGetTypeHash()
-HasGetTypeHash
-; uint32 GetStructTypeHash(const void*)
-GetStructTypeHash
-; EPropertyFlags GetComputedPropertyFlags() const
-GetComputedPropertyFlags
-; bool IsAbstract() const
-IsAbstract
 
 [FOutputDevice]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
-; void Serialize(const wchar_t*, ELogVerbosity::Type, const FName&, const double)
-Serialize__Ptr_C_wchar_t__ELogVerbosity_Type__Ref_C_FName__C_double
 ; void Serialize(const wchar_t*, ELogVerbosity::Type, const FName&)
-Serialize__Ptr_C_wchar_t__ELogVerbosity_Type__Ref_C_FName
+Serialize
 ; void Flush()
 Flush
 ; void TearDown()
 TearDown
-; void Dump(FArchive&)
-Dump
-; bool IsMemoryOnly() const
-IsMemoryOnly
 ; bool CanBeUsedOnAnyThread() const
 CanBeUsedOnAnyThread
-; bool CanBeUsedOnMultipleThreads() const
-CanBeUsedOnMultipleThreads
 
 [UStruct]
 ; void* __vecDelDtor(uint32)
@@ -271,40 +197,24 @@ __vecDelDtor
 GetInheritanceSuper
 ; void Link(FArchive&, bool)
 Link
-; void SerializeBin(FStructuredArchiveSlot, void*) const
-SerializeBin_C__FStructuredArchiveSlot__Ptr_void
 ; void SerializeBin(FArchive&, void*) const
-SerializeBin_C__Ref_FArchive__Ptr_void
-; void SerializeTaggedProperties(FStructuredArchiveSlot, uint8*, UStruct*, uint8*, const UObject*) const
-SerializeTaggedProperties_C__FStructuredArchiveSlot__Ptr_uint8__Ptr_UStruct__Ptr_uint8__Ptr_C_UObject
+SerializeBin
 ; void SerializeTaggedProperties(FArchive&, uint8*, UStruct*, uint8*, const UObject*) const
-SerializeTaggedProperties_C__Ref_FArchive__Ptr_uint8__Ptr_UStruct__Ptr_uint8__Ptr_C_UObject
+SerializeTaggedProperties
 ; void InitializeStruct(void*, int32) const
 InitializeStruct
 ; void DestroyStruct(void*, int32) const
 DestroyStruct
-; FProperty* CustomFindProperty(const FName) const
-CustomFindProperty
 ; EExprToken SerializeExpr(int32&, FArchive&)
 SerializeExpr
 ; const wchar_t* GetPrefixCPP() const
 GetPrefixCPP
 ; void SetSuperStruct(UStruct*)
 SetSuperStruct
+; void SerializeSuperStruct(FArchive&)
+SerializeSuperStruct
 ; FString PropertyNameToDisplayName(FName) const
 PropertyNameToDisplayName
-; FString GetAuthoredNameForField(const FField*) const
-GetAuthoredNameForField_C__Ptr_C_FField
-; FString GetAuthoredNameForField(const UField*) const
-GetAuthoredNameForField_C__Ptr_C_UField
-; bool IsStructTrashed() const
-IsStructTrashed
-; FName FindPropertyNameFromGuid(const FGuid&) const
-FindPropertyNameFromGuid
-; FGuid FindPropertyGuidFromName(const FName) const
-FindPropertyGuidFromName
-; bool ArePropertyGuidsAvailable() const
-ArePropertyGuidsAvailable
 
 [UGameViewportClient]
 ; void* __vecDelDtor(uint32)
@@ -339,10 +249,12 @@ SetViewport
 SetDropDetail
 ; FString ConsoleCommand(const FString&)
 ConsoleCommand
-; bool GetMousePosition(FVector2D&) const
-GetMousePosition
 ; ULocalPlayer* SetupInitialLocalPlayer(FString&)
 SetupInitialLocalPlayer
+; ULocalPlayer* CreatePlayer(int32, FString&, bool)
+CreatePlayer
+; bool RemovePlayer(ULocalPlayer*)
+RemovePlayer
 ; void UpdateActiveSplitscreenType()
 UpdateActiveSplitscreenType
 ; void LayoutPlayers()
@@ -371,28 +283,14 @@ VerifyPathRenderingComponents
 [FMalloc]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
-; void* Malloc(uint64, uint32)
-Malloc
-; void* TryMalloc(uint64, uint32)
-TryMalloc
-; void* Realloc(void*, uint64, uint32)
-Realloc
-; void* TryRealloc(void*, uint64, uint32)
-TryRealloc
-; void Free(void*)
-Free
-; uint64 QuantizeSize(uint64, uint32)
-QuantizeSize
-; bool GetAllocationSize(void*, uint64&)
-GetAllocationSize
-; void Trim(bool)
-Trim
-; void SetupTLSCachesOnCurrentThread()
-SetupTLSCachesOnCurrentThread
-; void ClearAndDisableTLSCachesOnCurrentThread()
-ClearAndDisableTLSCachesOnCurrentThread
 ; void InitializeStatsMetadata()
 InitializeStatsMetadata
+; void* Malloc(uint64, uint32)
+Malloc
+; void* Realloc(void*, uint64, uint32)
+Realloc
+; void Free(void*)
+Free
 ; void UpdateStats()
 UpdateStats
 ; void GetAllocatorStats(FGenericMemoryStats&)
@@ -403,30 +301,24 @@ DumpAllocatorStats
 IsInternallyThreadSafe
 ; bool ValidateHeap()
 ValidateHeap
+; bool GetAllocationSize(void*, uint64&)
+GetAllocationSize
 ; const wchar_t* GetDescriptiveName()
 GetDescriptiveName
 
 [FArchive]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
-; FArchive& operator<<(FWeakObjectPtr&)
-operator<<__Ref_FWeakObjectPtr
-; FArchive& operator<<(FSoftObjectPath&)
-operator<<__Ref_FSoftObjectPath
-; FArchive& operator<<(FSoftObjectPtr&)
-operator<<__Ref_FSoftObjectPtr
+; FArchive& operator<<(FStringAssetReference&)
+operator<<__Ref_FStringAssetReference
+; FArchive& operator<<(FAssetPtr&)
+operator<<__Ref_FAssetPtr
 ; FArchive& operator<<(FLazyObjectPtr&)
 operator<<__Ref_FLazyObjectPtr
-; FArchive& operator<<(FField*&)
-operator<<__Ptr_Ref_FField
 ; FArchive& operator<<(UObject*&)
 operator<<__Ptr_Ref_UObject
-; FArchive& operator<<(FText&)
-operator<<__Ref_FText
 ; FArchive& operator<<(FName&)
 operator<<__Ref_FName
-; void ForceBlueprintFinalization()
-ForceBlueprintFinalization
 ; void Serialize(void*, int64)
 Serialize
 ; void SerializeBits(void*, int64)
@@ -437,52 +329,6 @@ SerializeInt
 SerializeIntPacked
 ; void Preload(UObject*)
 Preload
-; void Seek(int64)
-Seek
-; void AttachBulkData(UObject*, FUntypedBulkData*)
-AttachBulkData
-; void DetachBulkData(FUntypedBulkData*, bool)
-DetachBulkData
-; bool IsProxyOf(FArchive*) const
-IsProxyOf
-; bool Precache(int64, int64)
-Precache
-; void FlushCache()
-FlushCache
-; bool SetCompressionMap(TArray<FCompressedChunk,TSizedDefaultAllocator<32> >*, ECompressionFlags)
-SetCompressionMap
-; void Flush()
-Flush
-; bool Close()
-Close
-; void MarkScriptSerializationStart(const UObject*)
-MarkScriptSerializationStart
-; void MarkScriptSerializationEnd(const UObject*)
-MarkScriptSerializationEnd
-; void MarkSearchableName(const UObject*, const FName&) const
-MarkSearchableName
-; void UsingCustomVersion(const FGuid&)
-UsingCustomVersion
-; FArchive* GetCacheableArchive()
-GetCacheableArchive
-; void PushSerializedProperty(FProperty*, const bool)
-PushSerializedProperty
-; void PopSerializedProperty(FProperty*, const bool)
-PopSerializedProperty
-; bool AttachExternalReadDependency(TFunction<bool __cdecl(double)>&)
-AttachExternalReadDependency
-; bool IsUsingEventDrivenLoader() const
-IsUsingEventDrivenLoader
-; void PushFileRegionType(EFileRegionType)
-PushFileRegionType
-; void PopFileRegionType()
-PopFileRegionType
-
-[FArchiveState]
-; void* __vecDelDtor(uint32)
-__vecDelDtor
-; FArchiveState& GetInnermostState()
-GetInnermostState
 ; void CountBytes(uint64, uint64)
 CountBytes
 ; FString GetArchiveName() const
@@ -495,204 +341,92 @@ Tell
 TotalSize
 ; bool AtEnd()
 AtEnd
-; UObject* GetArchetypeFromLoader(const UObject*)
-GetArchetypeFromLoader
-; const FCustomVersionContainer& GetCustomVersions() const
-GetCustomVersions
-; void SetCustomVersions(const FCustomVersionContainer&)
-SetCustomVersions
-; void ResetCustomVersions()
-ResetCustomVersions
+; void Seek(int64)
+Seek
+; void AttachBulkData(UObject*, FUntypedBulkData*)
+AttachBulkData
+; void DetachBulkData(FUntypedBulkData*, bool)
+DetachBulkData
+; bool Precache(int64, int64)
+Precache
+; void FlushCache()
+FlushCache
+; bool SetCompressionMap(TArray<FCompressedChunk,FDefaultAllocator>*, ECompressionFlags)
+SetCompressionMap
+; void Flush()
+Flush
+; bool Close()
+Close
+; bool GetError()
+GetError
+; void MarkScriptSerializationStart(const UObject*)
+MarkScriptSerializationStart
+; void MarkScriptSerializationEnd(const UObject*)
+MarkScriptSerializationEnd
+; void IndicateSerializationMismatch()
+IndicateSerializationMismatch
+; bool IsCloseComplete(bool&)
+IsCloseComplete
+; bool IsFilterEditorOnly()
+IsFilterEditorOnly
 ; void SetFilterEditorOnly(bool)
 SetFilterEditorOnly
+; bool IsSaveGame()
+IsSaveGame
 ; bool UseToResolveEnumerators() const
 UseToResolveEnumerators
-; bool ShouldSkipProperty(const FProperty*) const
+; bool ShouldSkipProperty(const UProperty*) const
 ShouldSkipProperty
-; void SetSerializedProperty(FProperty*)
-SetSerializedProperty
-; void SetSerializedPropertyChain(const FArchiveSerializedPropertyChain*, FProperty*)
-SetSerializedPropertyChain
-; void SetSerializeContext(FUObjectSerializeContext*)
-SetSerializeContext
-; FUObjectSerializeContext* GetSerializeContext()
-GetSerializeContext
-; void Reset()
-Reset
-; void SetIsLoading(bool)
-SetIsLoading
-; void SetIsSaving(bool)
-SetIsSaving
-; void SetIsTransacting(bool)
-SetIsTransacting
-; void SetIsTextFormat(bool)
-SetIsTextFormat
-; void SetWantBinaryPropertySerialization(bool)
-SetWantBinaryPropertySerialization
-; void SetUseUnversionedPropertySerialization(bool)
-SetUseUnversionedPropertySerialization
-; void SetForceUnicode(bool)
-SetForceUnicode
-; void SetIsPersistent(bool)
-SetIsPersistent
-; void SetUE4Ver(int32)
-SetUE4Ver
-; void SetLicenseeUE4Ver(int32)
-SetLicenseeUE4Ver
-; void SetEngineVer(const FEngineVersionBase&)
-SetEngineVer
-; void SetEngineNetVer(const uint32)
-SetEngineNetVer
-; void SetGameNetVer(const uint32)
-SetGameNetVer
-
-[AGameModeBase]
-; void* __vecDelDtor(uint32)
-__vecDelDtor
-; void InitializeHUDForPlayer_Implementation(APlayerController*)
-InitializeHUDForPlayer_Implementation
-; void InitStartSpot_Implementation(AActor*, AController*)
-InitStartSpot_Implementation
-; APawn* SpawnDefaultPawnAtTransform_Implementation(AController*, const FTransform&)
-SpawnDefaultPawnAtTransform_Implementation
-; APawn* SpawnDefaultPawnFor_Implementation(AController*, AActor*)
-SpawnDefaultPawnFor_Implementation
-; bool PlayerCanRestart_Implementation(APlayerController*)
-PlayerCanRestart_Implementation
-; AActor* FindPlayerStart_Implementation(AController*, const FString&)
-FindPlayerStart_Implementation
-; AActor* ChoosePlayerStart_Implementation(AController*)
-ChoosePlayerStart_Implementation
-; bool CanSpectate_Implementation(APlayerController*, APlayerState*)
-CanSpectate_Implementation
-; bool MustSpectate_Implementation(APlayerController*) const
-MustSpectate_Implementation
-; void HandleStartingNewPlayer_Implementation(APlayerController*)
-HandleStartingNewPlayer_Implementation
-; bool ShouldReset_Implementation(AActor*)
-ShouldReset_Implementation
-; UClass* GetDefaultPawnClassForController_Implementation(AController*)
-GetDefaultPawnClassForController_Implementation
-; void InitGame(const FString&, const FString&, FString&)
-InitGame
-; void InitGameState()
-InitGameState
-; TSubclassOf<AGameSession> GetGameSessionClass() const
-GetGameSessionClass
-; int32 GetNumPlayers()
-GetNumPlayers
-; int32 GetNumSpectators()
-GetNumSpectators
-; void StartPlay()
-StartPlay
-; bool HasMatchStarted() const
-HasMatchStarted
-; bool HasMatchEnded() const
-HasMatchEnded
-; bool SetPause(APlayerController*, TDelegate<bool __cdecl(void),FDefaultDelegateUserPolicy>)
-SetPause
-; bool ClearPause()
-ClearPause
-; bool AllowPausing(APlayerController*)
-AllowPausing
-; bool IsPaused() const
-IsPaused
-; void ResetLevel()
-ResetLevel
-; void ReturnToMainMenuHost()
-ReturnToMainMenuHost
-; bool CanServerTravel(const FString&, bool)
-CanServerTravel
-; void ProcessServerTravel(const FString&, bool)
-ProcessServerTravel
-; void GetSeamlessTravelActorList(bool, TArray<AActor *,TSizedDefaultAllocator<32> >&)
-GetSeamlessTravelActorList
-; void SwapPlayerControllers(APlayerController*, APlayerController*)
-SwapPlayerControllers
-; TSubclassOf<APlayerController> GetPlayerControllerClassToSpawnForSeamlessTravel(APlayerController*)
-GetPlayerControllerClassToSpawnForSeamlessTravel
-; void HandleSeamlessTravelPlayer(AController*&)
-HandleSeamlessTravelPlayer
-; void PostSeamlessTravel()
-PostSeamlessTravel
-; void StartToLeaveMap()
-StartToLeaveMap
-; void GameWelcomePlayer(UNetConnection*, FString&)
-GameWelcomePlayer
-; void PreLogin(const FString&, const FString&, const FUniqueNetIdRepl&, FString&)
-PreLogin
-; APlayerController* Login(UPlayer*, ENetRole, const FString&, const FString&, const FUniqueNetIdRepl&, FString&)
-Login
-; void PostLogin(APlayerController*)
-PostLogin
-; void Logout(AController*)
-Logout
-; APlayerController* SpawnPlayerController(ENetRole, const FVector&, const FRotator&)
-SpawnPlayerController__ENetRole__Ref_C_FVector__Ref_C_FRotator
-; APlayerController* SpawnPlayerController(ENetRole, const FString&)
-SpawnPlayerController__ENetRole__Ref_C_FString
-; APlayerController* SpawnReplayPlayerController(ENetRole, const FVector&, const FRotator&)
-SpawnReplayPlayerController
-; void ChangeName(AController*, const FString&, bool)
-ChangeName
-; void RestartPlayer(AController*)
-RestartPlayer
-; void RestartPlayerAtPlayerStart(AController*, AActor*)
-RestartPlayerAtPlayerStart
-; void RestartPlayerAtTransform(AController*, const FTransform&)
-RestartPlayerAtTransform
-; void SetPlayerDefaults(APawn*)
-SetPlayerDefaults
-; bool AllowCheats(APlayerController*)
-AllowCheats
-; bool IsHandlingReplays()
-IsHandlingReplays
-; bool SpawnPlayerFromSimulate(const FVector&, const FRotator&)
-SpawnPlayerFromSimulate
-; bool ShouldStartInCinematicMode(APlayerController*, bool&, bool&, bool&, bool&)
-ShouldStartInCinematicMode
-; void UpdateGameplayMuteList(APlayerController*)
-UpdateGameplayMuteList
-; FString InitNewPlayer(APlayerController*, const FUniqueNetIdRepl&, const FString&, const FString&)
-InitNewPlayer
-; void GenericPlayerInitialization(AController*)
-GenericPlayerInitialization
-; void ReplicateStreamingStatus(APlayerController*)
-ReplicateStreamingStatus
-; bool ShouldSpawnAtStartSpot(AController*)
-ShouldSpawnAtStartSpot
-; void FinishRestartPlayer(AController*, const FRotator&)
-FinishRestartPlayer
-; APlayerController* ProcessClientTravel(FString&, bool, bool)
-ProcessClientTravel__Ref_FString__bool__bool
-; APlayerController* ProcessClientTravel(FString&, FGuid, bool, bool)
-ProcessClientTravel__Ref_FString__FGuid__bool__bool
-; void InitSeamlessTravelPlayer(AController*)
-InitSeamlessTravelPlayer
-; APlayerController* SpawnPlayerControllerCommon(ENetRole, const FVector&, const FRotator&, TSubclassOf<APlayerController>)
-SpawnPlayerControllerCommon
 
 [AGameMode]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
+; bool PlayerCanRestart_Implementation(APlayerController*)
+PlayerCanRestart_Implementation
+; AActor* ChoosePlayerStart_Implementation(AController*)
+ChoosePlayerStart_Implementation
+; AActor* FindPlayerStart_Implementation(AController*, const FString&)
+FindPlayerStart_Implementation
+; bool CanSpectate_Implementation(APlayerController*, APlayerState*)
+CanSpectate_Implementation
+; APawn* SpawnDefaultPawnFor_Implementation(AController*, AActor*)
+SpawnDefaultPawnFor_Implementation
+; void InitStartSpot_Implementation(AActor*, AController*)
+InitStartSpot_Implementation
+; UClass* GetDefaultPawnClassForController_Implementation(AController*)
+GetDefaultPawnClassForController_Implementation
+; bool MustSpectate_Implementation(APlayerController*) const
+MustSpectate_Implementation
+; bool ShouldReset_Implementation(AActor*)
+ShouldReset_Implementation
 ; bool ReadyToEndMatch_Implementation()
 ReadyToEndMatch_Implementation
 ; bool ReadyToStartMatch_Implementation()
 ReadyToStartMatch_Implementation
+; bool HasMatchStarted() const
+HasMatchStarted
 ; bool IsMatchInProgress() const
 IsMatchInProgress
+; bool HasMatchEnded() const
+HasMatchEnded
+; void StartPlay()
+StartPlay
+; void PostSeamlessTravel()
+PostSeamlessTravel
 ; void StartMatch()
 StartMatch
 ; void EndMatch()
 EndMatch
+; void StartToLeaveMap()
+StartToLeaveMap
 ; void RestartGame()
 RestartGame
+; void ReturnToMainMenuHost()
+ReturnToMainMenuHost
 ; void AbortMatch()
 AbortMatch
 ; void SetMatchState(FName)
 SetMatchState
-; void OnMatchStateSet()
-OnMatchStateSet
 ; void HandleMatchIsWaitingToStart()
 HandleMatchIsWaitingToStart
 ; void HandleMatchHasStarted()
@@ -703,66 +437,114 @@ HandleMatchHasEnded
 HandleLeavingMap
 ; void HandleMatchAborted()
 HandleMatchAborted
+; void SetBandwidthLimit(float)
+SetBandwidthLimit
+; void ResetLevel()
+ResetLevel
+; void InitGame(const FString&, const FString&, FString&)
+InitGame
+; void InitGameState()
+InitGameState
 ; FString GetNetworkNumber()
 GetNetworkNumber
+; int32 GetNumPlayers()
+GetNumPlayers
+; bool SetPause(APlayerController*, TBaseDelegate<bool>)
+SetPause
+; void ClearPause()
+ClearPause
 ; FString GetDefaultGameClassPath(const FString&, const FString&, const FString&) const
 GetDefaultGameClassPath
 ; TSubclassOf<AGameMode> GetGameModeClass(const FString&, const FString&, const FString&) const
 GetGameModeClass
+; TSubclassOf<AGameSession> GetGameSessionClass() const
+GetGameSessionClass
+; void NotifyPendingConnectionLost()
+NotifyPendingConnectionLost
 ; bool GetTravelType()
 GetTravelType
-; void SendPlayer(APlayerController*, const FString&)
-SendPlayer
+; void ProcessServerTravel(const FString&, bool)
+ProcessServerTravel
+; APlayerController* ProcessClientTravel(FString&, FGuid, bool, bool)
+ProcessClientTravel
+; void PreLogin(const FString&, const FString&, const TSharedPtr<FUniqueNetId const ,0>&, FString&)
+PreLogin
+; APlayerController* Login(UPlayer*, ENetRole, const FString&, const FString&, const TSharedPtr<FUniqueNetId const ,0>&, FString&)
+Login
+; void PostLogin(APlayerController*)
+PostLogin
+; APlayerController* SpawnPlayerController(ENetRole, const FVector&, const FRotator&)
+SpawnPlayerController
+; void ReplicateStreamingStatus(APlayerController*)
+ReplicateStreamingStatus
+; void GenericPlayerInitialization(AController*)
+GenericPlayerInitialization
 ; void StartNewPlayer(APlayerController*)
 StartNewPlayer
-; void Say(const FString&)
-Say
-; void SetBandwidthLimit(float)
-SetBandwidthLimit
+; void Logout(AController*)
+Logout
+; void SetPlayerDefaults(APawn*)
+SetPlayerDefaults
+; void ChangeName(AController*, const FString&, bool)
+ChangeName
+; void SendPlayer(APlayerController*, const FString&)
+SendPlayer
 ; void Broadcast(AActor*, const FString&, FName)
 Broadcast
 ; void BroadcastLocalized(AActor*, TSubclassOf<ULocalMessage>, int32, APlayerState*, APlayerState*, UObject*)
 BroadcastLocalized
+; bool ShouldSpawnAtStartSpot(AController*)
+ShouldSpawnAtStartSpot
+; void UpdateGameplayMuteList(APlayerController*)
+UpdateGameplayMuteList
+; bool AllowCheats(APlayerController*)
+AllowCheats
+; bool AllowPausing(APlayerController*)
+AllowPausing
+; void PreCommitMapChange(const FString&, const FString&)
+PreCommitMapChange
+; void PostCommitMapChange()
+PostCommitMapChange
 ; void AddInactivePlayer(APlayerState*, APlayerController*)
 AddInactivePlayer
 ; bool FindInactivePlayer(APlayerController*)
 FindInactivePlayer
 ; void OverridePlayerState(APlayerController*, APlayerState*)
 OverridePlayerState
+; void GetSeamlessTravelActorList(bool, TArray<AActor *,FDefaultAllocator>&)
+GetSeamlessTravelActorList
+; FString GetRedirectURL(const FString&) const
+GetRedirectURL
+; void SwapPlayerControllers(APlayerController*, APlayerController*)
+SwapPlayerControllers
+; void HandleSeamlessTravelPlayer(AController*&)
+HandleSeamlessTravelPlayer
 ; void SetSeamlessTravelViewTarget(APlayerController*)
 SetSeamlessTravelViewTarget
 ; void MatineeCancelled()
 MatineeCancelled
-; void PreCommitMapChange(const FString&, const FString&)
-PreCommitMapChange
-; void PostCommitMapChange()
-PostCommitMapChange
-; void NotifyPendingConnectionLost(const FUniqueNetIdRepl&)
-NotifyPendingConnectionLost
-; void HandleDisconnect(UWorld*, UNetDriver*)
-HandleDisconnect
+; void RestartPlayer(AController*)
+RestartPlayer
+; bool IsHandlingReplays()
+IsHandlingReplays
+; FString InitNewPlayer(APlayerController*, const TSharedPtr<FUniqueNetId const ,0>&, const FString&, const FString&)
+InitNewPlayer
 
 [AActor]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
+; UObject* _getUObject() const
+_getUObject
 ; void OnRep_ReplicateMovement()
 OnRep_ReplicateMovement
 ; void TearOff()
 TearOff
 ; bool HasNetOwner() const
 HasNetOwner
-; bool HasLocalNetOwner() const
-HasLocalNetOwner
-; void OnRep_Owner()
-OnRep_Owner
 ; void SetReplicateMovement(bool)
 SetReplicateMovement
 ; void OnRep_AttachmentReplication()
 OnRep_AttachmentReplication
-; bool IsReplicationPausedForConnection(const FNetViewer&)
-IsReplicationPausedForConnection
-; void OnReplicationPausedChanged(bool)
-OnReplicationPausedChanged
 ; bool ReplicateSubobjects(UActorChannel*, FOutBunch*, FReplicationFlags*)
 ReplicateSubobjects
 ; void OnSubobjectCreatedFromReplication(UObject*)
@@ -771,10 +553,6 @@ OnSubobjectCreatedFromReplication
 OnSubobjectDestroyFromReplication
 ; void PreReplication(IRepChangedPropertyTracker&)
 PreReplication
-; void PreReplicationForReplay(IRepChangedPropertyTracker&)
-PreReplicationForReplay
-; void RewindForReplay()
-RewindForReplay
 ; void OnRep_Instigator()
 OnRep_Instigator
 ; void EnableInput(APlayerController*)
@@ -797,8 +575,6 @@ RemoveTickPrerequisiteActor
 RemoveTickPrerequisiteComponent
 ; void BeginPlay()
 BeginPlay
-; void EndPlay(const EEndPlayReason::Type)
-EndPlay
 ; void NotifyActorBeginOverlap(AActor*)
 NotifyActorBeginOverlap
 ; void NotifyActorEndOverlap(AActor*)
@@ -807,9 +583,9 @@ NotifyActorEndOverlap
 NotifyActorBeginCursorOver
 ; void NotifyActorEndCursorOver()
 NotifyActorEndCursorOver
-; void NotifyActorOnClicked(FKey)
+; void NotifyActorOnClicked()
 NotifyActorOnClicked
-; void NotifyActorOnReleased(FKey)
+; void NotifyActorOnReleased()
 NotifyActorOnReleased
 ; void NotifyActorOnInputTouchBegin(const ETouchIndex::Type)
 NotifyActorOnInputTouchBegin
@@ -827,22 +603,20 @@ SetLifeSpan
 GetLifeSpan
 ; void GatherCurrentMovement()
 GatherCurrentMovement
-; USceneComponent* GetDefaultAttachComponent() const
-GetDefaultAttachComponent
 ; void ApplyWorldOffset(const FVector&, bool)
 ApplyWorldOffset
 ; bool IsLevelBoundsRelevant() const
 IsLevelBoundsRelevant
+; float GetNetPriority(const FVector&, const FVector&, APlayerController*, UActorChannel*, float, bool)
+GetNetPriority__Ref_C_FVector__Ref_C_FVector__Ptr_APlayerController__Ptr_UActorChannel__float__bool
 ; float GetNetPriority(const FVector&, const FVector&, AActor*, AActor*, UActorChannel*, float, bool)
-GetNetPriority
-; float GetReplayPriority(const FVector&, const FVector&, AActor*, AActor*, UActorChannel* const, float)
-GetReplayPriority
+GetNetPriority__Ref_C_FVector__Ref_C_FVector__Ptr_AActor__Ptr_AActor__Ptr_UActorChannel__float__bool
+; bool GetNetDormancy(const FVector&, const FVector&, APlayerController*, AActor*, UActorChannel*, float, bool)
+GetNetDormancy__Ref_C_FVector__Ref_C_FVector__Ptr_APlayerController__Ptr_AActor__Ptr_UActorChannel__float__bool
 ; bool GetNetDormancy(const FVector&, const FVector&, AActor*, AActor*, UActorChannel*, float, bool)
-GetNetDormancy
+GetNetDormancy__Ref_C_FVector__Ref_C_FVector__Ptr_AActor__Ptr_AActor__Ptr_UActorChannel__float__bool
 ; void OnActorChannelOpen(FInBunch&, UNetConnection*)
 OnActorChannelOpen
-; bool UseShortConnectTimeout() const
-UseShortConnectTimeout
 ; void OnSerializeNewActor(FOutBunch&)
 OnSerializeNewActor
 ; void OnNetCleanup(UNetConnection*)
@@ -853,53 +627,45 @@ TickActor
 PostActorCreated
 ; void LifeSpanExpired()
 LifeSpanExpired
-; void PostNetReceiveRole()
-PostNetReceiveRole
 ; void PostNetInit()
 PostNetInit
 ; void OnRep_ReplicatedMovement()
 OnRep_ReplicatedMovement
+; void PostNetReceiveLocation()
+PostNetReceiveLocation
 ; void PostNetReceiveLocationAndRotation()
 PostNetReceiveLocationAndRotation
 ; void PostNetReceiveVelocity(const FVector&)
 PostNetReceiveVelocity
 ; void PostNetReceivePhysicState()
 PostNetReceivePhysicState
-; void SetOwner(AActor*)
-SetOwner
 ; bool CheckStillInWorld()
 CheckStillInWorld
 ; void Tick(float)
 Tick
 ; bool ShouldTickIfViewportsOnly() const
 ShouldTickIfViewportsOnly
+; bool IsNetRelevantFor(const APlayerController*, const AActor*, const FVector&) const
+IsNetRelevantFor_C__Ptr_C_APlayerController__Ptr_C_AActor__Ref_C_FVector
 ; bool IsNetRelevantFor(const AActor*, const AActor*, const FVector&) const
-IsNetRelevantFor
-; bool IsReplayRelevantFor(const AActor*, const AActor*, const FVector&, const float) const
-IsReplayRelevantFor
+IsNetRelevantFor_C__Ptr_C_AActor__Ptr_C_AActor__Ref_C_FVector
 ; bool IsRelevancyOwnerFor(const AActor*, const AActor*, const AActor*) const
 IsRelevancyOwnerFor
 ; void PreInitializeComponents()
 PreInitializeComponents
 ; void PostInitializeComponents()
 PostInitializeComponents
-; void DispatchPhysicsCollisionHit(const FRigidBodyCollisionInfo&, const FRigidBodyCollisionInfo&, const FCollisionImpactData&)
-DispatchPhysicsCollisionHit
 ; const AActor* GetNetOwner() const
 GetNetOwner
 ; UPlayer* GetNetOwningPlayer()
 GetNetOwningPlayer
 ; UNetConnection* GetNetConnection() const
 GetNetConnection
-; bool DestroyNetworkActorHandled()
-DestroyNetworkActorHandled
 ; void RegisterAllComponents()
 RegisterAllComponents
-; void PreRegisterAllComponents()
-PreRegisterAllComponents
 ; void PostRegisterAllComponents()
 PostRegisterAllComponents
-; void UnregisterAllComponents(bool)
+; void UnregisterAllComponents()
 UnregisterAllComponents
 ; void PostUnregisterAllComponents()
 PostUnregisterAllComponents
@@ -915,6 +681,8 @@ TeleportTo
 TeleportSucceeded
 ; void ClearCrossLevelReferences()
 ClearCrossLevelReferences
+; void EndPlay(const EEndPlayReason::Type)
+EndPlay
 ; bool IsBasedOnActor(const AActor*) const
 IsBasedOnActor
 ; bool IsAttachedTo(const AActor*) const
@@ -925,17 +693,21 @@ RerunConstructionScripts
 OnConstruction
 ; void RegisterActorTickFunctions(bool)
 RegisterActorTickFunctions
+; AActor* GetAttachParentActor() const
+GetAttachParentActor
+; FName GetAttachParentSocketName() const
+GetAttachParentSocketName
+; void GetAttachedActors(TArray<AActor *,FDefaultAllocator>&) const
+GetAttachedActors
 ; void Destroyed()
 Destroyed
 ; void FellOutOfWorld(const UDamageType&)
 FellOutOfWorld
 ; void OutsideWorldBounds()
 OutsideWorldBounds
-; FBox GetComponentsBoundingBox(bool, bool) const
+; FBox GetComponentsBoundingBox(bool) const
 GetComponentsBoundingBox
-; FBox CalculateComponentsBoundingBoxInLocalSpace(bool, bool) const
-CalculateComponentsBoundingBoxInLocalSpace
-; void GetComponentsBoundingCylinder(float&, float&, bool, bool) const
+; void GetComponentsBoundingCylinder(float&, float&, bool) const
 GetComponentsBoundingCylinder
 ; void GetSimpleCollisionCylinder(float&, float&) const
 GetSimpleCollisionCylinder
@@ -959,10 +731,6 @@ BecomeViewTarget
 EndViewTarget
 ; void CalcCamera(float, FMinimalViewInfo&)
 CalcCamera
-; bool HasActiveCameraComponent() const
-HasActiveCameraComponent
-; bool HasActivePawnControlCameraComponent() const
-HasActivePawnControlCameraComponent
 ; FString GetHumanReadableName() const
 GetHumanReadableName
 ; void Reset()
@@ -983,6 +751,8 @@ GetTargetLocation
 PostRenderFor
 ; UActorComponent* FindComponentByClass(const TSubclassOf<UActorComponent>) const
 FindComponentByClass
+; UActorComponent* GetComponentByClass(TSubclassOf<UActorComponent>)
+GetComponentByClass
 ; bool IsComponentRelevantForNavigation(UActorComponent*) const
 IsComponentRelevantForNavigation
 ; void DisplayDebug(UCanvas*, const FDebugDisplayInfo&, float&, float&)
@@ -991,39 +761,35 @@ DisplayDebug
 [UPlayer]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
+; UObject* _getUObject() const
+_getUObject
 ; void SwitchController(APlayerController*)
 SwitchController
 
 [UEngine]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
+; UObject* _getUObject() const
+_getUObject
 ; void WorldAdded(UWorld*)
 WorldAdded
 ; void WorldDestroyed(UWorld*)
 WorldDestroyed
 ; bool IsInitialized() const
 IsInitialized
-; ERHIFeatureLevel::Type GetDefaultWorldFeatureLevel() const
-GetDefaultWorldFeatureLevel
 ; void Init(IEngineLoop*)
 Init
-; void Start()
-Start
 ; void PreExit()
 PreExit
-; void ReleaseAudioDeviceManager()
-ReleaseAudioDeviceManager
+; void ShutdownAudioDeviceManager()
+ShutdownAudioDeviceManager
 ; void Tick(float, bool)
 Tick
-; void UpdateTimeAndHandleMaxTickRate()
-UpdateTimeAndHandleMaxTickRate
-; double CorrectNegativeTimeDelta(double)
-CorrectNegativeTimeDelta
 ; float GetMaxTickRate(float, bool) const
 GetMaxTickRate
-; float GetMaxFPS() const
+; int32 GetMaxFPS() const
 GetMaxFPS
-; void SetMaxFPS(const float)
+; void SetMaxFPS(const int32)
 SetMaxFPS
 ; void UpdateRunningAverageDeltaTime(float, bool)
 UpdateRunningAverageDeltaTime
@@ -1033,6 +799,10 @@ IsAllowedFramerateSmoothing
 OnLostFocusPause
 ; bool ShouldThrottleCPUUsage() const
 ShouldThrottleCPUUsage
+; bool IsHardwareSurveyRequired()
+IsHardwareSurveyRequired
+; void OnHardwareSurveyComplete(const FHardwareSurveyResults&)
+OnHardwareSurveyComplete
 ; bool ShouldDrawBrushWireframe(AActor*)
 ShouldDrawBrushWireframe
 ; bool GetMapBuildCancelled() const
@@ -1049,24 +819,32 @@ OnlyLoadEditorVisibleLevelsInPIE
 PreferToStreamLevelsInPIE
 ; int32 GetSpriteCategoryIndex(const FName&)
 GetSpriteCategoryIndex
-; void StartFPSChart(const FString&, bool)
+; void TickFPSChart(float)
+TickFPSChart
+; void StartFPSChart(const FString&)
 StartFPSChart
-; void StopFPSChart(const FString&)
+; void StopFPSChart()
 StopFPSChart
+; void DumpFPSChart(const FString&, bool)
+DumpFPSChart
+; void DumpFPSChartToHTML(float, float, int32, const FString&)
+DumpFPSChartToHTML
+; void DumpFPSChartToLog(float, float, int32, const FString&)
+DumpFPSChartToLog
+; void DumpFPSChartToStatsLog(float, float, int32, const FString&)
+DumpFPSChartToStatsLog
+; void DumpFrameTimesToStatsLog(float, float, int32, const FString&)
+DumpFrameTimesToStatsLog
 ; void ProcessToggleFreezeCommand(UWorld*)
 ProcessToggleFreezeCommand
 ; void ProcessToggleFreezeStreamingCommand(UWorld*)
 ProcessToggleFreezeStreamingCommand
-; bool IsSplitScreen(UWorld*)
-IsSplitScreen
 ; bool IsSettingUpPlayWorld() const
 IsSettingUpPlayWorld
 ; TSharedPtr<SViewport,0> GetGameViewportWidget() const
 GetGameViewportWidget
 ; void FocusNextPIEWorld(UWorld*, bool)
 FocusNextPIEWorld
-; void ResetPIEAudioSetting(UWorld*)
-ResetPIEAudioSetting
 ; UGameViewportClient* GetNextPIEViewport(UGameViewportClient*)
 GetNextPIEViewport
 ; void RemapGamepadControllerIdForPIE(UGameViewportClient*, int32&)
@@ -1077,20 +855,16 @@ NotifyToolsOfObjectReplacement
 UseSound
 ; UWorld* CreatePIEWorldByDuplication(FWorldContext&, UWorld*, FString&)
 CreatePIEWorldByDuplication
-; bool Experimental_ShouldPreDuplicateMap(const FName) const
-Experimental_ShouldPreDuplicateMap
-; void InitializeAudioDeviceManager()
+; bool InitializeAudioDeviceManager()
 InitializeAudioDeviceManager
 ; bool InitializeHMDDevice()
 InitializeHMDDevice
-; bool InitializeEyeTrackingDevice()
-InitializeEyeTrackingDevice
+; bool InitializeMotionControllers()
+InitializeMotionControllers
 ; void RecordHMDAnalytics()
 RecordHMDAnalytics
 ; void InitializeObjectReferences()
 InitializeObjectReferences
-; void InitializePortalServices()
-InitializePortalServices
 ; void InitializeRunningAverageDeltaTime()
 InitializeRunningAverageDeltaTime
 ; void SpawnServerActors(UWorld*)
@@ -1099,14 +873,10 @@ SpawnServerActors
 HandleNetworkFailure
 ; void HandleTravelFailure(UWorld*, ETravelFailure::Type, const FString&)
 HandleTravelFailure
-; void HandleNetworkLagStateChanged(UWorld*, UNetDriver*, ENetworkLagState::Type)
-HandleNetworkLagStateChanged
 ; bool NetworkRemapPath(UPendingNetGame*, FString&, bool)
 NetworkRemapPath__Ptr_UPendingNetGame__Ref_FString__bool
-; bool NetworkRemapPath(UNetConnection*, FString&, bool)
-NetworkRemapPath__Ptr_UNetConnection__Ref_FString__bool
-; bool NetworkRemapPath(UNetDriver*, FString&, bool)
-NetworkRemapPath__Ptr_UNetDriver__Ref_FString__bool
+; bool NetworkRemapPath(UWorld*, FString&, bool)
+NetworkRemapPath__Ptr_UWorld__Ref_FString__bool
 ; bool HandleOpenCommand(const wchar_t*, FOutputDevice&, UWorld*)
 HandleOpenCommand
 ; bool HandleTravelCommand(const wchar_t*, FOutputDevice&, UWorld*)
@@ -1123,8 +893,6 @@ HandleDisconnectCommand
 HandleReconnectCommand
 ; EBrowseReturnVal::Type Browse(FWorldContext&, FURL, FString&)
 Browse
-; void TickWorldTravel(FWorldContext&, float)
-TickWorldTravel
 ; bool LoadMap(FWorldContext&, FURL, UPendingNetGame*, FString&)
 LoadMap
 ; void RedrawViewports(bool)
@@ -1149,18 +917,12 @@ VerifyLoadMapWorldCleanup
 DestroyWorldContext
 ; bool AreEditorAnalyticsEnabled() const
 AreEditorAnalyticsEnabled
-; void CreateStartupAnalyticsAttributes(TArray<FAnalyticsEventAttribute,TSizedDefaultAllocator<32> >&) const
+; void CreateStartupAnalyticsAttributes(TArray<FAnalyticsEventAttribute,FDefaultAllocator>&) const
 CreateStartupAnalyticsAttributes
 ; bool IsAutosaving() const
 IsAutosaving
-; bool ShouldDoAsyncEndOfFrameTasks() const
-ShouldDoAsyncEndOfFrameTasks
 ; void MovePendingLevel(FWorldContext&)
 MovePendingLevel
-; bool ShouldShutdownWorldNetDriver()
-ShouldShutdownWorldNetDriver
-; void HandleBrowseToDefaultMapFailure(FWorldContext&, const FString&, const FString&)
-HandleBrowseToDefaultMapFailure
 ; void HandleNetworkFailure_NotifyGameInstance(UWorld*, UNetDriver*, ENetworkFailure::Type)
 HandleNetworkFailure_NotifyGameInstance
 ; void HandleTravelFailure_NotifyGameInstance(UWorld*, ETravelFailure::Type)
@@ -1169,10 +931,6 @@ HandleTravelFailure_NotifyGameInstance
 [ULocalPlayer]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
-; void GetViewPoint(FMinimalViewInfo&, EStereoscopicPass) const
-GetViewPoint
-; FSceneView* CalcSceneView(FSceneViewFamily*, FVector&, FRotator&, FViewport*, FViewElementDrawer*, EStereoscopicPass)
-CalcSceneView
 ; void PlayerAdded(UGameViewportClient*, int32)
 PlayerAdded
 ; void InitOnlineSession()
@@ -1181,7 +939,7 @@ InitOnlineSession
 PlayerRemoved
 ; bool SpawnPlayActor(const FString&, FString&, UWorld*)
 SpawnPlayActor
-; void SendSplitJoin(TArray<FString,TSizedDefaultAllocator<32> >&)
+; void SendSplitJoin()
 SendSplitJoin
 ; void SetControllerId(int32)
 SetControllerId
@@ -1189,37 +947,11 @@ SetControllerId
 GetNickname
 ; FString GetGameLoginOptions() const
 GetGameLoginOptions
-; bool GetProjectionData(FViewport*, EStereoscopicPass, FSceneViewProjectionData&) const
-GetProjectionData
-
-[FField]
-; void* __vecDelDtor(uint32)
-__vecDelDtor
-; void Serialize(FArchive&)
-Serialize
-; void PostLoad()
-PostLoad
-; void GetPreloadDependencies(TArray<UObject *,TSizedDefaultAllocator<32> >&)
-GetPreloadDependencies
-; void BeginDestroy()
-BeginDestroy
-; void AddReferencedObjects(FReferenceCollector&)
-AddReferencedObjects
-; void AddCppProperty(FProperty*)
-AddCppProperty
-; void Bind()
-Bind
-; void PostDuplicate(const FField&)
-PostDuplicate
-; FField* GetInnerFieldByName(const FName&)
-GetInnerFieldByName
-; void GetInnerFields(TArray<FField *,TSizedDefaultAllocator<32> >&)
-GetInnerFields
 
 [UField]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
-; void AddCppProperty(FProperty*)
+; void AddCppProperty(UProperty*)
 AddCppProperty
 ; void Bind()
 Bind
@@ -1237,16 +969,12 @@ GetCPPType
 GetCPPTypeForwardDeclaration
 ; void LinkInternal(FArchive&)
 LinkInternal
-; EConvertFromTypeResult ConvertFromType(const FPropertyTag&, FStructuredArchiveSlot, uint8*, UStruct*)
-ConvertFromType
 ; bool Identical(const void*, const void*, uint32) const
 Identical
-; void SerializeItem(FStructuredArchiveSlot, void*, const void*) const
+; void SerializeItem(FArchive&, void*, const void*) const
 SerializeItem
-; bool NetSerializeItem(FArchive&, UPackageMap*, void*, TArray<unsigned char,TSizedDefaultAllocator<32> >*) const
+; bool NetSerializeItem(FArchive&, UPackageMap*, void*, TArray<unsigned char,FDefaultAllocator>*) const
 NetSerializeItem
-; bool SupportsNetSharedSerialization() const
-SupportsNetSharedSerialization
 ; void ExportTextItem(FString&, const void*, const void*, UObject*, int32, UObject*) const
 ExportTextItem
 ; const wchar_t* ImportText_Internal(const wchar_t*, void*, int32, UObject*, FOutputDevice*) const
@@ -1275,11 +1003,13 @@ GetID
 InstanceSubobjects
 ; int32 GetMinAlignment() const
 GetMinAlignment
-; bool ContainsObjectReference(TArray<FStructProperty const *,TSizedDefaultAllocator<32> >&, EPropertyObjectReferenceType) const
+; bool ContainsObjectReference() const
 ContainsObjectReference
-; void EmitReferenceInfo(UClass&, int32, TArray<FStructProperty const *,TSizedDefaultAllocator<32> >&)
+; bool ContainsWeakObjectReference() const
+ContainsWeakObjectReference
+; void EmitReferenceInfo(UClass&, int32)
 EmitReferenceInfo
-; bool SameType(const FProperty*) const
+; bool SameType(const UProperty*) const
 SameType
 
 [FNumericProperty]
@@ -1307,36 +1037,14 @@ GetUnsignedIntPropertyValue
 GetFloatingPointPropertyValue
 ; FString GetNumericPropertyValueToString(const void*) const
 GetNumericPropertyValueToString
-; bool CanHoldDoubleValueInternal(double) const
-CanHoldDoubleValueInternal
-; bool CanHoldSignedValueInternal(int64) const
-CanHoldSignedValueInternal
-; bool CanHoldUnsignedValueInternal(uint64) const
-CanHoldUnsignedValueInternal
 
 [FMulticastDelegateProperty]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
-; const TMulticastScriptDelegate<FWeakObjectPtr>* GetMulticastDelegate(const void*) const
-GetMulticastDelegate
-; void SetMulticastDelegate(void*, TMulticastScriptDelegate<FWeakObjectPtr>) const
-SetMulticastDelegate
-; void AddDelegate(TScriptDelegate<FWeakObjectPtr>, UObject*, void*) const
-AddDelegate
-; void RemoveDelegate(const TScriptDelegate<FWeakObjectPtr>&, UObject*, void*) const
-RemoveDelegate
-; void ClearDelegate(UObject*, void*) const
-ClearDelegate
-; TArray<TScriptDelegate<FWeakObjectPtr>,TSizedDefaultAllocator<32> >& GetInvocationList(const void*) const
-GetInvocationList
 
 [FObjectPropertyBase]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
-; FString GetCPPTypeCustom(FString*, uint32, const FString&) const
-GetCPPTypeCustom
-; UObject* LoadObjectPropertyValue(const void*) const
-LoadObjectPropertyValue
 ; UObject* GetObjectPropertyValue(const void*) const
 GetObjectPropertyValue
 ; void SetObjectPropertyValue(void*, UObject*) const
@@ -1346,45 +1054,9 @@ AllowCrossLevel
 ; void CheckValidObject(void*) const
 CheckValidObject
 
-[ITextData]
-; void* __vecDelDtor(uint32)
-__vecDelDtor
-; bool OwnsLocalizedString() const
-OwnsLocalizedString
-; const FString& GetDisplayString() const
-GetDisplayString
-; TSharedPtr<FString,1> GetLocalizedString() const
-GetLocalizedString
-; TSharedPtr<FString,1>& GetMutableLocalizedString()
-GetMutableLocalizedString
-; const FTextHistory& GetTextHistory() const
-GetTextHistory
-; FTextHistory& GetMutableTextHistory()
-GetMutableTextHistory
-; void PersistText()
-PersistText
-; uint16 GetGlobalHistoryRevision() const
-GetGlobalHistoryRevision
-; uint16 GetLocalHistoryRevision() const
-GetLocalHistoryRevision
-
 [UDataTable]
 ; void* __vecDelDtor(uint32)
 __vecDelDtor
-; TMap<FName, unsigned char *>& GetNonConstRowMap()
-GetNonConstRowMap
-; void AddRowInternal(FName, uint8*)
-AddRowInternal
-; const TMap<FName, unsigned char *>& GetRowMap()
-GetRowMap
-; const TMap<FName, unsigned char *>& GetRowMap() const
-GetRowMap_C
-; bool AllowDuplicateRowsOnImport() const
-AllowDuplicateRowsOnImport
-; void EmptyTable()
-EmptyTable
-; void RemoveRow(FName)
-RemoveRow
-; void AddRow(FName, const FTableRowBase&)
-AddRow
+; UObject* _getUObject() const
+_getUObject
 

--- a/assets/VTableLayoutTemplates/VTableLayout_4_27_Template.ini
+++ b/assets/VTableLayoutTemplates/VTableLayout_4_27_Template.ini
@@ -108,7 +108,7 @@ GetRestoreForUObjectOverwrite
 ; bool AreNativePropertiesIdenticalTo(UObject*) const
 AreNativePropertiesIdenticalTo
 ; void GetAssetRegistryTags(TArray<UObject::FAssetRegistryTag,TSizedDefaultAllocator<32> >&) const
-GetAssetRegistryTags_C__Ref_TArray_UObject_FAssetRegistryTag_TSizedDefaultAllocator_32_
+GetAssetRegistryTags_C__Ref_TArray_UObject_FAssetRegistryTag_FDefaultAllocator_
 ; bool IsAsset() const
 IsAsset
 ; FPrimaryAssetId GetPrimaryAssetId() const

--- a/assets/VTableLayoutTemplates/VTableLayout_5_00_Template.ini
+++ b/assets/VTableLayoutTemplates/VTableLayout_5_00_Template.ini
@@ -118,7 +118,7 @@ GetRestoreForUObjectOverwrite
 ; bool AreNativePropertiesIdenticalTo(UObject*) const
 AreNativePropertiesIdenticalTo
 ; void GetAssetRegistryTags(TArray<UObject::FAssetRegistryTag,TSizedDefaultAllocator<32> >&) const
-GetAssetRegistryTags_C__Ref_TArray_UObject_FAssetRegistryTag_TSizedDefaultAllocator_32_
+GetAssetRegistryTags_C__Ref_TArray_UObject_FAssetRegistryTag_FDefaultAllocator_
 ; void GetExternalActorExtendedAssetRegistryTags(TArray<UObject::FAssetRegistryTag,TSizedDefaultAllocator<32> >&) const
 GetExternalActorExtendedAssetRegistryTags
 ; bool IsAsset() const

--- a/assets/VTableLayoutTemplates/VTableLayout_5_01_Template.ini
+++ b/assets/VTableLayoutTemplates/VTableLayout_5_01_Template.ini
@@ -118,7 +118,7 @@ GetRestoreForUObjectOverwrite
 ; bool AreNativePropertiesIdenticalTo(UObject*) const
 AreNativePropertiesIdenticalTo
 ; void GetAssetRegistryTags(TArray<UObject::FAssetRegistryTag,TSizedDefaultAllocator<32> >&) const
-GetAssetRegistryTags_C__Ref_TArray_UObject_FAssetRegistryTag_TSizedDefaultAllocator_32_
+GetAssetRegistryTags_C__Ref_TArray_UObject_FAssetRegistryTag_FDefaultAllocator_
 ; void GetExternalActorExtendedAssetRegistryTags(TArray<UObject::FAssetRegistryTag,TSizedDefaultAllocator<32> >&) const
 GetExternalActorExtendedAssetRegistryTags
 ; bool IsAsset() const

--- a/assets/VTableLayoutTemplates/VTableLayout_5_02_Template.ini
+++ b/assets/VTableLayoutTemplates/VTableLayout_5_02_Template.ini
@@ -118,7 +118,7 @@ GetRestoreForUObjectOverwrite
 ; bool AreNativePropertiesIdenticalTo(UObject*) const
 AreNativePropertiesIdenticalTo
 ; void GetAssetRegistryTags(TArray<UObject::FAssetRegistryTag,TSizedDefaultAllocator<32> >&) const
-GetAssetRegistryTags_C__Ref_TArray_UObject_FAssetRegistryTag_TSizedDefaultAllocator_32_
+GetAssetRegistryTags_C__Ref_TArray_UObject_FAssetRegistryTag_FDefaultAllocator_
 ; void GetExternalActorExtendedAssetRegistryTags(TArray<UObject::FAssetRegistryTag,TSizedDefaultAllocator<32> >&) const
 GetExternalActorExtendedAssetRegistryTags
 ; bool IsAsset() const

--- a/assets/VTableLayoutTemplates/VTableLayout_5_03_Template.ini
+++ b/assets/VTableLayoutTemplates/VTableLayout_5_03_Template.ini
@@ -118,7 +118,7 @@ GetRestoreForUObjectOverwrite
 ; bool AreNativePropertiesIdenticalTo(UObject*) const
 AreNativePropertiesIdenticalTo
 ; void GetAssetRegistryTags(TArray<UObject::FAssetRegistryTag,TSizedDefaultAllocator<32> >&) const
-GetAssetRegistryTags_C__Ref_TArray_UObject_FAssetRegistryTag_TSizedDefaultAllocator_32_
+GetAssetRegistryTags_C__Ref_TArray_UObject_FAssetRegistryTag_FDefaultAllocator_
 ; void GetExternalActorExtendedAssetRegistryTags(TArray<UObject::FAssetRegistryTag,TSizedDefaultAllocator<32> >&) const
 GetExternalActorExtendedAssetRegistryTags
 ; bool IsAsset() const

--- a/assets/VTableLayoutTemplates/VTableLayout_5_04_Template.ini
+++ b/assets/VTableLayoutTemplates/VTableLayout_5_04_Template.ini
@@ -118,7 +118,7 @@ GetRestoreForUObjectOverwrite
 ; bool AreNativePropertiesIdenticalTo(UObject*) const
 AreNativePropertiesIdenticalTo
 ; void GetAssetRegistryTags(TArray<UObject::FAssetRegistryTag,TSizedDefaultAllocator<32> >&) const
-GetAssetRegistryTags_C__Ref_TArray_UObject_FAssetRegistryTag_TSizedDefaultAllocator_32_
+GetAssetRegistryTags_C__Ref_TArray_UObject_FAssetRegistryTag_FDefaultAllocator_
 ; void GetAssetRegistryTags(FAssetRegistryTagsContext) const
 GetAssetRegistryTags_C__FAssetRegistryTagsContext
 ; bool IsAsset() const

--- a/assets/VTableLayoutTemplates/VTableLayout_5_05_Template.ini
+++ b/assets/VTableLayoutTemplates/VTableLayout_5_05_Template.ini
@@ -122,7 +122,7 @@ GetRestoreForUObjectOverwrite
 ; bool AreNativePropertiesIdenticalTo(UObject*) const
 AreNativePropertiesIdenticalTo
 ; void GetAssetRegistryTags(TArray<UObject::FAssetRegistryTag,TSizedDefaultAllocator<32> >&) const
-GetAssetRegistryTags_C__Ref_TArray_UObject_FAssetRegistryTag_TSizedDefaultAllocator_32_
+GetAssetRegistryTags_C__Ref_TArray_UObject_FAssetRegistryTag_FDefaultAllocator_
 ; void GetAssetRegistryTags(FAssetRegistryTagsContext) const
 GetAssetRegistryTags_C__FAssetRegistryTagsContext
 ; bool IsAsset() const

--- a/assets/VTableLayoutTemplates/VTableLayout_5_06_Template.ini
+++ b/assets/VTableLayoutTemplates/VTableLayout_5_06_Template.ini
@@ -116,7 +116,7 @@ GetRestoreForUObjectOverwrite
 ; bool AreNativePropertiesIdenticalTo(UObject*) const
 AreNativePropertiesIdenticalTo
 ; void GetAssetRegistryTags(TArray<UObject::FAssetRegistryTag,TSizedDefaultAllocator<32> >&) const
-GetAssetRegistryTags_C__Ref_TArray_UObject_FAssetRegistryTag_TSizedDefaultAllocator_32_
+GetAssetRegistryTags_C__Ref_TArray_UObject_FAssetRegistryTag_FDefaultAllocator_
 ; void GetAssetRegistryTags(FAssetRegistryTagsContext) const
 GetAssetRegistryTags_C__FAssetRegistryTagsContext
 ; bool IsAsset() const
@@ -1298,9 +1298,9 @@ SpawnPlayActor
 ; void PreBeginHandshake(const TDelegate<void __cdecl(void),FDefaultDelegateUserPolicy>&)
 PreBeginHandshake
 ; void SendSplitJoin(TArray<FString,TSizedDefaultAllocator<32> >&, UNetDriver*, UE::Net::EJoinFlags)
-SendSplitJoin__Ref_TArray_FString_TSizedDefaultAllocator_32___Ptr_UNetDriver__UE_Net_EJoinFlags
+SendSplitJoin__Ref_TArray_FString_FDefaultAllocator___Ptr_UNetDriver__UE_Net_EJoinFlags
 ; void SendSplitJoin(TArray<FString,TSizedDefaultAllocator<32> >&)
-SendSplitJoin__Ref_TArray_FString_TSizedDefaultAllocator_32_
+SendSplitJoin__Ref_TArray_FString_FDefaultAllocator_
 ; void SetControllerId(int32)
 SetControllerId
 ; void SetPlatformUserId(FPlatformUserId)

--- a/assets/VTableLayoutTemplates/VTableLayout_5_07_Template.ini
+++ b/assets/VTableLayoutTemplates/VTableLayout_5_07_Template.ini
@@ -116,7 +116,7 @@ GetRestoreForUObjectOverwrite
 ; bool AreNativePropertiesIdenticalTo(UObject*) const
 AreNativePropertiesIdenticalTo
 ; void GetAssetRegistryTags(TArray<UObject::FAssetRegistryTag,TSizedDefaultAllocator<32> >&) const
-GetAssetRegistryTags_C__Ref_TArray_UObject_FAssetRegistryTag_TSizedDefaultAllocator_32_
+GetAssetRegistryTags_C__Ref_TArray_UObject_FAssetRegistryTag_FDefaultAllocator_
 ; void GetAssetRegistryTags(FAssetRegistryTagsContext) const
 GetAssetRegistryTags_C__FAssetRegistryTagsContext
 ; bool IsAsset() const
@@ -1246,9 +1246,9 @@ SpawnPlayActor
 ; void PreBeginHandshake(const TDelegate<void __cdecl(void),FDefaultDelegateUserPolicy>&)
 PreBeginHandshake
 ; void SendSplitJoin(TArray<FString,TSizedDefaultAllocator<32> >&, UNetDriver*, UE::Net::EJoinFlags)
-SendSplitJoin__Ref_TArray_FString_TSizedDefaultAllocator_32___Ptr_UNetDriver__UE_Net_EJoinFlags
+SendSplitJoin__Ref_TArray_FString_FDefaultAllocator___Ptr_UNetDriver__UE_Net_EJoinFlags
 ; void SendSplitJoin(TArray<FString,TSizedDefaultAllocator<32> >&)
-SendSplitJoin__Ref_TArray_FString_TSizedDefaultAllocator_32_
+SendSplitJoin__Ref_TArray_FString_FDefaultAllocator_
 ; void SetControllerId(int32)
 SetControllerId
 ; void SetPlatformUserId(FPlatformUserId)


### PR DESCRIPTION
**Description**
Adds UE 4.7 through 4.10 support on the UE4SS side. The 4.7 and 4.8 PDBs are added to
the dump list and the layout and vtable templates are regenerated for every version from
4.07 through 5.07.


Fixes # (issue) (if applicable)

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

**How has this been tested?**
Full UVTD run over all 30 PDBs with no errors, UEPseudo and UE4SS both build against the
regenerated dumps. Verified in 4.7 game and several others of different versions.


**Checklist**
<!-- Please delete options that are not relevant. Update the list as the PR progresses. -->

- [x] I have commented my code, particularly in hard-to-understand areas.

