### PR TITLE
BPModLoaderMod: use RegisterInitGameStatePostHook instead of RegisterLoadMapPostHook to avoid the LoadMap Error-argument crash

### DIFF
--- a/assets/Mods/BPModLoaderMod/Scripts/main.lua
+++ b/assets/Mods/BPModLoaderMod/Scripts/main.lua
@@ -289,8 +289,13 @@ RegisterBeginPlayPostHook(function(ContextParam)
     end
 end)
 
-RegisterLoadMapPostHook(function(Engine, World)
-    LoadMods(World:get())
+-- Retargeted from RegisterLoadMapPostHook: that hook's native FString&
+-- Error argument is bound to garbage on at least this engine build and
+-- crashes UE4SS's own glue code before this callback ever runs (see
+-- issue #1391). InitGameState has no FString parameter at all, so
+-- it's unaffected by that bug.
+RegisterInitGameStatePostHook(function(Context)
+    LoadMods(Context:GetWorld())
 end)
 
 ExecuteInGameThread(function()


### PR DESCRIPTION
`RegisterLoadMapPostHook`'s native dispatch code (`LuaMod.cpp:6470`) crashes with `STATUS_ACCESS_VIOLATION` on at least this engine build (Conan Exiles, CL 373004, UE5.6) the moment it touches its `Error` (`FString&`) argument — see #1391 for the full root-cause writeup. Since `BPModLoaderMod` is UE4SS's own bundled Blueprint-mod loader and is the only registrant of `RegisterLoadMapPostHook` in the shipped `Mods/` tree, this crashes any server that loads Blueprint mods at all on an affected engine build.

`BPModLoaderMod` doesn't actually need anything from the `LoadMap` Post-hook's problematic arguments — it only needs a `World` reference to know when to call `LoadMods()`. `RegisterInitGameStatePostHook`'s native dispatch lambda constructs only one Lua argument (`Context`, an `AGameModeBase*`), with no `FString&` parameter at all, so it's structurally unaffected by this bug class, and `Context:GetWorld()` provides an equivalent, valid `World` reference through Blueprint mod loading. `InitGameState` also fires at a point in the loading sequence — after the game state actually exists — that's a good fit for "instantiate mod actors into the world," arguably a better-defined trigger point than `LoadMap` for this specific purpose.

**Live-tested on a real deployment:** applied to a running Conan Exiles dedicated server. Before: consistent crash right after every map load. After: clean startup, mod loading, sustained gameplay simulation with no exception text in either `UE4SS.log` or `ConanSandbox.log`, and a real game client successfully connecting, logging in, and playing.

This is a mitigation for one specific consumer of the buggy hook, not a fix for the underlying UE4SS bug — the underlying `Error`-argument corruption (see #1391) would still affect any third-party mod that calls `RegisterLoadMapPostHook` directly. Worth landing regardless, since it removes the crash from UE4SS's own core mod immediately, without waiting on a native fix.