### PR TITLE
docs: note what FindAllOf costs, and to prefer GetFName over GetFullName

### DIFF
--- a/docs/lua-api/global-functions/findallof.md
+++ b/docs/lua-api/global-functions/findallof.md
@@ -28,3 +28,45 @@ else
     end
 end
 ```
+
+## Performance
+
+How much this costs depends far more on how broad the class is, and on how you
+compare names afterwards, than on `FindAllOf` itself. All of it runs on the game
+thread, so it is a frame hitch rather than background work.
+
+In one level of a single-corridor game, `"Actor"` returned 255 instances while
+`"Object"` returned 23,919 — roughly 94x, from the same call in the same level.
+The count tracks how much is loaded rather than how large the map is, so a small
+game is no guarantee of a small result.
+
+Working through a large result is dominated by name comparison. Measured over
+23,919 instances, averaged across 7 rounds:
+
+| Loop body | Total | Per instance |
+|-----------|-------|--------------|
+| `IsValid()` (baseline for call overhead) | 7.7 ms | 0.32 µs |
+| `GetFullName()` compared to a string | 42.1 ms | 1.76 µs |
+| `GetFName()` compared to an `FName` | 19.4 ms | 0.81 µs |
+
+**Avoid `GetFullName` in production code.** It builds a full path string for
+every instance. If you need to match by name, use `GetFName` and construct the
+`FName` you compare against once, outside the loop — unlike `UObject`, two
+`FName` values compare correctly with `==`. If the leaf name is not specific
+enough on its own, walk the outer chain and compare `FName`s along it.
+
+```lua
+-- Construct the FName once, not per instance.
+local Target = FName("BP_SomeActor_C_0")
+for _, Instance in pairs(FindAllOf("Object") or {}) do
+    if Instance:GetFName() == Target then
+        -- Only now is it worth building the full path, if you need it at all.
+    end
+end
+```
+
+If you look the same objects up repeatedly, cache them rather than re-scanning.
+
+> Figures above are from The Exit 8 (UE 5.2) with UE4SS v3.0.1 on a Ryzen 9
+> 9950X3D, and are meant to show the shape of the cost rather than to be exact
+> for any other title.

--- a/docs/lua-api/global-functions/findallof.md
+++ b/docs/lua-api/global-functions/findallof.md
@@ -31,17 +31,11 @@ end
 
 ## Performance
 
-How much this costs depends far more on how broad the class is, and on how you
-compare names afterwards, than on `FindAllOf` itself. All of it runs on the game
-thread, so it is a frame hitch rather than background work.
+How much this costs depends far more on how broad the class is, and on how you compare names afterwards, than on `FindAllOf` itself. All of it runs on the game thread, so it is a frame hitch rather than background work.
 
-In one level of a single-corridor game, `"Actor"` returned 255 instances while
-`"Object"` returned 23,919 — roughly 94x, from the same call in the same level.
-The count tracks how much is loaded rather than how large the map is, so a small
-game is no guarantee of a small result.
+In one level of The Exit 8 — a short game whose playable space is a single looping corridor — `"Actor"` returned 255 instances while `"Object"` returned 23,919. That is roughly 94x, from the same call in the same level. The count tracks how much is loaded rather than how large the map is, so a small game is no guarantee of a small result.
 
-Working through a large result is dominated by name comparison. Measured over
-23,919 instances, averaged across 7 rounds:
+Working through a large result is dominated by name comparison. Measured over 23,919 instances, averaged across 7 rounds:
 
 | Loop body | Total | Per instance |
 |-----------|-------|--------------|
@@ -49,11 +43,7 @@ Working through a large result is dominated by name comparison. Measured over
 | `GetFullName()` compared to a string | 42.1 ms | 1.76 µs |
 | `GetFName()` compared to an `FName` | 19.4 ms | 0.81 µs |
 
-**Avoid `GetFullName` in production code.** It builds a full path string for
-every instance. If you need to match by name, use `GetFName` and construct the
-`FName` you compare against once, outside the loop — unlike `UObject`, two
-`FName` values compare correctly with `==`. If the leaf name is not specific
-enough on its own, walk the outer chain and compare `FName`s along it.
+**Avoid `GetFullName` in production code.** It builds a full path string for every instance. If you need to match by name, use `GetFName` and construct the `FName` you compare against once, outside the loop — unlike `UObject`, two `FName` values compare correctly with `==`. If the leaf name is not specific enough on its own, walk the outer chain and compare `FName`s along it.
 
 ```lua
 -- Construct the FName once, not per instance.
@@ -67,6 +57,4 @@ end
 
 If you look the same objects up repeatedly, cache them rather than re-scanning.
 
-> Figures above are from The Exit 8 (UE 5.2) with UE4SS v3.0.1 on a Ryzen 9
-> 9950X3D, and are meant to show the shape of the cost rather than to be exact
-> for any other title.
+> Figures above are from The Exit 8 (UE 5.2) with UE4SS **v3.0.1 Beta #0, Git SHA `d7e7826d`** — an experimental build, not 3.0.1 stable — on a Ryzen 9 9950X3D. They are meant to show the shape of the cost rather than to be exact for any other title, engine version, or UE4SS build.

--- a/docs/lua-api/global-functions/findallof.md
+++ b/docs/lua-api/global-functions/findallof.md
@@ -31,30 +31,139 @@ end
 
 ## Performance
 
-How much this costs depends far more on how broad the class is, and on how you compare names afterwards, than on `FindAllOf` itself. All of it runs on the game thread, so it is a frame hitch rather than background work.
+This function is very slow as it must complete an entire pass of the entire global object array.
 
-In one level of The Exit 8 — a short game whose playable space is a single looping corridor — `"Actor"` returned 255 instances while `"Object"` returned 23,919. That is roughly 94x, from the same call in the same level. The count tracks how much is loaded rather than how large the map is, so a small game is no guarantee of a small result.
+Avoid using this function in production code when avoidable.
 
-Working through a large result is dominated by name comparison. Measured over 23,919 instances, averaged across 7 rounds:
+If you must use it, you can use the `#` operator to check how many objects were found.
 
-| Loop body | Total | Per instance |
-|-----------|-------|--------------|
-| `IsValid()` (baseline for call overhead) | 7.7 ms | 0.32 µs |
-| `GetFullName()` compared to a string | 42.1 ms | 1.76 µs |
-| `GetFName()` compared to an `FName` | 19.4 ms | 0.81 µs |
+If there are a lot, consider not doing a lot of work while iterating these objects.
 
-**Avoid `GetFullName` in production code.** It builds a full path string for every instance. If you need to match by name, use `GetFName` and construct the `FName` you compare against once, outside the loop — unlike `UObject`, two `FName` values compare correctly with `==`. If the leaf name is not specific enough on its own, walk the outer chain and compare `FName`s along it.
+Prefer manually iterating the outer, class, and/or super chain(s) and calling `UObject::GetFName` on each element in the chain over using `UObject::GetFullName` and processing the string.
+
+You can cache FNames to compare against outside your loop.
+
+Alternatively, call `UObject::IsA` instead.
+
+Here's an example of finding all actors, and filtering to only do logic on instances of `Light`.  
+This example is intentionally complicated, and is meant to showcase how iterating the super struct linked list works.
 
 ```lua
--- Construct the FName once, not per instance.
-local Target = FName("BP_SomeActor_C_0")
-for _, Instance in pairs(FindAllOf("Object") or {}) do
-    if Instance:GetFName() == Target then
-        -- Only now is it worth building the full path, if you need it at all.
+local AllActors = FindAllOf("Actor")
+print(string.format("NumActors found: %s\n", #AllActors))
+local LightName = UEHelpers.FindOrAddFName("Light")
+for _, Actor in ipairs(AllActors) do
+    -- Filter on the type.
+    -- The class represents the type.
+    local ActorClass = Actor:GetClass()
+
+    -- Check direct type.
+    local bIsLight = false
+    if ActorClass:GetFName() == LightName then
+        -- Is directly a Light.
+        bIsLight = true
+    end
+
+    -- Check inheritance.
+    local Super = ActorClass:GetSuperStruct()
+    while Super:IsValid() do
+        if Super:GetFName() == LightName then
+            -- Inherits from Light.
+            bIsLight = true
+        end
+        Super = Super:GetSuperStruct()
+    end
+
+    if bIsLight then
+        -- Do logic on Light.
     end
 end
 ```
 
-If you look the same objects up repeatedly, cache them rather than re-scanning.
+This filtering can often be done for you if you specify a lower type to the `FindAllOf` function.  
+For example, the above example could be replaced entirely with a call to `FindAllOf("Light")`.
 
-> Figures above are from The Exit 8 (UE 5.2) with UE4SS **v3.0.1 Beta #0, Git SHA `d7e7826d`** — an experimental build, not 3.0.1 stable — on a Ryzen 9 9950X3D. They are meant to show the shape of the cost rather than to be exact for any other title, engine version, or UE4SS build.
+Here's another more useful example where we want to get all lights, and do operations on them depending on what type of light it is:
+
+```lua
+local function IsObjectOfType(Object, TypeName)
+    -- Filter on the type.
+    -- The class represents the type.
+    local ObjectClass = Object:GetClass()
+
+    -- Check direct type.
+    if ObjectClass:GetFName() == TypeName then
+        return true
+    end
+
+    -- Check inheritance.
+    local Super = ObjectClass:GetSuperStruct()
+    while Super:IsValid() do
+        if Super:GetFName() == TypeName then
+            return true
+        end
+        Super = Super:GetSuperStruct()
+    end
+
+    return false
+end
+
+local AllActors = FindAllOf("Light")
+print(string.format("NumActors found: %s\n", #AllActors))
+local PointLightName = UEHelpers.FindOrAddFName("PointLight")
+local RectLightName = UEHelpers.FindOrAddFName("RectLight")
+local SpotLightName = UEHelpers.FindOrAddFName("SpotLight")
+local DirectionalLightName = UEHelpers.FindOrAddFName("DirectionalLight")
+for _, Light in ipairs(AllActors) do
+    if IsObjectOfType(Light, PointLightName) then
+        -- Do logic on PointLight.
+    end
+
+    if IsObjectOfType(Light, RectLightName) then
+        -- Do logic on RectLight.
+    end
+
+    if IsObjectOfType(Light, SpotLightName) then
+        -- Do logic on SpotLight.
+    end
+
+    if IsObjectOfType(Light, DirectionalLightName) then
+        -- Do logic on DirectionalLightName.
+    end
+end
+```
+
+You can also make use of the helper function `IsA` if you'd rather not write your own filter.  
+The `IsA` function does a full type check and uses class objects instead of names, which is why you need to
+cache and supply them yourself.  
+It's the most accurate way to verify types.
+
+```lua
+local AllActors = FindAllOf("Light")
+print(string.format("NumActors found: %s\n", #AllActors))
+local PointLightClass = StaticFindObject("/Script/Engine.PointLight")
+local RectLightClass = StaticFindObject("/Script/Engine.RectLight")
+local SpotLightClass = StaticFindObject("/Script/Engine.SpotLight")
+local DirectionalLightClass = StaticFindObject("/Script/Engine.DirectionalLight")
+for _, Actor in ipairs(AllActors) do
+    if Actor:IsA(PointLightClass) then
+        -- Do logic on PointLight.
+        print(string.format("PL: '%s'\n", Actor:GetFullName()))
+    end
+
+    if Actor:IsA(RectLightClass) then
+        -- Do logic on RectLight.
+        print(string.format("RL: '%s'\n", Actor:GetFullName()))
+    end
+
+    if Actor:IsA(SpotLightClass) then
+        -- Do logic on SpotLight.
+        print(string.format("SL: '%s'\n", Actor:GetFullName()))
+    end
+
+    if Actor:IsA(DirectionalLightClass) then
+        -- Do logic on DirectionalLightName.
+        print(string.format("DL: '%s'\n", Actor:GetFullName()))
+    end
+end
+```


### PR DESCRIPTION
Closes #1402.

Adds a Performance section to the FindAllOf page covering the two things that
issue turned up, plus the guidance you gave in the thread.

**What it says**

- The returned set size depends heavily on how broad the class is — 255 for
  `"Actor"` against 23,919 for `"Object"`, same call, same level — and tracks
  what is loaded rather than map size, so a small game is no guarantee.
- Working through a large result is dominated by name comparison, not by
  `FindAllOf`.
- Avoid `GetFullName` in production code; use `GetFName` with the target `FName`
  constructed once outside the loop, and walk the outer chain if the leaf is not
  specific enough. Noted that `FName` values compare correctly with `==`, unlike
  `UObject`, since that is what makes the advice usable.
- Cache rather than re-scan.

**Numbers**

Measured over 23,919 instances, 7 rounds each, on the game thread, with an
`IsValid()` loop as a baseline so the call overhead is separated from the string
work:

| Loop body | Total | Per instance |
|---|---|---|
| `IsValid()` | 7.7 ms | 0.32 µs |
| `GetFullName()` vs string | 42.1 ms | 1.76 µs |
| `GetFName()` vs `FName` | 19.4 ms | 0.81 µs |

The page says explicitly that these are from one title on one machine and are
meant to show the shape of the cost, not to be exact anywhere else.

I also applied the same change to my own code after your comment; the FName
comparison came out at the 2.2x above, before counting that the full path is
then built only for the few objects whose leaf matches.

Happy to trim the numbers down to a sentence if a table is more than the page
wants, or to drop the baseline row.
