### PR TITLE
fix: skip UE4SS teardown during process termination

### DIFF
--- a/UE4SS/src/main_ue4ss_rewritten.cpp
+++ b/UE4SS/src/main_ue4ss_rewritten.cpp
@@ -131,7 +131,7 @@ auto dll_process_attached(HMODULE moduleHandle) -> void
     }
 }
 
-auto WIN_API_FUNCTION_NAME(HMODULE hModule, DWORD ul_reason_for_call, [[maybe_unused]] LPVOID lpReserved) -> BOOL
+auto WIN_API_FUNCTION_NAME(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved) -> BOOL
 {
     switch (ul_reason_for_call)
     {
@@ -143,7 +143,15 @@ auto WIN_API_FUNCTION_NAME(HMODULE hModule, DWORD ul_reason_for_call, [[maybe_un
     case DLL_THREAD_DETACH:
         break;
     case DLL_PROCESS_DETACH:
-        UE4SSProgram::static_cleanup();
+        // A non-null reserved pointer means the entire process is terminating.
+        // Avoid running the program destructor from DllMain in that case: the
+        // CRT and dependency statics may already be partially torn down, and
+        // Windows will reclaim all remaining process resources anyway.
+        // Preserve explicit cleanup when UE4SS is unloaded via FreeLibrary.
+        if (lpReserved == nullptr)
+        {
+            UE4SSProgram::static_cleanup();
+        }
         break;
     }
     return TRUE;


### PR DESCRIPTION
**Description**
<!-- Please include a summary of the change and which issue is fixed. Include relevant motivation and context. List any dependencies that are required for this change. -->

Taken from downstream: https://github.com/Huarch/RE-UE4SS/tree/codex/fallen-doll-ue57-runtime
Original commit: https://github.com/UE4SS-RE/RE-UE4SS/commit/beb83ee7eab4a7d188fc9bea46235039978df173
Their changes are correct as per MSDN: https://learn.microsoft.com/en-us/windows/win32/dlls/dllmain

**Type of change**
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)