### PR TITLE
fix(lua): guard against null Stack.Node() in script hook dispatcher

### DIFF
--- a/UE4SS/src/Mod/LuaMod.cpp
+++ b/UE4SS/src/Mod/LuaMod.cpp
@@ -6290,8 +6290,13 @@ Overloads:
             {
                 return;
             }
-            auto data = precise_name_match ? LuaMod::find_function_hook_data(callback_container, Stack.Node())
-                                           : LuaMod::find_function_hook_data(callback_container, Stack.Node()->GetNamePrivate());
+            auto* node = Stack.Node();
+            if (!node)
+            {
+                return;
+            }
+            auto data = precise_name_match ? LuaMod::find_function_hook_data(callback_container, node)
+                                           : LuaMod::find_function_hook_data(callback_container, node->GetNamePrivate());
             if (data)
             {
                 const auto& callback_data = data->callback_data;
@@ -6314,7 +6319,6 @@ Overloads:
                         static auto s_object_property_name = Unreal::FName(STR("ObjectProperty"), Unreal::FNAME_Find);
                         LuaType::RemoteUnrealParam::construct(lua, &Context, s_object_property_name);
 
-                        auto node = Stack.Node();
                         auto return_value_offset = node->GetReturnValueOffset();
                         auto has_return_value = return_value_offset != 0xFFFF;
                         auto num_unreal_params = node->GetNumParms();

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -489,6 +489,8 @@ Fix SetupAttachment implementations randomly changing order ([UE4SS #606](https:
 Fix non-ascii characters in outputted .cpp files ([UE4SS #1378](https://github.com/UE4SS-RE/RE-UE4SS/pull/1378))  
 
 ### Lua API 
+Fixed crash in script hook dispatcher when `Stack.Node()` returns `nullptr` on synthetic or native thunk frames.
+
 Fixed FString use after free ([UE4SS #425](https://github.com/UE4SS-RE/RE-UE4SS/pull/425)) - localcc 
 
 Fixed `IterateGameDirectories` crashing when the game root contains a deeply nested directory tree, common once a mod manager unpacks downloads into it. The traversal never grew the Lua stack and wrote past the end of it. It now also stops at a depth of 64, skips unreadable directories, and won't follow a link back into a directory it is already inside. ([UE4SS #1092](https://github.com/UE4SS-RE/RE-UE4SS/issues/1092))


### PR DESCRIPTION
**Description**
In `LuaMod::script_hook`, the `execute_hook` lambda unconditionally called `Stack.Node()->GetNamePrivate()` if `callback_container` was non-empty and `precise_name_match` was false.

In certain execution environments (such as synthetic script frames, native thunks, or corrupted execution frames), `Stack.Node()` can return `nullptr`. Dereferencing it caused an immediate access violation crash (`0xC0000005`) in `GetNamePrivate()`.

This PR adds an explicit null check for `Stack.Node()` at the beginning of `execute_hook`, gracefully returning early if no valid `UFunction` node is associated with the script frame, and reuses the guarded local pointer downstream (also eliminating variable shadowing).

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How has this been tested?**
- Tested in a live game session with multiple active script hooks registered across Blueprint and C++ functions (`BP_PlayerBullet_C:F_StartBullet`, `BP_Enemy_C:F_DamageFeedback`, `BP_Item_C:F_TraceBullet`).
- Confirmed that script hooks continue to fire normally while edge-case frames with null nodes no longer trigger a crash.

**Checklist**
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries.
