### PR TITLE
fix(games): update Far Far West FName_Constructor signature

### DIFF
--- a/assets/CustomGameConfigs/Far Far West/UE4SS_Signatures/FName_Constructor.lua
+++ b/assets/CustomGameConfigs/Far Far West/UE4SS_Signatures/FName_Constructor.lua
@@ -1,16 +1,7 @@
--- FName::FName(wchar_t const *, enum EFindName) for UE 5.8 (Far Far West launch)
--- Direct scan starting at the function entry. Single wildcard added on the
--- "08" stack-offset byte to make UE4SS's Lua scanner actually find the
--- pattern (the no-wildcard prologue version is not picked up by the scanner
--- for unknown reasons, even though x64dbg confirms the bytes are present).
---
--- Verified function start: 0x7FF6099C81A0 (after int3 padding).
+-- FName::FName(wchar_t const *, enum EFindName) for Far Far West
+-- Updated for Steam buildid 24978658 (Aug 2026 update).
 function Register()
-    -- Function prologue with one wildcard at byte 4:
-    --   mov [rsp+??], rbx ; push rdi ; sub rsp, 0x30 ; mov rbx, rcx ;
-    --   mov [rsp+0x20], rdx ; xor ecx, ecx ; mov edi, r8d ; mov r10, rdx ;
-    --   mov r9d, ecx ; test rdx, rdx
-    return "48 89 5C 24 ?? 57 48 83 EC 30 48 8B D9 48 89 54 24 20 33 C9 41 8B F8 4C 8B D2 44 8B C9 48 85 D2"
+    return "40 53 48 83 EC 30 48 8B D9 48 89 54 24 20 33 C9 4C 8B CA 44 8B C1 48 85 D2 74 ?? 0F B7 02 66 85 C0"
 end
 
 function OnMatchFound(MatchAddress)


### PR DESCRIPTION
**Description**
Updates the `FName_Constructor` signature for *Far Far West* to match the updated Steam binary (Steam buildid `24978658`, August 2026 update).

The previous signature no longer matched the new function prologue emitted in recent compiler updates of the game binary, preventing `FName::FName(wchar_t const *, enum EFindName)` from being found during second-pass initialization.

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Other: Game-specific configuration update

**How has this been tested?**
- Tested with *Far Far West* Steam buildid `24978658`.
- Output log confirms single match at function entry point:
  ```
  [FName_Constructor] OnMatchFound called with: 0x7FF60B023EB0
  FName::FName address: 0x7ff60b023eb0 <- Lua Script
  ```
- FName construction and global name table lookups functioned normally throughout gameplay.

**Checklist**
- [x] Verified against target game version.
