### PR TITLE
feat(lua): add UObject equality comparison and FWeakObjectProperty setter

### DIFF
--- a/UE4SS/include/LuaType/LuaUObject.hpp
+++ b/UE4SS/include/LuaType/LuaUObject.hpp
@@ -413,6 +413,7 @@ namespace RC::LuaType
             const Operation operation, const LuaMadeSimple::Lua&, Unreal::UObject* base, Unreal::FName property_name, Unreal::FField* field) -> void;
 
     auto is_a_implementation(const LuaMadeSimple::Lua& lua) -> int;
+    auto uobject_equal_implementation(const LuaMadeSimple::Lua& lua) -> int;
 
     template <typename DerivedType, typename ObjectName>
     class UObjectBase;
@@ -517,6 +518,8 @@ namespace RC::LuaType
                 }
                 return 0;
             });
+
+            base_object.get_metamethods().create(LuaMadeSimple::Lua::MetaMethod::Equal, uobject_equal_implementation);
         }
 
       public:
@@ -524,6 +527,8 @@ namespace RC::LuaType
         auto static setup_member_functions(const LuaMadeSimple::Lua::Table& table) -> void
         {
             Super::template setup_member_functions<LuaMadeSimple::Type::IsFinal::No>(table);
+
+            table.add_pair("__is_uobject", true);
 
             // Add functions that are not intended to be overridden later here
             table.add_pair("GetFullName", [](const LuaMadeSimple::Lua& lua) -> int {

--- a/UE4SS/src/LuaType/LuaUObject.cpp
+++ b/UE4SS/src/LuaType/LuaUObject.cpp
@@ -70,6 +70,30 @@ namespace RC::LuaType
         return object && s_lua_unreal_objects.contains(object->HashObject());
     }
 
+    static auto is_uobject_userdata(lua_State* L, int32_t index) -> bool
+    {
+        int abs_index = lua_absindex(L, index);
+        if (lua_type(L, abs_index) != LUA_TUSERDATA)
+        {
+            return false;
+        }
+        if (lua_getiuservalue(L, abs_index, 3) != LUA_TTABLE)
+        {
+            lua_pop(L, 1);
+            return false;
+        }
+        lua_pushstring(L, "__is_uobject");
+        lua_rawget(L, -2);
+        bool is_uobj = lua_toboolean(L, -1);
+        lua_pop(L, 2);
+        return is_uobj;
+    }
+
+    static auto is_weak_object_ptr_userdata(lua_State* L, int32_t index) -> bool
+    {
+        return luaL_testudata(L, index, "FWeakObjectPtr") != nullptr;
+    }
+
     FLuaObjectDeleteListener FLuaObjectDeleteListener::s_lua_object_delete_listener{};
     void FLuaObjectDeleteListener::NotifyUObjectDeleted(const Unreal::UObjectBase* object, [[maybe_unused]] int32_t index)
     {
@@ -1611,10 +1635,35 @@ namespace RC::LuaType
             }
             return;
         }
-        case Operation::Set:
-            // For now, doing nothing just to get past the error
-            Output::send(STR("[push_weakobjectproperty] Operation::Set is not supported\n"));
+        case Operation::Set: {
+            if (params.lua.is_nil(params.stored_at_index))
+            {
+                *static_cast<Unreal::FWeakObjectPtr*>(params.data) = Unreal::FWeakObjectPtr{};
+                return;
+            }
+
+            lua_State* L = params.lua.get_lua_state();
+            if (is_uobject_userdata(L, params.stored_at_index))
+            {
+                const auto& lua_object = params.lua.get_userdata<LuaType::UObject>(params.stored_at_index, true);
+                auto* remote_object = lua_object.get_remote_cpp_object();
+                if (remote_object == LuaMadeSimple::Type::special_invalid_ptr())
+                {
+                    remote_object = nullptr;
+                }
+                *static_cast<Unreal::FWeakObjectPtr*>(params.data) = remote_object;
+                return;
+            }
+            if (is_weak_object_ptr_userdata(L, params.stored_at_index))
+            {
+                auto& lua_weak = params.lua.get_userdata<LuaType::FWeakObjectPtr>(params.stored_at_index, true);
+                *static_cast<Unreal::FWeakObjectPtr*>(params.data) = lua_weak.get_local_cpp_object();
+                return;
+            }
+
+            params.throw_error("push_weakobjectproperty", "Value must be UObject, FWeakObjectPtr, or nil");
             return;
+        }
         case Operation::GetParam:
             params.throw_error("push_weakobjectproperty", "Operation::GetParam is not supported");
             return;
@@ -2137,6 +2186,33 @@ Overloads:
             lua.throw_error(error_overload_not_found);
         }
 
+        return 1;
+    }
+
+    auto uobject_equal_implementation(const LuaMadeSimple::Lua& lua) -> int
+    {
+        lua_State* L = lua.get_lua_state();
+        if (!is_uobject_userdata(L, 1) || !is_uobject_userdata(L, 2))
+        {
+            lua.set_bool(false);
+            return 1;
+        }
+
+        const auto& uobj_a = lua.get_userdata<LuaType::UObject>(1, true);
+        const auto& uobj_b = lua.get_userdata<LuaType::UObject>(2, true);
+
+        auto* ptr_a = uobj_a.get_remote_cpp_object();
+        auto* ptr_b = uobj_b.get_remote_cpp_object();
+        if (ptr_a == LuaMadeSimple::Type::special_invalid_ptr())
+        {
+            ptr_a = nullptr;
+        }
+        if (ptr_b == LuaMadeSimple::Type::special_invalid_ptr())
+        {
+            ptr_b = nullptr;
+        }
+
+        lua.set_bool(ptr_a == ptr_b);
         return 1;
     }
 

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -151,6 +151,10 @@ Fixed Static Mesh Dumper crashing on material interfaces in UE 5.6 and above due
 
 ### Lua API
 
+Added `__eq` metamethod for `UObjectBase`, allowing comparing `UObject` instances by underlying pointer (`objA == objB`) from Lua rather than userdata reference equality.
+
+Added support for setting `FWeakObjectProperty` values (`Operation::Set`), allowing assignment of `UObject`, `FWeakObjectPtr`, or `nil` from Lua.
+
 Added support for `FUtf8String` and `FAnsiString` Unreal string types with string manipulation API ([UE4SS #1015](https://github.com/UE4SS-RE/RE-UE4SS/pull/1015))
 - Refactored FString implementation to use unified `TLuaStringBase` template for code reuse and consistency
 

--- a/docs/lua-api/classes/fweakobjectptr.md
+++ b/docs/lua-api/classes/fweakobjectptr.md
@@ -10,3 +10,18 @@
 - **Return type:** `UObjectDerivative`
 - **Returns:** the pointed to `UObject` or `UObject` derivative.
 > The return can be invalid, so call `UObject:IsValid` after calling this function.
+
+## Property Assignment
+
+Reflected `FWeakObjectProperty` fields on `UObject` instances can be assigned directly from Lua:
+- Assigning a `UObject`: sets the weak pointer to reference the target object.
+- Assigning an `FWeakObjectPtr`: copies the weak pointer reference.
+- Assigning `nil`: clears the weak pointer reference.
+
+```lua
+-- Assign an actor to a weak object property
+TargetActor.WeakTarget = CurrentEnemy
+
+-- Clear a weak object property
+TargetActor.WeakTarget = nil
+```

--- a/docs/lua-api/classes/uobject.md
+++ b/docs/lua-api/classes/uobject.md
@@ -52,6 +52,20 @@ The `UObject` class is the base class that most other Unreal Engine game objects
     Engine.MaxParticleResize = 4
     ```
 
+### __eq
+
+- **Usage:** `ObjectA == ObjectB`
+
+- Compares two `UObject` instances by their underlying C++ pointers. Returns `true` if both userdata wrap the same remote `UObject*` (or both are null/invalid), and `false` otherwise. Safely evaluates to `false` without crashing if compared against non-`UObject` userdata or types.
+
+- **Example:**
+    ```lua
+    local Player = FindFirstOf("BP_Player_C")
+    if Player == Controller.Pawn then
+        print("Pawn matches active player")
+    end
+    ```
+
 ## Methods
 
 ### GetFullName()


### PR DESCRIPTION
**Description**
This PR enhances the Lua runtime with two core UObject capabilities:
1. **Type-safe `__eq` metamethod for `UObjectBase`**: Modders can now compare `UObject` instances by their underlying remote C++ pointer (`objA == objB`), rather than defaulting to Lua userdata reference equality.
2. **`Operation::Set` for `FWeakObjectProperty`**: Modders can now assign `UObject`, `FWeakObjectPtr`, or `nil` directly to reflected weak object properties (`actor.WeakProp = target`).

### Motivation & Context
- Previously, comparing two userdata wrapping the exact same underlying Unreal `UObject*` returned `false` because each query allocates a distinct userdata wrapper. Modders had to write verbose workarounds such as `objA:GetAddress() == objB:GetAddress()`.
- Previously, assigning to weak object properties from Lua was completely unsupported (`Operation::Set is not supported`), preventing modders from updating weak object references (such as `FHitResult.HitObjectHandle.ReferenceObject`).
- Unifying both features avoids duplicate userdata type verification boilerplate (`is_uobject_userdata`) and ensures clean interoperability between reflected properties and object instances.
- Sentinel pointer (`special_invalid_ptr()`) normalization is included so invalid or uninitialized userdata do not write bad addresses into the weak pointer table.

**Type of change**
- [x] New feature (non-breaking change which adds functionality)
- [x] Is/requires documentation update

**How has this been tested?**
- Tested with *Far Far West* runtime:
  - `FindFirstOf("Engine") == FindFirstOf("Engine")` evaluates to `true`.
  - `FindFirstOf("Engine") == FindFirstOf("GameInstance")` evaluates to `false`.
  - `FindFirstOf("Engine") == nil` and comparison against non-UObject types cleanly evaluate to `false` without crashing.
  - Assigned live actors and `nil` into `FWeakObjectProperty` fields.
  - Confirmed sentinel pointer normalization prevents access violations during weak pointer assignment.

**Checklist**
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (`docs/lua-api/classes/uobject.md`, `docs/lua-api/classes/fweakobjectptr.md`).
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries (`assets/Changelog.md`).
