### PR TITLE
fix(lifecycle): activate FUEDeathListener and pause async tasks during engine shutdown

### DIFF
--- a/UE4SS/include/UE4SSProgram.hpp
+++ b/UE4SS/include/UE4SSProgram.hpp
@@ -94,7 +94,7 @@ namespace RC
 
       public:
         RC_UE4SS_API static SettingsManager settings_manager;
-        static inline bool unreal_is_shutting_down{};
+        static inline std::atomic<bool> unreal_is_shutting_down{};
         static inline std::atomic_bool cpp_mods_done_loading{};
 
       public:

--- a/UE4SS/src/Mod/LuaMod.cpp
+++ b/UE4SS/src/Mod/LuaMod.cpp
@@ -7219,8 +7219,9 @@ Overloads:
     {
         for (m_processing_events = true; m_processing_events && !m_async_thread.get_stop_token().stop_requested();)
         {
-            if (m_pause_events_processing)
+            if (m_pause_events_processing || UE4SSProgram::unreal_is_shutting_down)
             {
+                std::this_thread::sleep_for(std::chrono::milliseconds(20));
                 continue;
             }
 

--- a/UE4SS/src/UE4SSProgram.cpp
+++ b/UE4SS/src/UE4SSProgram.cpp
@@ -70,8 +70,6 @@
 
 namespace RC
 {
-    // Commented out because this system (turn off hotkeys when in-game console is open) it doesn't work properly.
-    /*
     struct RC_UE_API FUEDeathListener : public Unreal::FUObjectCreateListener
     {
         static FUEDeathListener UEDeathListener;
@@ -80,10 +78,14 @@ namespace RC
         void OnUObjectArrayShutdown() override
         {
             UE4SSProgram::unreal_is_shutting_down = true;
+            Unreal::UnrealInitializer::StaticStorage::bIsInitialized = false;
             Unreal::UObjectArray::RemoveUObjectCreateListener(this);
         }
     };
     FUEDeathListener FUEDeathListener::UEDeathListener{};
+
+    // Commented out because this system (turn off hotkeys when in-game console is open) it doesn't work properly.
+    /*
 
     auto get_player_controller() -> UObject*
     {
@@ -991,10 +993,7 @@ namespace RC
         ProfilerScope();
         using namespace Unreal;
 
-        // Commented out because this system (turn off hotkeys when in-game console is open) it doesn't work properly.
-        /*
         UObjectArray::AddUObjectCreateListener(&FUEDeathListener::UEDeathListener);
-        //*/
 
         if (settings_manager.Debug.RenderMode == GUI::RenderMode::EngineTick)
         {

--- a/UE4SS/src/main_ue4ss_rewritten.cpp
+++ b/UE4SS/src/main_ue4ss_rewritten.cpp
@@ -143,6 +143,7 @@ auto WIN_API_FUNCTION_NAME(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpR
     case DLL_THREAD_DETACH:
         break;
     case DLL_PROCESS_DETACH:
+        UE4SSProgram::unreal_is_shutting_down = true;
         // A non-null reserved pointer means the entire process is terminating.
         // Avoid running the program destructor from DllMain in that case: the
         // CRT and dependency statics may already be partially torn down, and

--- a/assets/Changelog.md
+++ b/assets/Changelog.md
@@ -431,6 +431,8 @@ Switch to xmake from cmake which makes building much more streamlined ([UE4SS #3
 ## Fixes 
 
 ### General 
+Fixed access violation crash on engine shutdown by activating `FUEDeathListener` and pausing async Lua action loops when the engine terminates.
+
 Fixed proxy injection incorrectly running UE4SS initialization inside the loader lock when the main thread was the first thread snapshot entry.
 
 Fixed BPModLoaderMod not working in games made in UE 5.2+ - ([UE4SS #503](https://github.com/UE4SS-RE/RE-UE4SS/pull/503)) 


### PR DESCRIPTION
**Description**
When shutting down Unreal Engine games with active background Lua tasks (such as `LoopAsync` timers or delayed action loops running `FindAllOf` / `FindFirstOf`), clicking "Quit Game" frequently triggered an unhandled access violation crash (`0xC0000005`) in `ntdll.dll`.

### Root Cause
During engine shutdown, Unreal Engine tears down its object tables and critical sections. However, UE4SS background threads (specifically `LuaMod::update_async()`) remained running and continued invoking searcher routines on torn-down engine data structures.

Furthermore, `FUEDeathListener` in `UE4SSProgram.cpp` was previously commented out, preventing `UE4SSProgram::unreal_is_shutting_down` from ever being set when `UObjectArray` shuts down.

### Proposed Changes
- In `UE4SS/include/UE4SSProgram.hpp`:
  - Promote `unreal_is_shutting_down` to `static inline std::atomic<bool>` for thread-safe cross-thread visibility between the shutdown thread and background Lua worker threads.
- In `UE4SS/src/UE4SSProgram.cpp`:
  - Uncomment and register `FUEDeathListener` with `UObjectArray`.
  - On `OnUObjectArrayShutdown()`: set `UE4SSProgram::unreal_is_shutting_down = true` and `UnrealInitializer::StaticStorage::bIsInitialized = false`.
- In `UE4SS/src/Mod/LuaMod.cpp`:
  - `LuaMod::update_async()` now checks `UE4SSProgram::unreal_is_shutting_down` and sleeps rather than executing async actions when the engine is tearing down.
- In `UE4SS/src/main_ue4ss_rewritten.cpp`:
  - In `DLL_PROCESS_DETACH`, set `UE4SSProgram::unreal_is_shutting_down = true`.

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How has this been tested?**
- Tested with *Far Far West* (UE 5.8) with active background `LoopAsync(500, ...)` enemy searchers:
  - Multiple combat encounters with continuous weapon fire and delayed timers.
  - On clicking "Quit Game" in the main menu: clean exit with 0 access violations and 0 crash dumps generated.

**Checklist**
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added the necessary description of this PR to the changelog, and I have followed the same format as other entries (`assets/Changelog.md`).
